### PR TITLE
K-Means Clustering Algorithm (With Constraints)

### DIFF
--- a/backend/python/app/services/implementations/k_means_clustering_algorithm.py
+++ b/backend/python/app/services/implementations/k_means_clustering_algorithm.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 from typing import TYPE_CHECKING
 
 import numpy as np
-from sklearn.cluster import KMeans # type: ignore[import-untyped]
+from sklearn.cluster import KMeans  # type: ignore[import-untyped]
 
 from app.services.protocols.clustering_algorithm import (
     ClusteringAlgorithmProtocol,
@@ -96,7 +96,7 @@ class KMeansClusteringAlgorithm(ClusteringAlgorithmProtocol):
                 max_locations_per_cluster is not None
                 or max_boxes_per_cluster is not None
             ):
-                # Distrance matrix representing the distance form each point to each centroid
+                # Distance matrix representing the distance from each point to each centroid
                 distances = kmeans.transform(coordinates)
                 clusters = self._assign_with_constraints(
                     locations,
@@ -149,7 +149,7 @@ class KMeansClusteringAlgorithm(ClusteringAlgorithmProtocol):
         cluster_counts: dict[int, int] = defaultdict(int)
 
         # Hold actual location cluster assignments
-        assignments: list[int | None] = [0] * len(locations)
+        assignments: list[int] = [0] * len(locations)
 
         # Build candidate list: (location_index, preferred_cluster (by cluster number), distance_to_preferred, all_distances)
         candidates = []
@@ -163,8 +163,6 @@ class KMeansClusteringAlgorithm(ClusteringAlgorithmProtocol):
 
         # Helper to check if we can place a location into a cluster w.r.t. constraints + place it if yes
         def can_place_and_put(location_index: int, cluster_id: int) -> bool:
-            loc = locations[location_index]
-
             # Look at each cluster, see if num of locations or num of boxes (depending on constraints) assigned to that cluster is still within max limit
             # Because using defaultdict, "not-yet-touched" clusters have num locations/boxes = 0 by default
             loc = locations[location_index]
@@ -186,8 +184,8 @@ class KMeansClusteringAlgorithm(ClusteringAlgorithmProtocol):
                     cluster_counts[cluster_id] += need
                     return True
                 return False
-            
-            # If no constraints, always allow placement (should never run this function is there are no constraints, but added for mypy's happiness!)
+
+            # If no constraints, always allow placement (should never run this function if there are no constraints, but added for mypy's happiness!)
             return True
 
         # Assign each location "greedily" - assign location to closest cluster with space

--- a/backend/python/app/services/implementations/k_means_clustering_algorithm.py
+++ b/backend/python/app/services/implementations/k_means_clustering_algorithm.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
-import numpy as np
-import math
+
 import time
-from sklearn.cluster import KMeans
 from collections import defaultdict
 from typing import TYPE_CHECKING
+
+import numpy as np
+from sklearn.cluster import KMeans # type: ignore[import-untyped]
 
 from app.services.protocols.clustering_algorithm import (
     ClusteringAlgorithmProtocol,
@@ -26,7 +27,7 @@ class KMeansClusteringAlgorithm(ClusteringAlgorithmProtocol):
         num_clusters: int,
         max_locations_per_cluster: int | None = None,
         max_boxes_per_cluster: int | None = None,
-        timeout_seconds: float | None = None,  # noqa: ARG002
+        timeout_seconds: float | None = None,
     ) -> list[list[Location]]:
         """Split locations evenly into clusters in sequential order.
 
@@ -36,8 +37,8 @@ class KMeansClusteringAlgorithm(ClusteringAlgorithmProtocol):
             max_locations_per_cluster: Maximum number of locations
                 per cluster. Validates that the clustering is
                 possible and raises an error if violated.
-            timeout_seconds: Optional timeout in seconds. Not enforced in this
-                mock implementation.
+            timeout_seconds: Not enforced in this
+                implementation, as seems to not be a problem.
 
         Returns:
             List of clusters, where each cluster is a list of locations
@@ -52,9 +53,11 @@ class KMeansClusteringAlgorithm(ClusteringAlgorithmProtocol):
         # If no locations to cluster, return empty list
         if not locations:
             return [[] for _ in range(num_clusters)]
-        
+
         # Extract lat and long coords into a numpy array
-        coordinates = np.array([[location.latitude, location.longitude] for location in locations])
+        coordinates = np.array(
+            [[location.latitude, location.longitude] for location in locations]
+        )
 
         # Check that clustering is possible for the given locations
         if max_locations_per_cluster is not None:
@@ -63,7 +66,9 @@ class KMeansClusteringAlgorithm(ClusteringAlgorithmProtocol):
             max_possible = num_clusters * max_locations_per_cluster
 
             if total_locations > max_possible:
-                raise ValueError("Max locations per cluster + number of clusters clustering parameters cannot be simultaneously satisfied")
+                raise ValueError(
+                    "Max locations per cluster + number of clusters clustering parameters cannot be simultaneously satisfied"
+                )
         if max_boxes_per_cluster is not None:
             # Check if it is mathematically possible to meet the constraints on num of clusters + max boxes per cluster
             total_boxes = sum(loc.num_boxes for loc in locations)
@@ -71,28 +76,39 @@ class KMeansClusteringAlgorithm(ClusteringAlgorithmProtocol):
             max_possible = num_clusters * max_boxes_per_cluster
 
             if total_boxes > max_possible:
-                raise ValueError("Max boxes per cluster + number of clusters clustering parameters cannot be simultaneously satisfied")
-        
+                raise ValueError(
+                    "Max boxes per cluster + number of clusters clustering parameters cannot be simultaneously satisfied"
+                )
+
         try:
             # Run with timeout
             start_time = time.time()
 
             # kmeans!
             kmeans = KMeans(
-                    n_clusters = num_clusters,
-                    random_state = 42,
-                    n_init = 10,
+                n_clusters=num_clusters,
+                random_state=42,
+                n_init=10,
             )
             kmeans.fit(coordinates)
 
-            if max_locations_per_cluster is not None or max_boxes_per_cluster is not None:
+            if (
+                max_locations_per_cluster is not None
+                or max_boxes_per_cluster is not None
+            ):
                 # Distrance matrix representing the distance form each point to each centroid
                 distances = kmeans.transform(coordinates)
-                clusters = self._assign_with_constraints(locations, distances, num_clusters, max_locations_per_cluster, max_boxes_per_cluster)
+                clusters = self._assign_with_constraints(
+                    locations,
+                    distances,
+                    num_clusters,
+                    max_locations_per_cluster,
+                    max_boxes_per_cluster,
+                )
             else:
                 # No constraints
                 cluster_labels = kmeans.predict(coordinates)
-                
+
                 # Build result lists (each list corresponds to locations in a different cluster)
                 clusters = [[] for _ in range(num_clusters)]
                 for i, location in enumerate(locations):
@@ -103,41 +119,50 @@ class KMeansClusteringAlgorithm(ClusteringAlgorithmProtocol):
             elapsed = time.time() - start_time
             print("Time:", elapsed)
             if timeout_seconds and elapsed > timeout_seconds:
-                print(f"Warning: Clustering took {elapsed:.2f}s (exceeded {timeout_seconds}s)")
+                print(
+                    f"Warning: Clustering took {elapsed:.2f}s (exceeded {timeout_seconds}s)"
+                )
                 return []
 
             return clusters
-        
+
         except Exception as e:
             print(f"Constrained k-means clustering failed: {e}")
             return []
-        
-    def _assign_with_constraints(self, locations, distances, num_clusters, max_locations_per_cluster, max_boxes_per_cluster):
+
+    def _assign_with_constraints(
+        self,
+        locations: list[Location],
+        distances: np.ndarray,
+        num_clusters: int,
+        max_locations_per_cluster: int | None,
+        max_boxes_per_cluster: int | None,
+    ) -> list[list[Location]]:
         """
         Assign locations to clusters respecting size constraints
         Greedy approach: assign closest points first
         """
-         # Assert that only one AT MOST of the limiting max params is set to a value
+        # Assert that only one AT MOST of the limiting max params is set to a value
         assert max_boxes_per_cluster is None or max_locations_per_cluster is None
 
         # Count number of locations in each cluster
-        cluster_counts = defaultdict(int)
+        cluster_counts: dict[int, int] = defaultdict(int)
 
         # Hold actual location cluster assignments
-        assignments = [None] * len(locations)
-        
+        assignments: list[int | None] = [0] * len(locations)
+
         # Build candidate list: (location_index, preferred_cluster (by cluster number), distance_to_preferred, all_distances)
         candidates = []
         for i in range(len(locations)):
             best_cluster = int(np.argmin(distances[i]))
             best_distance = distances[i][best_cluster]
             candidates.append((i, best_cluster, best_distance, distances[i]))
-        
+
         # Sort by distance (closest first)
         candidates.sort(key=lambda x: x[2])
 
         # Helper to check if we can place a location into a cluster w.r.t. constraints + place it if yes
-        def can_place_and_put (location_index: int, cluster_id: int) -> bool:
+        def can_place_and_put(location_index: int, cluster_id: int) -> bool:
             loc = locations[location_index]
 
             # Look at each cluster, see if num of locations or num of boxes (depending on constraints) assigned to that cluster is still within max limit
@@ -145,7 +170,7 @@ class KMeansClusteringAlgorithm(ClusteringAlgorithmProtocol):
             loc = locations[location_index]
             if max_locations_per_cluster is not None:
                 # Count location
-                need = 1  
+                need = 1
                 if cluster_counts[cluster_id] + need <= max_locations_per_cluster:
                     assignments[location_index] = cluster_id
                     cluster_counts[cluster_id] += need
@@ -161,9 +186,17 @@ class KMeansClusteringAlgorithm(ClusteringAlgorithmProtocol):
                     cluster_counts[cluster_id] += need
                     return True
                 return False
-        
+            
+            # If no constraints, always allow placement (should never run this function is there are no constraints, but added for mypy's happiness!)
+            return True
+
         # Assign each location "greedily" - assign location to closest cluster with space
-        for location_index, preferred_cluster, distance_to_preferred, all_distances in candidates:
+        for (
+            location_index,
+            preferred_cluster,
+            _distance_to_preferred,
+            all_distances,
+        ) in candidates:
             # Try the location's preferred cluster first
             if can_place_and_put(location_index, preferred_cluster):
                 continue
@@ -177,14 +210,15 @@ class KMeansClusteringAlgorithm(ClusteringAlgorithmProtocol):
                     break
 
             if not placed:
-                raise ValueError(f"Unable to assign location index {location_index} under constraints")
-        
-        # Build result lists (each list corresponds to locations in a different cluster)
-        clusters = [[] for _ in range(num_clusters)]
-        for i, location in enumerate(locations):
-            clusters[assignments[i]].append(location)
-        
-        return clusters
-        
+                raise ValueError(
+                    f"Unable to assign location index {location_index} under constraints"
+                )
 
-        
+        # Build result lists (each list corresponds to locations in a different cluster)
+        clusters: list[list[Location]] = [[] for _ in range(num_clusters)]
+        for i, location in enumerate(locations):
+            cluster_id = assignments[i]
+            if cluster_id is not None:
+                clusters[cluster_id].append(location)
+
+        return clusters

--- a/backend/python/app/services/implementations/k_means_clustering_algorithm.py
+++ b/backend/python/app/services/implementations/k_means_clustering_algorithm.py
@@ -57,14 +57,14 @@ class KMeansClusteringAlgorithm(ClusteringAlgorithmProtocol):
         coordinates = np.array([[location.latitude, location.longitude] for location in locations])
 
         # Check that clustering is possible for the given locations
-        if max_locations_per_cluster:
+        if max_locations_per_cluster is not None:
             # Check if it is mathematically possible to meet the constraints on num of clusters + max locations per cluster
             total_locations = len(locations)
             max_possible = num_clusters * max_locations_per_cluster
 
             if total_locations > max_possible:
                 raise ValueError("Max locations per cluster + number of clusters clustering parameters cannot be simultaneously satisfied")
-        if max_boxes_per_cluster:
+        if max_boxes_per_cluster is not None:
             # Check if it is mathematically possible to meet the constraints on num of clusters + max boxes per cluster
             total_boxes = sum(loc.num_boxes for loc in locations)
 
@@ -85,7 +85,7 @@ class KMeansClusteringAlgorithm(ClusteringAlgorithmProtocol):
             )
             kmeans.fit(coordinates)
 
-            if max_locations_per_cluster or max_boxes_per_cluster:
+            if max_locations_per_cluster is not None or max_boxes_per_cluster is not None:
                 # Distrance matrix representing the distance form each point to each centroid
                 distances = kmeans.transform(coordinates)
                 clusters = self._assign_with_constraints(locations, distances, num_clusters, max_locations_per_cluster, max_boxes_per_cluster)

--- a/backend/python/app/services/implementations/k_means_clustering_algorithm.py
+++ b/backend/python/app/services/implementations/k_means_clustering_algorithm.py
@@ -25,6 +25,7 @@ class KMeansClusteringAlgorithm(ClusteringAlgorithmProtocol):
         locations: list[Location],
         num_clusters: int,
         max_locations_per_cluster: int | None = None,
+        max_boxes_per_cluster: int | None = None,
         timeout_seconds: float | None = None,  # noqa: ARG002
     ) -> list[list[Location]]:
         """Split locations evenly into clusters in sequential order.
@@ -45,19 +46,32 @@ class KMeansClusteringAlgorithm(ClusteringAlgorithmProtocol):
             ValueError: If the clustering parameters are invalid or cannot
                 be satisfied
         """
+        # Assert that only one AT MOST of the limiting max params is set to a value
+        assert max_boxes_per_cluster is None or max_locations_per_cluster is None
+
+        # If no locations to cluster, return empty list
         if not locations:
             return [[] for _ in range(num_clusters)]
         
         # Extract lat and long coords into a numpy array
         coordinates = np.array([[location.latitude, location.longitude] for location in locations])
 
+        # Check that clustering is possible for the given locations
         if max_locations_per_cluster:
             # Check if it is mathematically possible to meet the constraints on num of clusters + max locations per cluster
             total_locations = len(locations)
             max_possible = num_clusters * max_locations_per_cluster
 
             if total_locations > max_possible:
-                raise ValueError("Clustering parameters cannot be satisfied")
+                raise ValueError("Max locations per cluster + number of clusters clustering parameters cannot be simultaneously satisfied")
+        if max_boxes_per_cluster:
+            # Check if it is mathematically possible to meet the constraints on num of clusters + max boxes per cluster
+            total_boxes = sum(loc.num_boxes for loc in locations)
+
+            max_possible = num_clusters * max_boxes_per_cluster
+
+            if total_boxes > max_possible:
+                raise ValueError("Max boxes per cluster + number of clusters clustering parameters cannot be simultaneously satisfied")
         
         try:
             # Run with timeout
@@ -71,10 +85,10 @@ class KMeansClusteringAlgorithm(ClusteringAlgorithmProtocol):
             )
             kmeans.fit(coordinates)
 
-            if max_locations_per_cluster:
+            if max_locations_per_cluster or max_boxes_per_cluster:
                 # Distrance matrix representing the distance form each point to each centroid
                 distances = kmeans.transform(coordinates)
-                clusters = self._assign_with_constraints(locations, distances, num_clusters, max_locations_per_cluster)
+                clusters = self._assign_with_constraints(locations, distances, num_clusters, max_locations_per_cluster, max_boxes_per_cluster)
             else:
                 # No constraints
                 cluster_labels = kmeans.predict(coordinates)
@@ -98,11 +112,14 @@ class KMeansClusteringAlgorithm(ClusteringAlgorithmProtocol):
             print(f"Constrained k-means clustering failed: {e}")
             return []
         
-    def _assign_with_constraints(self, locations, distances, num_clusters, max_per_cluster):
+    def _assign_with_constraints(self, locations, distances, num_clusters, max_locations_per_cluster, max_boxes_per_cluster):
         """
         Assign locations to clusters respecting size constraints
         Greedy approach: assign closest points first
         """
+         # Assert that only one AT MOST of the limiting max params is set to a value
+        assert max_boxes_per_cluster is None or max_locations_per_cluster is None
+
         # Count number of locations in each cluster
         cluster_counts = defaultdict(int)
 
@@ -118,26 +135,49 @@ class KMeansClusteringAlgorithm(ClusteringAlgorithmProtocol):
         
         # Sort by distance (closest first)
         candidates.sort(key=lambda x: x[2])
+
+        # Helper to check if we can place a location into a cluster w.r.t. constraints + place it if yes
+        def can_place_and_put (location_index: int, cluster_id: int) -> bool:
+            loc = locations[location_index]
+
+            # Look at each cluster, see if num of locations or num of boxes (depending on constraints) assigned to that cluster is still within max limit
+            # Because using defaultdict, "not-yet-touched" clusters have num locations/boxes = 0 by default
+            loc = locations[location_index]
+            if max_locations_per_cluster is not None:
+                # Count location
+                need = 1  
+                if cluster_counts[cluster_id] + need <= max_locations_per_cluster:
+                    assignments[location_index] = cluster_id
+                    cluster_counts[cluster_id] += need
+                    return True
+                return False
+
+            # Otherwise boxes constraint must be active (by assert)
+            if max_boxes_per_cluster is not None:
+                # Count boxes at location
+                need = getattr(loc, "num_boxes", 0)
+                if cluster_counts[cluster_id] + need <= max_boxes_per_cluster:
+                    assignments[location_index] = cluster_id
+                    cluster_counts[cluster_id] += need
+                    return True
+                return False
         
         # Assign each location "greedily" - assign location to closest cluster with space
         for location_index, preferred_cluster, distance_to_preferred, all_distances in candidates:
             # Try the location's preferred cluster first
-            # Look at each cluster, see if num of locations assigned to that cluster is still within max limit
-            # Because using defaultdict, "not-yet-touched" clusters have num locations = 0 by default
-            if cluster_counts[preferred_cluster] < max_per_cluster:
-                # If still have space in preferred cluster, add location
-                assignments[location_index] = preferred_cluster
-                cluster_counts[preferred_cluster] += 1
-            else:
-                # Find nearest cluster with available space
-                sorted_clusters = np.argsort(all_distances)
-                for cluster_id in sorted_clusters:
-                    cluster_id = int(cluster_id)
-                    # Check if cluster has space, if not, add the location to the cluster
-                    if cluster_counts[cluster_id] < max_per_cluster:
-                        assignments[location_index] = cluster_id
-                        cluster_counts[cluster_id] += 1
-                        break
+            if can_place_and_put(location_index, preferred_cluster):
+                continue
+
+            sorted_clusters = np.argsort(all_distances)
+            placed = False
+            for cluster_id in sorted_clusters:
+                cluster_id = int(cluster_id)
+                if can_place_and_put(location_index, cluster_id):
+                    placed = True
+                    break
+
+            if not placed:
+                raise ValueError(f"Unable to assign location index {location_index} under constraints")
         
         # Build result lists (each list corresponds to locations in a different cluster)
         clusters = [[] for _ in range(num_clusters)]

--- a/backend/python/app/services/implementations/k_means_clustering_algorithm.py
+++ b/backend/python/app/services/implementations/k_means_clustering_algorithm.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+import numpy as np
+import math
+import time
+from sklearn.cluster import KMeans
+from collections import defaultdict
+from typing import TYPE_CHECKING
+
+from app.services.protocols.clustering_algorithm import (
+    ClusteringAlgorithmProtocol,
+)
+
+if TYPE_CHECKING:
+    from app.models.location import Location
+
+
+class KMeansClusteringAlgorithm(ClusteringAlgorithmProtocol):
+    """K means clustering algorithm that splits locations into clusters following k means clustering algorithm.
+
+    Includes max locations per cluster handling via "greedy-esque algorithm"
+    """
+
+    def cluster_locations(
+        self,
+        locations: list[Location],
+        num_clusters: int,
+        max_locations_per_cluster: int,
+        timeout_seconds: float | None = None,  # noqa: ARG002
+    ) -> list[list[Location]]:
+        """Split locations evenly into clusters in sequential order.
+
+        Args:
+            locations: List of locations to cluster
+            num_clusters: Target number of clusters to create
+            max_locations_per_cluster: Maximum number of locations
+                per cluster. Validates that the clustering is
+                possible and raises an error if violated.
+            timeout_seconds: Optional timeout in seconds. Not enforced in this
+                mock implementation.
+
+        Returns:
+            List of clusters, where each cluster is a list of locations
+
+        Raises:
+            ValueError: If the clustering parameters are invalid or cannot
+                be satisfied
+        """
+        if not locations:
+            return [[] for _ in range(num_clusters)]
+        
+        # Extract lat and long coords into a numpy array
+        coordinates = np.array([[location.latitude, location.longitude] for location in locations])
+
+        # Check if it is mathematically possible to meet the constraints on num of clusters + max locations per cluster
+        total_locations = len(locations)
+        max_possible = num_clusters * max_locations_per_cluster
+
+        if total_locations > max_possible:
+            raise ValueError("Clustering parameters cannot be satisfied")
+        
+        try:
+            # Run with timeout
+            start_time = time.time()
+
+            # kmeans!
+            kmeans = KMeans(
+                    n_clusters = num_clusters,
+            )
+            kmeans.fit(coordinates)
+
+            # Distrance matrix representing the distance form each point to each centroid
+            distances = kmeans.transform(coordinates)
+            clusters = self._assign_with_constraints(locations, distances, num_clusters, max_locations_per_cluster)
+
+            # Check time elapsed
+            elapsed = time.time() - start_time
+            print("Time:", elapsed)
+            if timeout_seconds and elapsed > timeout_seconds:
+                print(f"Warning: Clustering took {elapsed:.2f}s (exceeded {timeout_seconds}s)")
+                return []
+
+            return clusters
+        
+        except Exception as e:
+            print(f"Constrained k-means clustering failed: {e}")
+            return []
+        
+    def _assign_with_constraints(self, locations, distances, num_clusters, max_per_cluster):
+        """
+        Assign locations to clusters respecting size constraints
+        Greedy approach: assign closest points first
+        """
+        # Count number of locations in each cluster
+        cluster_counts = defaultdict(int)
+
+        # Hold actual location cluster assignments
+        assignments = [None] * len(locations)
+        
+        # Build candidate list: (location_index, preferred_cluster (by cluster number), distance_to_preferred, all_distances)
+        candidates = []
+        for i in range(len(locations)):
+            best_cluster = int(np.argmin(distances[i]))
+            best_distance = distances[i][best_cluster]
+            candidates.append((i, best_cluster, best_distance, distances[i]))
+        
+        # Sort by distance (closest first)
+        candidates.sort(key=lambda x: x[2])
+        
+        # Assign each location "greedily" - assign location to closest cluster with space
+        for location_index, preferred_cluster, distance_to_preferred, all_distances in candidates:
+            # Try the location's preferred cluster first
+            # Look at each cluster, see if num of locations assigned to that cluster is still within max limit
+            # Because using defaultdict, "not-yet-touched" clusters have num locations = 0 by default
+            if cluster_counts[preferred_cluster] < max_per_cluster:
+                # If still have space in preferred cluster, add location
+                assignments[location_index] = preferred_cluster
+                cluster_counts[preferred_cluster] += 1
+            else:
+                # Find nearest cluster with available space
+                sorted_clusters = np.argsort(all_distances)
+                for cluster_id in sorted_clusters:
+                    cluster_id = int(cluster_id)
+                    # Check if cluster has space, if not, add the location to the cluster
+                    if cluster_counts[cluster_id] < max_per_cluster:
+                        assignments[location_index] = cluster_id
+                        cluster_counts[cluster_id] += 1
+                        break
+        
+        # Build result lists (each list corresponds to locations in a different cluster)
+        clusters = [[] for _ in range(num_clusters)]
+        for i, location in enumerate(locations):
+            clusters[assignments[i]].append(location)
+        
+        return clusters
+        
+
+        

--- a/backend/python/app/services/implementations/k_means_test.py
+++ b/backend/python/app/services/implementations/k_means_test.py
@@ -12,11 +12,11 @@ from sqlmodel import Session, create_engine, select
 
 # Import all models to register them with SQLModel
 from app.models.location import Location
-from app.models.location_group import LocationGroup
-from app.models.route import Route
-from app.models.route_group import RouteGroup
-from app.models.route_group_membership import RouteGroupMembership
-from app.models.route_stop import RouteStop
+from app.models.location_group import LocationGroup  # noqa: F401
+from app.models.route import Route  # noqa: F401
+from app.models.route_group import RouteGroup  # noqa: F401
+from app.models.route_group_membership import RouteGroupMembership  # noqa: F401
+from app.models.route_stop import RouteStop  # noqa: F401
 from app.services.implementations.k_means_clustering_algorithm import (
     KMeansClusteringAlgorithm,
 )

--- a/backend/python/app/services/implementations/k_means_test.py
+++ b/backend/python/app/services/implementations/k_means_test.py
@@ -9,22 +9,17 @@ import sys
 sys.path.insert(0, "/app")
 
 from sqlmodel import Session, create_engine, select
-from app.services.implementations.k_means_clustering_algorithm import KMeansClusteringAlgorithm
 
 # Import all models to register them with SQLModel
-from app.models.admin import Admin
-from app.models.base import BaseModel
-from app.models.driver import Driver
-from app.models.driver_assignment import DriverAssignment
-from app.models.driver_history import DriverHistory
-from app.models.enum import ProgressEnum
-from app.models.job import Job
 from app.models.location import Location
 from app.models.location_group import LocationGroup
 from app.models.route import Route
 from app.models.route_group import RouteGroup
 from app.models.route_group_membership import RouteGroupMembership
 from app.models.route_stop import RouteStop
+from app.services.implementations.k_means_clustering_algorithm import (
+    KMeansClusteringAlgorithm,
+)
 
 # Use the same connection string as seed_database.py
 DATABASE_URL = "postgresql://postgres:postgres@f4k_db:5432/f4k"
@@ -37,10 +32,7 @@ def main() -> None:
         # Fetch locations that have coordinates
         statement = (
             select(Location)
-            .where(
-                Location.latitude != None, # noqa: E711
-                Location.longitude != None # noqa: E711
-                )
+            .where(Location.latitude is not None, Location.longitude is not None)
             .limit(20)
         )
 

--- a/backend/python/app/services/implementations/k_means_test.py
+++ b/backend/python/app/services/implementations/k_means_test.py
@@ -3,8 +3,10 @@
 Test script for KMeans clustering with real database locations.
 Run with: python -m app.services.implementations.k_means_test
 """
+
 import sys
-sys.path.insert(0, '/app')
+
+sys.path.insert(0, "/app")
 
 from sqlmodel import Session, create_engine, select
 from app.services.implementations.k_means_clustering_algorithm import KMeansClusteringAlgorithm
@@ -28,27 +30,31 @@ from app.models.route_stop import RouteStop
 DATABASE_URL = "postgresql://postgres:postgres@f4k_db:5432/f4k"
 
 
-def main():
+def main() -> None:
     engine = create_engine(DATABASE_URL, echo=False)
-    
+
     with Session(engine) as session:
         # Fetch locations that have coordinates
-        statement = select(Location).where(
-            Location.latitude.isnot(None),
-            Location.longitude.isnot(None)
-        ).limit(20)
-        
+        statement = (
+            select(Location)
+            .where(
+                Location.latitude != None, # noqa: E711
+                Location.longitude != None # noqa: E711
+                )
+            .limit(20)
+        )
+
         locations = list(session.exec(statement).all())
-        
+
         print(f"Fetched {len(locations)} locations from database\n")
-        
+
         if len(locations) < 2:
             print("Not enough locations with coordinates to cluster!")
             return
 
         # Count total number of boxes
         total_boxes = 0
-        
+
         # Print the locations
         print("Locations to cluster:")
         print("-" * 60)
@@ -60,43 +66,43 @@ def main():
             print(f"    Boxes: {loc.num_boxes}")
             print()
             total_boxes = sum(loc.num_boxes for loc in locations)
-        
+
         print("Total number of boxes: ", total_boxes)
         print("Total locations: ", len(locations))
-        
+
         # Run clustering
         clustering_algo = KMeansClusteringAlgorithm()
-        num_clusters = 3
-        max_locations_per_cluster = 1
+        num_clusters = 9
+        max_locations_per_cluster = 10
         max_boxes_per_cluster = None
-        
-        print(f"Running K-Means clustering:")
+
+        print("Running K-Means clustering:")
         print(f"  - Number of clusters: {num_clusters}")
         print(f"  - Max locations per cluster: {max_locations_per_cluster}")
         print(f"  - Max boxes per cluster: {max_boxes_per_cluster}")
         print("-" * 60)
-        
+
         try:
             clusters = clustering_algo.cluster_locations(
                 locations=locations,
                 num_clusters=num_clusters,
                 max_locations_per_cluster=max_locations_per_cluster,
                 max_boxes_per_cluster=max_boxes_per_cluster,
-                timeout_seconds=30.0
+                timeout_seconds=30.0,
             )
-            
+
             # Print results
             print("\nClustering Results:")
             print("=" * 60)
-            
+
             for i, cluster in enumerate(clusters):
                 print(f"\nCluster {i + 1} ({len(cluster)} locations):")
                 print("-" * 40)
-                
+
                 if not cluster:
                     print("  (empty cluster)")
                     continue
-                
+
                 total_boxes = 0
                 for loc in cluster:
                     name = loc.school_name or loc.contact_name
@@ -105,20 +111,23 @@ def main():
                     print(f"    Coords: ({loc.latitude}, {loc.longitude})")
                     print(f"    Boxes: {loc.num_boxes}")
                     total_boxes += loc.num_boxes
-                
+
                 print(f"\n  Total boxes in cluster: {total_boxes}")
-            
+
             print("\n" + "=" * 60)
             print("Summary:")
             print(f"  Total clusters: {len(clusters)}")
-            print(f"  Number of locations in each cluster: {[len(c) for c in clusters]}")
+            print(
+                f"  Number of locations in each cluster: {[len(c) for c in clusters]}"
+            )
             print(f"  Total locations clustered: {sum(len(c) for c in clusters)}")
-            
+
         except ValueError as e:
             print(f"Clustering failed: {e}")
         except Exception as e:
             print(f"Unexpected error: {e}")
             import traceback
+
             traceback.print_exc()
 
 

--- a/backend/python/app/services/implementations/k_means_test.py
+++ b/backend/python/app/services/implementations/k_means_test.py
@@ -4,11 +4,15 @@ Test script for KMeans clustering with real database locations.
 Run with: python -m app.services.implementations.k_means_test
 """
 
+import os
+import seaborn as sns
+import matplotlib.pyplot as plt
+import pandas as pd  # Often useful for data handling
 import sys
 
 sys.path.insert(0, "/app")
 
-from sqlmodel import Session, create_engine, select
+from sqlmodel import Session, create_engine, func, select
 
 # Import all models to register them with SQLModel
 from app.models.location import Location
@@ -33,6 +37,7 @@ def main() -> None:
         statement = (
             select(Location)
             .where(Location.latitude is not None, Location.longitude is not None)
+            .order_by(func.random())
             .limit(20)
         )
 
@@ -87,6 +92,7 @@ def main() -> None:
             print("\nClustering Results:")
             print("=" * 60)
 
+            df_rows = []
             for i, cluster in enumerate(clusters):
                 print(f"\nCluster {i + 1} ({len(cluster)} locations):")
                 print("-" * 40)
@@ -103,9 +109,27 @@ def main() -> None:
                     print(f"    Coords: ({loc.latitude}, {loc.longitude})")
                     print(f"    Boxes: {loc.num_boxes}")
                     total_boxes += loc.num_boxes
+                    new_row = {
+                        "name": name,
+                        "long": loc.longitude,
+                        "lat": loc.latitude,
+                        "group": i,
+                    }
+                    df_rows.append(new_row)
+            df = pd.DataFrame(data=df_rows)
+            sns.scatterplot(data=df, x="long", y="lat", hue="group", palette="Set2")
+            plt.title(
+                f"Generated K Means classification for {len(locations)} locations with {len(clusters)} clusters"
+            )
+            plt.xlabel("Longitude")
+            plt.ylabel("Latitude")
+            output_dir = "./app/data"
+            if not os.path.exists(output_dir):
+                os.makedirs(output_dir)
+            filename = os.path.join(output_dir, "kmeans_test.png")
+            plt.savefig(filename, dpi=300, bbox_inches="tight")
 
-                print(f"\n  Total boxes in cluster: {total_boxes}")
-
+            print(f"\n  Total boxes in cluster: {total_boxes}")
             print("\n" + "=" * 60)
             print("Summary:")
             print(f"  Total clusters: {len(clusters)}")

--- a/backend/python/app/services/implementations/k_means_test.py
+++ b/backend/python/app/services/implementations/k_means_test.py
@@ -29,6 +29,14 @@ from app.services.implementations.k_means_clustering_algorithm import (
 # Use the same connection string as seed_database.py
 DATABASE_URL = "postgresql://postgres:postgres@f4k_db:5432/f4k"
 
+# Configure number of locations pulled from csv for testing
+LOCATIONS_COUNT = 18
+
+# Configure number of clusters + locations per cluster and max boxes per cluster limits
+NUM_CLUSTERS = 10
+MAX_LOCATIONS_PER_CLUSTER = 10
+MAX_BOXES_PER_CLUSTER = None
+
 
 def main() -> None:
     engine = create_engine(DATABASE_URL, echo=False)
@@ -39,7 +47,7 @@ def main() -> None:
             select(Location)
             .where(Location.latitude is not None, Location.longitude is not None)
             .order_by(func.random())
-            .limit(20)
+            .limit(LOCATIONS_COUNT)
         )
 
         locations = list(session.exec(statement).all())
@@ -70,22 +78,19 @@ def main() -> None:
 
         # Run clustering
         clustering_algo = KMeansClusteringAlgorithm()
-        num_clusters = 9
-        max_locations_per_cluster = 10
-        max_boxes_per_cluster = None
 
         print("Running K-Means clustering:")
-        print(f"  - Number of clusters: {num_clusters}")
-        print(f"  - Max locations per cluster: {max_locations_per_cluster}")
-        print(f"  - Max boxes per cluster: {max_boxes_per_cluster}")
+        print(f"  - Number of clusters: {NUM_CLUSTERS}")
+        print(f"  - Max locations per cluster: {MAX_LOCATIONS_PER_CLUSTER}")
+        print(f"  - Max boxes per cluster: {MAX_BOXES_PER_CLUSTER}")
         print("-" * 60)
 
         try:
             clusters = clustering_algo.cluster_locations(
                 locations=locations,
-                num_clusters=num_clusters,
-                max_locations_per_cluster=max_locations_per_cluster,
-                max_boxes_per_cluster=max_boxes_per_cluster,
+                num_clusters=NUM_CLUSTERS,
+                max_locations_per_cluster=MAX_LOCATIONS_PER_CLUSTER,
+                max_boxes_per_cluster=MAX_BOXES_PER_CLUSTER,
                 timeout_seconds=30.0,
             )
 

--- a/backend/python/app/services/implementations/k_means_test.py
+++ b/backend/python/app/services/implementations/k_means_test.py
@@ -45,6 +45,9 @@ def main():
         if len(locations) < 2:
             print("Not enough locations with coordinates to cluster!")
             return
+
+        # Count total number of boxes
+        total_boxes = 0
         
         # Print the locations
         print("Locations to cluster:")
@@ -56,22 +59,29 @@ def main():
             print(f"    Coords: ({loc.latitude}, {loc.longitude})")
             print(f"    Boxes: {loc.num_boxes}")
             print()
+            total_boxes = sum(loc.num_boxes for loc in locations)
+        
+        print("Total number of boxes: ", total_boxes)
+        print("Total locations: ", len(locations))
         
         # Run clustering
         clustering_algo = KMeansClusteringAlgorithm()
         num_clusters = 3
-        max_per_cluster = 10
+        max_locations_per_cluster = 1
+        max_boxes_per_cluster = None
         
         print(f"Running K-Means clustering:")
         print(f"  - Number of clusters: {num_clusters}")
-        print(f"  - Max locations per cluster: {max_per_cluster}")
+        print(f"  - Max locations per cluster: {max_locations_per_cluster}")
+        print(f"  - Max boxes per cluster: {max_boxes_per_cluster}")
         print("-" * 60)
         
         try:
             clusters = clustering_algo.cluster_locations(
                 locations=locations,
                 num_clusters=num_clusters,
-                max_locations_per_cluster=max_per_cluster,
+                max_locations_per_cluster=max_locations_per_cluster,
+                max_boxes_per_cluster=max_boxes_per_cluster,
                 timeout_seconds=30.0
             )
             
@@ -101,7 +111,7 @@ def main():
             print("\n" + "=" * 60)
             print("Summary:")
             print(f"  Total clusters: {len(clusters)}")
-            print(f"  Cluster sizes: {[len(c) for c in clusters]}")
+            print(f"  Number of locations in each cluster: {[len(c) for c in clusters]}")
             print(f"  Total locations clustered: {sum(len(c) for c in clusters)}")
             
         except ValueError as e:

--- a/backend/python/app/services/implementations/k_means_test.py
+++ b/backend/python/app/services/implementations/k_means_test.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""
+Test script for KMeans clustering with real database locations.
+Run with: python -m app.services.implementations.k_means_test
+"""
+import sys
+sys.path.insert(0, '/app')
+
+from sqlmodel import Session, create_engine, select
+from app.services.implementations.k_means_clustering_algorithm import KMeansClusteringAlgorithm
+
+# Import all models to register them with SQLModel
+from app.models.admin import Admin
+from app.models.base import BaseModel
+from app.models.driver import Driver
+from app.models.driver_assignment import DriverAssignment
+from app.models.driver_history import DriverHistory
+from app.models.enum import ProgressEnum
+from app.models.job import Job
+from app.models.location import Location
+from app.models.location_group import LocationGroup
+from app.models.route import Route
+from app.models.route_group import RouteGroup
+from app.models.route_group_membership import RouteGroupMembership
+from app.models.route_stop import RouteStop
+
+# Use the same connection string as seed_database.py
+DATABASE_URL = "postgresql://postgres:postgres@f4k_db:5432/f4k"
+
+
+def main():
+    engine = create_engine(DATABASE_URL, echo=False)
+    
+    with Session(engine) as session:
+        # Fetch locations that have coordinates
+        statement = select(Location).where(
+            Location.latitude.isnot(None),
+            Location.longitude.isnot(None)
+        ).limit(20)
+        
+        locations = list(session.exec(statement).all())
+        
+        print(f"Fetched {len(locations)} locations from database\n")
+        
+        if len(locations) < 2:
+            print("Not enough locations with coordinates to cluster!")
+            return
+        
+        # Print the locations
+        print("Locations to cluster:")
+        print("-" * 60)
+        for loc in locations:
+            name = loc.school_name or loc.contact_name
+            print(f"  {name}")
+            print(f"    Address: {loc.address}")
+            print(f"    Coords: ({loc.latitude}, {loc.longitude})")
+            print(f"    Boxes: {loc.num_boxes}")
+            print()
+        
+        # Run clustering
+        clustering_algo = KMeansClusteringAlgorithm()
+        num_clusters = 4
+        max_per_cluster = 8
+        
+        print(f"Running K-Means clustering:")
+        print(f"  - Number of clusters: {num_clusters}")
+        print(f"  - Max locations per cluster: {max_per_cluster}")
+        print("-" * 60)
+        
+        try:
+            clusters = clustering_algo.cluster_locations(
+                locations=locations,
+                num_clusters=num_clusters,
+                max_locations_per_cluster=max_per_cluster,
+                timeout_seconds=30.0
+            )
+            
+            # Print results
+            print("\nClustering Results:")
+            print("=" * 60)
+            
+            for i, cluster in enumerate(clusters):
+                print(f"\nCluster {i + 1} ({len(cluster)} locations):")
+                print("-" * 40)
+                
+                if not cluster:
+                    print("  (empty cluster)")
+                    continue
+                
+                total_boxes = 0
+                for loc in cluster:
+                    name = loc.school_name or loc.contact_name
+                    print(f"  • {name}")
+                    print(f"    {loc.address}")
+                    print(f"    Coords: ({loc.latitude}, {loc.longitude})")
+                    print(f"    Boxes: {loc.num_boxes}")
+                    total_boxes += loc.num_boxes
+                
+                print(f"\n  Total boxes in cluster: {total_boxes}")
+            
+            print("\n" + "=" * 60)
+            print("Summary:")
+            print(f"  Total clusters: {len(clusters)}")
+            print(f"  Cluster sizes: {[len(c) for c in clusters]}")
+            print(f"  Total locations clustered: {sum(len(c) for c in clusters)}")
+            
+        except ValueError as e:
+            print(f"Clustering failed: {e}")
+        except Exception as e:
+            print(f"Unexpected error: {e}")
+            import traceback
+            traceback.print_exc()
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/python/app/services/implementations/k_means_test.py
+++ b/backend/python/app/services/implementations/k_means_test.py
@@ -5,10 +5,11 @@ Run with: python -m app.services.implementations.k_means_test
 """
 
 import os
-import seaborn as sns
+import sys
+
 import matplotlib.pyplot as plt
 import pandas as pd  # Often useful for data handling
-import sys
+import seaborn as sns
 
 sys.path.insert(0, "/app")
 

--- a/backend/python/app/services/implementations/k_means_test.py
+++ b/backend/python/app/services/implementations/k_means_test.py
@@ -59,8 +59,8 @@ def main():
         
         # Run clustering
         clustering_algo = KMeansClusteringAlgorithm()
-        num_clusters = 4
-        max_per_cluster = 8
+        num_clusters = 3
+        max_per_cluster = 10
         
         print(f"Running K-Means clustering:")
         print(f"  - Number of clusters: {num_clusters}")

--- a/backend/python/app/services/implementations/k_means_test.py
+++ b/backend/python/app/services/implementations/k_means_test.py
@@ -38,7 +38,7 @@ MAX_LOCATIONS_PER_CLUSTER = 10
 MAX_BOXES_PER_CLUSTER = None
 
 
-def main() -> None:
+async def main() -> None:
     engine = create_engine(DATABASE_URL, echo=False)
 
     with Session(engine) as session:
@@ -86,7 +86,7 @@ def main() -> None:
         print("-" * 60)
 
         try:
-            clusters = clustering_algo.cluster_locations(
+            clusters = await clustering_algo.cluster_locations(
                 locations=locations,
                 num_clusters=NUM_CLUSTERS,
                 max_locations_per_cluster=MAX_LOCATIONS_PER_CLUSTER,
@@ -154,4 +154,6 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    main()
+    import asyncio
+
+    asyncio.run(main())

--- a/backend/python/requirements.txt
+++ b/backend/python/requirements.txt
@@ -68,4 +68,6 @@ phonenumbers>=8.13.0
 
 # Data generation and mathematical optimization
 faker>=20.0.0
-scikit-learn>=1.3.0
+numpy==1.26.4
+scikit-learn==1.3.2
+scikit-learn-extra==0.2.0

--- a/backend/python/requirements.txt
+++ b/backend/python/requirements.txt
@@ -71,3 +71,6 @@ faker>=20.0.0
 numpy==1.26.4
 scikit-learn==1.3.2
 scikit-learn-extra==0.2.0
+seaborn==0.13.2
+matplotlib==3.10.0
+pandas==2.3.3

--- a/backend/python/requirements.txt
+++ b/backend/python/requirements.txt
@@ -76,3 +76,5 @@ scikit-learn-extra==0.2.0
 seaborn==0.13.2
 matplotlib==3.10.0
 pandas==2.3.3
+pandas-stubs
+types-seaborn


### PR DESCRIPTION
## JIRA ticket link
https://f4kblueprint.atlassian.net/jira/software/projects/F4KRP/boards/1?selectedIssue=F4KRP-105
Clustering


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* K-means clustering algorithm implementation 
* Includes handling for optional max locations per cluster and max boxes per cluster constraints
* Note: it was determined that timeout does not need to be enforced right now

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. I (with Chat's help for formatting) made a testing file (called k_means_test.py), if you go to lines 75-77 you'll see you can modify 3 params related to the algorithm. Feel free to play with them to test out how the algorithm performs in different situations! (And then you can run it via: docker-compose exec backend python -m app.services.implementations.k_means_test)


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Implementation (Does it make sense? Any edge cases not yet covered?)
* NOTE 1: Linter is currently mad because the Clustering Protocol signature does not match that of the currently-implemented algorithm (current algorithm includes max-boxes-per-cluster handling, but the protocol doesn't YET (changes pending))
* NOTE 2: For now, we can assume that at most one of the constraints (i.e. one of max boxes and max locations per cluster) will be applied when the algorithm is called - that is, there should not be a situation where the user calls the algorithm with both max boxes and max locations per cluster constraints


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
