### PR TITLE
refactor: inject get_location_service deps via Depends()

### DIFF
--- a/backend/python/app/dependencies/services.py
+++ b/backend/python/app/dependencies/services.py
@@ -1,5 +1,14 @@
-"""
-Service dependency injection module
+"""Service dependency injection module.
+
+Convention:
+- Leaf factories (no service dependencies — just a logger, settings, or an
+  expensive client like GoogleMapsClient) use ``@lru_cache`` and call
+  ``get_logger()`` directly. They are process-wide singletons.
+- Composite factories (those that depend on other services/clients) take those
+  dependencies via ``Depends(...)`` rather than calling the other factory
+  directly in the body. This keeps the dependency graph explicit and lets tests
+  swap pieces via ``app.dependency_overrides``. See ``get_auth_service`` and
+  ``get_location_service``.
 """
 
 import logging
@@ -158,12 +167,15 @@ def get_system_settings_service() -> SystemSettingsService:
     return SystemSettingsService(logger)
 
 
-@lru_cache
-def get_location_service() -> LocationService:
+def get_location_service(
+    google_maps_client: GoogleMapsClient = Depends(get_google_maps_client),
+    system_settings_service: SystemSettingsService = Depends(
+        get_system_settings_service
+    ),
+) -> LocationService:
     """Get location service instance"""
     logger = get_logger()
-    google_maps_client = get_google_maps_client()
-    return LocationService(logger, google_maps_client, get_system_settings_service())
+    return LocationService(logger, google_maps_client, system_settings_service)
 
 
 @lru_cache


### PR DESCRIPTION
## What

Convert `get_location_service` from an `@lru_cache`'d factory that calls `get_google_maps_client()` and `get_system_settings_service()` directly in its body, to one that receives those dependencies via `Depends()` — mirroring the existing `get_auth_service` pattern.

Also documents the **leaf vs composite factory convention** in the module docstring:
- **Leaf factories** (logger/settings/expensive-client only) keep `@lru_cache` + direct `get_logger()`. Process-wide singletons.
- **Composite factories** (depend on other services) take those via `Depends(...)`, keeping the dependency graph explicit and overridable in tests through `app.dependency_overrides`.

## Why

`get_location_service` was the one composite factory still wiring its dependencies imperatively inside an `@lru_cache`'d body, which hides the graph and makes the pieces awkward to override in tests. This brings it in line with `get_auth_service`.

## Scope

Single file: `backend/python/app/dependencies/services.py`. No schema/model changes, so no migration. Behavior-preserving.

## Verification

- ✅ `pytest` — 115 passed
- ✅ `ruff check` + `ruff format --check`
- ✅ `mypy` — no issues in 105 source files

🤖 Generated with [Claude Code](https://claude.com/claude-code)