### PR TITLE
chore: add .claude/ to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 **/*.egg-info
 switch_github.sh
 CLAUDE.md
+.claude/
 backend/python/app/data/
 **/*service-account*.json
 **/*secrets*.json


### PR DESCRIPTION
## Summary
- Add `.claude/` directory to `.gitignore` to prevent personal Claude Code settings/memory from being committed

## Test plan
- [x] Verify `.claude/` no longer shows as untracked in `git status`

🤖 Generated with [Claude Code](https://claude.com/claude-code)