### PR TITLE
fix: location group creation 500 + unlinked locations

### DIFF
--- a/backend/python/app/services/implementations/location_group_service.py
+++ b/backend/python/app/services/implementations/location_group_service.py
@@ -63,23 +63,30 @@ class LocationGroupService:
 
             new_location_group = LocationGroup(**data)
             session.add(new_location_group)
-            await session.commit()
-            await session.refresh(new_location_group)
+            # flush (not commit) so the group is persistent for the FK updates
+            # below while keeping the insert + links in one atomic transaction.
+            # The PK is a Python-side uuid4 default, so it's already populated.
+            await session.flush()
 
-            # Update each location's location_group_id foreign key
-            for location_id in location_ids:
-                statement = select(Location).where(Location.location_id == location_id)
-                result = await session.execute(statement)
-                location = result.scalars().first()
+            # Link the requested locations in a single query rather than one
+            # SELECT per id.
+            result = await session.execute(
+                select(Location).where(
+                    Location.location_id.in_(location_ids)  # type: ignore[attr-defined]
+                )
+            )
+            locations = result.scalars().all()
+            found_ids = {location.location_id for location in locations}
 
-                if location:
-                    if location.location_group_id is not None:
-                        self.logger.warning(
-                            f"Location with id {location_id} already has a location group set; reassigning"
-                        )
-                    location.location_group_id = new_location_group.location_group_id
-                else:
-                    self.logger.warning(f"Location with id {location_id} not found")
+            for location in locations:
+                if location.location_group_id is not None:
+                    self.logger.warning(
+                        f"Location with id {location.location_id} already has a location group set; reassigning"
+                    )
+                location.location_group_id = new_location_group.location_group_id
+
+            for missing_id in set(location_ids) - found_ids:
+                self.logger.warning(f"Location with id {missing_id} not found")
 
             await session.commit()
 
@@ -124,9 +131,15 @@ class LocationGroupService:
                 setattr(location_group, field, value)
 
             await session.commit()
-            await session.refresh(location_group)
 
-            return location_group
+            # Reload with locations eager-loaded so the caller can read
+            # LocationGroupRead.num_locations without an async lazy load (500).
+            reloaded_group = await self.get_location_group(session, location_group_id)
+            if not reloaded_group:
+                raise Exception(
+                    f"Failed to reload updated location group with id {location_group_id}"
+                )
+            return reloaded_group
 
         except Exception as error:
             self.logger.error(f"Failed to update location group: {error!s}")

--- a/backend/python/app/services/implementations/location_group_service.py
+++ b/backend/python/app/services/implementations/location_group_service.py
@@ -2,6 +2,7 @@ import logging
 from uuid import UUID
 
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
 from sqlmodel import select
 
 from app.models.location import Location
@@ -19,7 +20,11 @@ class LocationGroupService:
     async def get_location_groups(self, session: AsyncSession) -> list[LocationGroup]:
         """Get all location groups"""
         try:
-            statement = select(LocationGroup)
+            # Eager-load locations so LocationGroupRead.num_locations can be read
+            # without triggering an (illegal) lazy load on the async session.
+            statement = select(LocationGroup).options(
+                selectinload(LocationGroup.locations)  # type: ignore[arg-type]
+            )
             result = await session.execute(statement)
             return list(result.scalars().all())
         except Exception as error:
@@ -30,8 +35,12 @@ class LocationGroupService:
         self, session: AsyncSession, location_group_id: UUID
     ) -> LocationGroup | None:
         """Get location group by ID"""
