### PR TITLE
Update clustering protocol to include max-boxes-per-cluster constraint handling

### DIFF
--- a/backend/python/app/services/implementations/mock_clustering_algorithm.py
+++ b/backend/python/app/services/implementations/mock_clustering_algorithm.py
@@ -22,6 +22,7 @@ class MockClusteringAlgorithm(ClusteringAlgorithmProtocol):
         locations: list[Location],
         num_clusters: int,
         max_locations_per_cluster: int | None = None,
+        max_boxes_per_cluster: int | None = None,
         timeout_seconds: float | None = None,  # noqa: ARG002
     ) -> list[list[Location]]:
         """Split locations evenly into clusters in sequential order.

--- a/backend/python/app/services/implementations/mock_clustering_algorithm.py
+++ b/backend/python/app/services/implementations/mock_clustering_algorithm.py
@@ -11,10 +11,11 @@ if TYPE_CHECKING:
 
 
 class MockClusteringAlgorithm(ClusteringAlgorithmProtocol):
-    """Simple mock clustering algorithm that splits locations evenly into clusters.
+    """Simple mock clustering algorithm that splits locations into clusters.
 
-    This is a pure function with no database interaction - it just
-    distributes locations evenly across the requested number of clusters.
+    This is a pure function with no database interaction. It distributes
+    locations across clusters while respecting max_locations_per_cluster and
+    max_boxes_per_cluster constraints.
     """
 
     async def cluster_locations(
@@ -25,7 +26,7 @@ class MockClusteringAlgorithm(ClusteringAlgorithmProtocol):
         max_boxes_per_cluster: int | None = None,
         timeout_seconds: float | None = None,  # noqa: ARG002
     ) -> list[list[Location]]:
-        """Split locations evenly into clusters in sequential order.
+        """Split locations into clusters while respecting box constraints.
 
         Args:
             locations: List of locations to cluster
@@ -33,6 +34,9 @@ class MockClusteringAlgorithm(ClusteringAlgorithmProtocol):
             max_locations_per_cluster: Optional maximum number of locations
                 per cluster. If provided, validates that the clustering is
                 possible and raises an error if violated.
+            max_boxes_per_cluster: Optional maximum number of boxes per cluster.
+                If provided, validates that the clustering is possible and
+                raises an error if violated.
             timeout_seconds: Optional timeout in seconds. Not enforced in this
                 mock implementation.
 
@@ -48,6 +52,7 @@ class MockClusteringAlgorithm(ClusteringAlgorithmProtocol):
 
         if num_clusters < 1:
             raise ValueError("num_clusters must be at least 1")
+
         # Calculate base cluster size and validate constraints
         total_locations = len(locations)
         base_cluster_size = total_locations // num_clusters
@@ -67,11 +72,34 @@ class MockClusteringAlgorithm(ClusteringAlgorithmProtocol):
                 f"Required cluster size would be up to {max_cluster_size}."
             )
 
-        # Distribute remainder locations across the first 'remainder' clusters
-        clusters = []
-        start = 0
-        for i in range(num_clusters):
-            size = base_cluster_size + (1 if i < remainder else 0)
-            clusters.append(locations[start : start + size])
-            start += size
+        # Distribute locations while respecting constraints
+        clusters: list[list[Location]] = [[] for _ in range(num_clusters)]
+        cluster_boxes: list[int] = [0] * num_clusters
+        cluster_idx = 0
+
+        for location in locations:
+            # Find next cluster that can accommodate this location
+            attempts = 0
+            while attempts < num_clusters:
+                boxes_ok = (
+                    max_boxes_per_cluster is None
+                    or cluster_boxes[cluster_idx] + location.num_boxes
+                    <= max_boxes_per_cluster
+                )
+                locations_ok = (
+                    max_locations_per_cluster is None
+                    or len(clusters[cluster_idx]) < max_locations_per_cluster
+                )
+                if boxes_ok and locations_ok:
+                    break
+                cluster_idx = (cluster_idx + 1) % num_clusters
+                attempts += 1
+            else:
+                raise ValueError(
+                    "Cannot assign location: no cluster can accommodate it with the given constraints."
+                )
+            clusters[cluster_idx].append(location)
+            cluster_boxes[cluster_idx] += location.num_boxes
+            cluster_idx = (cluster_idx + 1) % num_clusters
+
         return clusters

