### PR TITLE
ci: always report required checks (fix stuck checks on path-filtered PRs)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,15 +4,9 @@ on:
   push:
     branches:
       - main
-    paths:
-      - "frontend/**"
-      - "backend/python/**"
   pull_request:
     branches:
       - main
-    paths:
-      - "frontend/**"
-      - "backend/python/**"
 
 jobs:
   run-lint:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -4,13 +4,9 @@ on:
   push:
     branches:
       - main
-    paths:
-      - "backend/python/**"
   pull_request:
     branches:
       - main
-    paths:
-      - "backend/python/**"
 
 concurrency:
   group: pytest-${{ github.workflow }}-${{ github.ref }}
@@ -41,20 +37,36 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      # Run the job on every PR so the required `test` check always reports a
+      # status, but only do the expensive setup + tests when backend code
+      # changed. A path-filtered workflow is skipped entirely on frontend-only
+      # PRs, which leaves the required check stuck on "Expected — Waiting for
+      # status to be reported" and blocks merge.
+      - name: Filter changed files
+        uses: dorny/paths-filter@v2
+        id: changes
+        with:
+          filters: |
+            python-backend:
+              - "backend/python/**"
+
       - name: Set up Python
+        if: steps.changes.outputs.python-backend == 'true'
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
           cache: "pip"
           cache-dependency-path: backend/python/requirements.txt
-      
+
       - name: Install dependencies
+        if: steps.changes.outputs.python-backend == 'true'
         working-directory: ./backend/python
         run: |
           python -m pip install --upgrade pip
           python -m pip install -r requirements.txt
-      
+
       - name: Run tests
+        if: steps.changes.outputs.python-backend == 'true'
         working-directory: ./backend/python
         env:
           PYTHONPATH: ${{ github.workspace }}/backend/python
@@ -68,4 +80,3 @@ jobs:
           GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}
         run: |
           pytest -q --disable-warnings -ra
-


### PR DESCRIPTION
## Problem

`test` (Pytest CI) and `run-lint` (Lint codebase) are **required** status checks, but both were triggered by `paths:` filters (`backend/python/**`, and `frontend/**`+`backend/python/**` respectively). When a PR doesn't touch the filtered paths, the whole workflow is skipped, the required check never reports, and the PR is stuck on **"Expected — Waiting for status to be reported"** — unable to merge.

- A **frontend-only** PR (e.g. #127) skips `pytest.yml` → `test` hangs.
- A **CI/docs-only** PR (e.g. this one) skips `lint.yml` → `run-lint` hangs.

[Documented GitHub behavior](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks): a path-filtered *workflow* that's skipped reports **no** status (blocks a required check), whereas a *step/job* skipped via `if:` reports **success**. GitHub's guidance: don't use path filtering to skip a workflow that's required to merge.

## Fix

Drop the workflow-level `paths:` filters and gate the work at the **step** level instead (via `dorny/paths-filter`, which `lint.yml` already used):

- **`pytest.yml`** — run the `test` job on every PR; gate Python setup/install/pytest behind a `backend/python/**` filter.
- **`lint.yml`** — already gated every step behind the filter; just removed the workflow-level `paths:` so `run-lint` always runs and reports.

Result: both checks **always report a status**. On a no-op PR they skip the expensive steps and report success (no wasted backend test runs / installs); on a relevant PR they run exactly as before.

## Test plan

- [ ] This PR (CI-only) — both `test` and `run-lint` report success instead of hanging
- [ ] A backend PR still runs the full pytest suite + backend lint
- [ ] A frontend PR still runs frontend lint; `test` reports success without running backend tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)