-        statement = select(LocationGroup).where(
-            LocationGroup.location_group_id == location_group_id
+        # Eager-load locations so LocationGroupRead.num_locations can be read
+        # without triggering an (illegal) lazy load on the async session.
+        statement = (
+            select(LocationGroup)
+            .where(LocationGroup.location_group_id == location_group_id)
+            .options(selectinload(LocationGroup.locations))  # type: ignore[arg-type]
         )
         result = await session.execute(statement)
         location_group = result.scalars().first()
@@ -66,11 +75,9 @@ class LocationGroupService:
                 if location:
                     if location.location_group_id is not None:
                         self.logger.warning(
-                            f"Location with id {location_id} already has a location group set"
+                            f"Location with id {location_id} already has a location group set; reassigning"
                         )
-                        location.location_group_id = (
-                            new_location_group.location_group_id
-                        )
+                    location.location_group_id = new_location_group.location_group_id
                 else:
                     self.logger.warning(f"Location with id {location_id} not found")
 

--- a/backend/python/tests/test_routes.py
+++ b/backend/python/tests/test_routes.py
@@ -357,6 +357,117 @@ class TestLocationGroupRoutes:
         assert len(groups) == 1
         assert groups[0]["num_locations"] == 1
 
+    @pytest.mark.asyncio
+    async def test_create_location_group_skips_unknown_location_id(
+        self,
+        async_client: AsyncClient,
+        sample_location_data: dict[str, Any],
+        sample_location_group_data: dict[str, Any],
+    ) -> None:
+        """Unknown location_ids are warned and skipped, not fatal — the group
+        is still created and links only the locations that exist."""
+        create_response = await async_client.post(
+            "/locations/", json=sample_location_data
+        )
+        location_id = create_response.json()["location_id"]
+        unknown_id = str(uuid4())
+
+        response = await async_client.post(
+            "/location-groups/",
+            json={
+                **sample_location_group_data,
+                "location_ids": [location_id, unknown_id],
+            },
+        )
+        assert response.status_code == 201
+        # Only the real location was linked
+        assert response.json()["num_locations"] == 1
+
+    @pytest.mark.asyncio
+    async def test_create_location_group_reassigns_existing_location(
+        self,
+        async_client: AsyncClient,
+        sample_location_data: dict[str, Any],
+        sample_location_group_data: dict[str, Any],
+    ) -> None:
+        """A location already in group A is moved to a new group B when B's
+        create references it (and A loses it)."""
+        create_response = await async_client.post(
+            "/locations/", json=sample_location_data
+        )
+        location_id = create_response.json()["location_id"]
+
+        await async_client.post(
+            "/location-groups/",
+            json={
+                **sample_location_group_data,
+                "name": "Group A",
+                "location_ids": [location_id],
+            },
+        )
+
+        group_b = (
+            await async_client.post(
+                "/location-groups/",
+                json={
+                    **sample_location_group_data,
+                    "name": "Group B",
+                    "location_ids": [location_id],
+                },
+            )
+        ).json()
+
+        # The location now points at B, and B reports it
+        assert group_b["num_locations"] == 1
+        loc = (await async_client.get(f"/locations/{location_id}")).json()
+        assert loc["location_group_id"] == group_b["location_group_id"]
+
+        # A no longer counts it
+        groups = {
+            g["name"]: g for g in (await async_client.get("/location-groups/")).json()
+        }
+        assert groups["Group A"]["num_locations"] == 0
+        assert groups["Group B"]["num_locations"] == 1
+
+    @pytest.mark.asyncio
+    async def test_update_location_group(
+        self,
+        async_client: AsyncClient,
+        sample_location_data: dict[str, Any],
+        sample_location_group_data: dict[str, Any],
+    ) -> None:
+        """PATCH /location-groups/{id} updates fields and returns the group
+        with num_locations populated (regression: previously 500'd reading the
+        lazily-loaded num_locations)."""
+        location_id = (
+            await async_client.post("/locations/", json=sample_location_data)
+        ).json()["location_id"]
+        group = (
+            await async_client.post(
+                "/location-groups/",
+                json={**sample_location_group_data, "location_ids": [location_id]},
+            )
+        ).json()
+
+        response = await async_client.patch(
+            f"/location-groups/{group['location_group_id']}",
+            json={"name": "Renamed Group"},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["name"] == "Renamed Group"
+        assert data["num_locations"] == 1
+
+    @pytest.mark.asyncio
+    async def test_update_location_group_not_found(
+        self, async_client: AsyncClient
+    ) -> None:
+        """PATCH /location-groups/{id} returns 404 for a non-existent group."""
+        response = await async_client.patch(
+            f"/location-groups/{uuid4()}", json={"name": "Nope"}
+        )
+        assert response.status_code == 404
+
 
 class TestRouteRoutes:
     """Test suite for route API routes."""

--- a/backend/python/tests/test_routes.py
+++ b/backend/python/tests/test_routes.py
@@ -273,6 +273,91 @@ class TestLocationRoutes:
         assert get_response.status_code == 404
 
 
+class TestLocationGroupRoutes:
+    """Test suite for location group API routes."""
+
+    @pytest.mark.asyncio
+    async def test_get_location_groups_empty(self, async_client: AsyncClient) -> None:
+        """GET /location-groups returns an empty list when none exist."""
+        response = await async_client.get("/location-groups/")
+        assert response.status_code == 200
+        assert response.json() == []
+
+    @pytest.mark.asyncio
+    async def test_create_location_group_links_locations(
+        self,
+        async_client: AsyncClient,
+        sample_location_data: dict[str, Any],
+        sample_location_group_data: dict[str, Any],
+    ) -> None:
+        """POST /location-groups creates a group, links the given locations,
+        and returns an accurate num_locations.
+
+        Regression test for two bugs: (1) a 500 from reading the computed
+        num_locations off a lazily-loaded relationship on the async session,
+        and (2) brand-new (ungrouped) locations never being linked because the
+        assignment was nested under `if location_group_id is not None`.
+        """
+        # Create two ungrouped locations
+        location_ids = []
+        for i in range(2):
+            data = {**sample_location_data, "contact_name": f"Contact {i}"}
+            create_response = await async_client.post("/locations/", json=data)
+            assert create_response.status_code == 201
+            location_ids.append(create_response.json()["location_id"])
+
+        # Create a group that references them
+        response = await async_client.post(
+            "/location-groups/",
+            json={**sample_location_group_data, "location_ids": location_ids},
+        )
+        assert response.status_code == 201
+        group = response.json()
+        assert group["name"] == sample_location_group_data["name"]
+        assert group["num_locations"] == 2
+
+        # Each location now reports the group via its FK
+        for location_id in location_ids:
+            loc = (await async_client.get(f"/locations/{location_id}")).json()
+            assert loc["location_group_id"] == group["location_group_id"]
+
+    @pytest.mark.asyncio
+    async def test_create_location_group_requires_location_ids(
+        self,
+        async_client: AsyncClient,
+        sample_location_group_data: dict[str, Any],
+    ) -> None:
+        """POST /location-groups rejects an empty location_ids list."""
+        response = await async_client.post(
+            "/location-groups/",
+            json={**sample_location_group_data, "location_ids": []},
+        )
+        assert response.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_get_location_groups_with_data(
+        self,
+        async_client: AsyncClient,
+        sample_location_data: dict[str, Any],
+        sample_location_group_data: dict[str, Any],
+    ) -> None:
+        """GET /location-groups returns groups with num_locations populated."""
+        create_response = await async_client.post(
+            "/locations/", json=sample_location_data
+        )
+        location_id = create_response.json()["location_id"]
+        await async_client.post(
+            "/location-groups/",
+            json={**sample_location_group_data, "location_ids": [location_id]},
+        )
+
+        response = await async_client.get("/location-groups/")
+        assert response.status_code == 200
+        groups = response.json()
+        assert len(groups) == 1
+        assert groups[0]["num_locations"] == 1
+
+
 class TestRouteRoutes:
     """Test suite for route API routes."""
 


### PR DESCRIPTION
## Summary

Fixes issues in `POST /location-groups`:
1. **500 on success** — the route returns `LocationGroupRead`, whose computed `num_locations` reads `self.locations`. The create/get path didn't eager-load that relationship, so reading it triggered an illegal lazy load on the async session. Now eager-loaded via `selectinload` in `get_location_group` and `get_location_groups`.
2. **Locations were never linked** — in `create_location_group` the `location.location_group_id = ...` assignment was nested inside `if location.location_group_id is not None`, so brand-new (ungrouped) locations — the common case — were skipped entirely. Now always assigns; warns only when overwriting an existing group.

## Tests

New `TestLocationGroupRoutes`:
- create + link (asserts `num_locations` is accurate and each location's FK is set)
- empty `location_ids` → 422
- list endpoint returns groups with `num_locations` populated

All 119 backend tests pass; ruff / ruff format / mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)