### PR TITLE
Fix the migration to not use auth_id from admin_info

### DIFF
--- a/backend/python/migrations/versions/ba76119b3e4c_update_user_system.py
+++ b/backend/python/migrations/versions/ba76119b3e4c_update_user_system.py
@@ -81,7 +81,7 @@ def upgrade() -> None:
                     'user_id': user_id,
                     'name': admin[1],
                     'email': admin[2],
-                    'auth_id': f'admin_{user_id}' # THIS DOESN'T WORK LOL, THIS DOES NOT CORRESPOND TO THE FIREBASE AUTH_ID
+                    'auth_id': f'admin_{user_id}'
                 })
 
         # Add user_id column as nullable first

--- a/backend/python/migrations/versions/ba76119b3e4c_update_user_system.py
+++ b/backend/python/migrations/versions/ba76119b3e4c_update_user_system.py
@@ -66,7 +66,7 @@ def upgrade() -> None:
         # Get existing admin records that need migration
         if 'admin_email' in admin_info_columns and 'admin_name' in admin_info_columns:
             existing_admins = connection.execute(sa.text("""
-                SELECT admin_id, admin_name, admin_email, auth_id
+                SELECT admin_id, admin_name, admin_email
                 FROM admin_info
             """)).fetchall()
 
@@ -81,7 +81,7 @@ def upgrade() -> None:
                     'user_id': user_id,
                     'name': admin[1],
                     'email': admin[2],
-                    'auth_id': admin[3] if admin[3] else f'admin_{user_id}'
+                    'auth_id': f'admin_{user_id}' # THIS DOESN'T WORK LOL, THIS DOES NOT CORRESPOND TO THE FIREBASE AUTH_ID
                 })
 
         # Add user_id column as nullable first


### PR DESCRIPTION
Bug fix, no corresponding ticket


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Don't query for auth_id from the admin_info table


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Start from a blank database and try running migrations

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* How to deal with admin_info


## Checklist
- [ ] My PR name is descriptive and in imperative tense
- [ ] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [ ] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