--- a/backend/python/app/services/protocols/clustering_algorithm.py
+++ b/backend/python/app/services/protocols/clustering_algorithm.py
@@ -37,10 +37,14 @@ class ClusteringAlgorithmProtocol(Protocol):
             num_clusters: Target number of clusters to create
             max_locations_per_cluster: Optional maximum number of locations
                 per cluster. If provided and cannot be satisfied with the given
-                number of clusters, the algorithm should raise an error.
+                number of clusters, the algorithm should raise an error. Can
+                assert that at most one of the max_locations_per_cluster
+                and max_boxes_per_cluster args are non-null (at least for now).
             max_boxes_per_cluster: Optional maximum number of boxes per cluster.
                 If provided and cannot be satisfied with the given
-                number of clusters, the algorithm should raise an error.
+                number of clusters, the algorithm should raise an error. Can
+                assert that at most one of the max_locations_per_cluster
+                and max_boxes_per_cluster args are non-null (at least for now).
             timeout_seconds: Optional timeout in seconds. If provided, the
                 algorithm should raise TimeoutError if execution exceeds this
                 duration. If None, no timeout is enforced.

--- a/backend/python/app/services/protocols/clustering_algorithm.py
+++ b/backend/python/app/services/protocols/clustering_algorithm.py
@@ -38,7 +38,7 @@ class ClusteringAlgorithmProtocol(Protocol):
             max_locations_per_cluster: Optional maximum number of locations
                 per cluster. If provided and cannot be satisfied with the given
                 number of clusters, the algorithm should raise an error.
-            max_boxes_per_cluster: Optional maximum number of boxes per cluster. 
+            max_boxes_per_cluster: Optional maximum number of boxes per cluster.
                 If provided and cannot be satisfied with the given
                 number of clusters, the algorithm should raise an error.
             timeout_seconds: Optional timeout in seconds. If provided, the

--- a/backend/python/app/services/protocols/clustering_algorithm.py
+++ b/backend/python/app/services/protocols/clustering_algorithm.py
@@ -38,6 +38,9 @@ class ClusteringAlgorithmProtocol(Protocol):
             max_locations_per_cluster: Optional maximum number of locations
                 per cluster. If provided and cannot be satisfied with the given
                 number of clusters, the algorithm should raise an error.
+            max_boxes_per_cluster: Optional maximum number of boxes per cluster. 
+                If provided and cannot be satisfied with the given
+                number of clusters, the algorithm should raise an error.
             timeout_seconds: Optional timeout in seconds. If provided, the
                 algorithm should raise TimeoutError if execution exceeds this
                 duration. If None, no timeout is enforced.

--- a/backend/python/app/services/protocols/clustering_algorithm.py
+++ b/backend/python/app/services/protocols/clustering_algorithm.py
@@ -27,6 +27,7 @@ class ClusteringAlgorithmProtocol(Protocol):
         locations: list[Location],
         num_clusters: int,
         max_locations_per_cluster: int | None = None,
+        max_boxes_per_cluster: int | None = None,
         timeout_seconds: float | None = None,
     ) -> list[list[Location]]:  # pragma: no cover - interface only
         """Cluster locations into groups.


### PR DESCRIPTION
FOR KERUSHANI AND EDDY: Adding you guys as reviewers for this PR since I heard you're also working on a clustering implementation! TLDR for this PR is that there is another optional arg for the clustering algorithm: max_boxes_per_cluster, which is a max cap on the number of boxes in a cluster. This is to account for the limited space in drivers' trunks.

## JIRA ticket link
Update Clustering Protocol

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Updated the clustering protocol to include handling for constraints on the max number of boxes allowed per cluster


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Update was applied comprehensively across codebase


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Please check that the update was applied comprehensively across codebase


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [ ] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
