### PR TITLE
feat: require a delivery group on every location

### DIFF
--- a/backend/python/app/models/location.py
+++ b/backend/python/app/models/location.py
@@ -21,8 +21,8 @@ class LocationState(str, Enum):
 class LocationBase(SQLModel):
     """Shared fields between table and API models"""
 
-    location_group_id: UUID | None = Field(
-        default=None, foreign_key="location_groups.location_group_id", nullable=True
+    location_group_id: UUID = Field(
+        foreign_key="location_groups.location_group_id", nullable=False
     )
     school_name: str | None = None
     contact_name: str
@@ -53,6 +53,16 @@ class Location(LocationBase, BaseModel, table=True):
     location_group: "LocationGroup" = Relationship(back_populates="locations")
     note_chain: "NoteChain" = Relationship()
 
+    @property
+    def location_group_name(self) -> str:
+        """Name of the location's (required) delivery group.
+
+        Surfaced on LocationRead so list views can show the group name without
+        a second lookup. Requires location_group to be eager-loaded (see the
+        selectinload calls in LocationService) to avoid an async lazy load.
+        """
+        return self.location_group.name
+
 
 class AlertCode(str, Enum):
     """Machine-readable reason code for an import alert."""
@@ -82,7 +92,9 @@ class ValidatedLocationImportEntry(LocationImportEntry):
     contact_name: str
     address: str
     phone_number: str
-    delivery_group: str | None = None
+    # Required: every location must belong to a delivery group (the import
+    # flags MISSING_DELIVERY_GROUP, and location_group_id is non-nullable).
+    delivery_group: str
     num_boxes: int | None = None
     halal: bool | None = None
     dietary_restrictions: str | None = None
@@ -170,6 +182,7 @@ class LocationRead(LocationBase):
     """Read response model"""
 
     location_id: UUID
+    location_group_name: str
 
 
 class LocationUpdate(SQLModel):

--- a/backend/python/app/routers/location_group_routes.py
+++ b/backend/python/app/routers/location_group_routes.py
@@ -104,9 +104,13 @@ async def delete_location_group(
     """
     Delete a location group by ID
     """
-    success = await location_group_service.delete_location_group(
-        session, location_group_id
-    )
+    try:
+        success = await location_group_service.delete_location_group(
+            session, location_group_id
+        )
+    except ValueError as e:
+        # Group still has locations (they require a group, so can't be orphaned)
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(e)) from e
     if not success:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,

--- a/backend/python/app/seed_database.py
+++ b/backend/python/app/seed_database.py
@@ -15,7 +15,7 @@ import faker
 import phonenumbers
 from phonenumbers import PhoneNumberFormat
 from sklearn.cluster import KMeans  # type: ignore[import-untyped]
-from sqlalchemy import create_engine, not_, text
+from sqlalchemy import create_engine, text
 from sqlmodel import Session, select
 
 from app.models.admin import Admin
@@ -47,8 +47,6 @@ fake = faker.Faker()
 ADMIN_AUTH_ID = os.getenv("ADMIN_AUTH_ID")
 
 # Configuration constants
-# Percentage of locations that will be unassigned to any location group
-UNASSIGNED_LOCATION_PERCENTAGE = 0.05
 # Average number of stops per route (used to calculate number of clusters)
 AVG_STOPS_PER_ROUTE = 7.5
 # Maximum number of stops per route (Google Maps directions URLs support max 10 waypoints)
@@ -452,26 +450,22 @@ def main() -> None:
                         )
 
                         # Determine location group
-                        group_id: str | None
-                        if random.random() < UNASSIGNED_LOCATION_PERCENTAGE:
-                            group_id = None
+                        # Every location must belong to a delivery group
+                        # (location_group_id is non-nullable).
+                        is_small_city = any(
+                            city in address.lower() for city in SMALL_CITIES
+                        )
+                        if is_small_city:
+                            # Random assignment from non-school groups for small cities
+                            group_id = random.choice(non_school_groups)
                         else:
-                            # Check for small cities that need specific group assignments
-                            is_small_city = any(
-                                city in address.lower() for city in SMALL_CITIES
-                            )
-
-                            if is_small_city:
-                                # Random assignment from non-school groups for small cities
-                                group_id = random.choice(non_school_groups)
-                            else:
-                                # Random assignment for other locations
-                                group_id = random.choice(list(group_ids.values()))
+                            # Random assignment for other locations
+                            group_id = random.choice(list(group_ids.values()))
 
                         # Generate fake data for location insertion
                         is_school = random.choice([True, False])
                         location = Location(
-                            location_group_id=uuid.UUID(group_id) if group_id else None,
+                            location_group_id=uuid.UUID(group_id),
                             school_name=fake.company() + " School"
                             if is_school
                             else None,
@@ -509,18 +503,11 @@ def main() -> None:
             print("Creating routes...")
             routes_created = 0
 
-            # Get all locations with a location group assigned
-            locations_with_group = session.exec(
-                select(Location).where(
-                    not_(Location.location_group_id.is_(None))  # type: ignore[union-attr]
-                )
-            ).all()
+            # Every location belongs to a group; group them by group id.
+            all_locations = session.exec(select(Location)).all()
 
-            # Group locations by location group
             locations_by_group: dict[str, list[Location]] = {}
-            for location in locations_with_group:
-                # Type narrowing: we filtered for non-None location_group_id in the query
-                assert location.location_group_id is not None
+            for location in all_locations:
                 group_id = str(location.location_group_id)
                 if group_id not in locations_by_group:
                     locations_by_group[group_id] = []

--- a/backend/python/app/services/implementations/location_group_service.py
+++ b/backend/python/app/services/implementations/location_group_service.py
@@ -163,14 +163,18 @@ class LocationGroupService:
                 )
                 return False
 
+            # Locations require a group, so we can't orphan them on delete.
+            # Refuse to delete a group that still has locations; callers must
+            # reassign them first.
             locations_statement = select(Location).where(
                 Location.location_group_id == location_group_id
             )
             locations_result = await session.execute(locations_statement)
-            locations = locations_result.scalars().all()
-
-            for location in locations:
-                location.location_group_id = None
+            if locations_result.scalars().first() is not None:
+                raise ValueError(
+                    f"Cannot delete location group {location_group_id}: it still "
+                    "has locations. Reassign them to another group first."
+                )
 
             await session.delete(location_group)
             await session.commit()

--- a/backend/python/app/services/implementations/location_service.py
+++ b/backend/python/app/services/implementations/location_service.py
@@ -8,6 +8,7 @@ from uuid import UUID
 import pandas as pd
 from fastapi import UploadFile
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
 from sqlmodel import select
 
 from app.models.enum import NotePermission
@@ -72,7 +73,13 @@ class LocationService:
     ) -> Location:
         """Get location by ID - returns SQLModel instance"""
         try:
-            statement = select(Location).where(Location.location_id == location_id)
+            # Eager-load location_group so LocationRead.location_group_name can be
+            # read without an (illegal) lazy load on the async session.
+            statement = (
+                select(Location)
+                .where(Location.location_id == location_id)
+                .options(selectinload(Location.location_group))  # type: ignore[arg-type]
+            )
             result = await session.execute(statement)
             location = result.scalars().first()
 
@@ -92,6 +99,7 @@ class LocationService:
             statement = (
                 select(Location)
                 .where(Location.state == LocationState.ACTIVE)
+                .options(selectinload(Location.location_group))  # type: ignore[arg-type]
                 .order_by(Location.created_at.desc())  # type: ignore[union-attr]
             )
             result, total = await paginate_query(session, statement, pagination)
@@ -122,8 +130,9 @@ class LocationService:
             location.note_chain_id = note_chain.note_chain_id
             session.add(location)
             await session.commit()
-            await session.refresh(location)
-            return location
+            # Reload with location_group eager-loaded so serializing to
+            # LocationRead (location_group_name) doesn't lazy-load post-commit.
+            return await self.get_location_by_id(session, location.location_id)
         except Exception as e:
             self.logger.error(f"Failed to create location: {e!s}")
             await session.rollback()
@@ -146,8 +155,9 @@ class LocationService:
                 setattr(location, field, value)
 
             await session.commit()
-            await session.refresh(location)
-            return location
+            # Reload with location_group eager-loaded so serializing to
+            # LocationRead (location_group_name) doesn't lazy-load post-commit.
+            return await self.get_location_by_id(session, location_id)
 
         except Exception as e:
             self.logger.error(f"Failed to update location by id: {e!s}")
@@ -427,8 +437,7 @@ class LocationService:
                 {
                     entry.delivery_group
                     for entry in request.net_new
-                    if entry.delivery_group
-                    and entry.delivery_group not in group_by_name
+                    if entry.delivery_group not in group_by_name
                 }
             )
             for name in needed_names:
@@ -453,11 +462,6 @@ class LocationService:
                 )
                 new_note_chains.append(note_chain)
 
-                entry_group = (
-                    group_by_name.get(entry.delivery_group)
-                    if entry.delivery_group
-                    else None
-                )
                 new_locations.append(
                     Location(
                         contact_name=entry.contact_name,
@@ -470,9 +474,9 @@ class LocationService:
                         dietary_restrictions=entry.dietary_restrictions or "",
                         num_boxes=entry.num_boxes or 0,
                         note_chain_id=note_chain.note_chain_id,
-                        location_group_id=(
-                            entry_group.location_group_id if entry_group else None
-                        ),
+                        location_group_id=group_by_name[
+                            entry.delivery_group
+                        ].location_group_id,
                     )
                 )
 

--- a/backend/python/migrations/versions/f3b1c9a2d4e7_require_location_group.py
+++ b/backend/python/migrations/versions/f3b1c9a2d4e7_require_location_group.py
@@ -1,0 +1,42 @@
+"""Require location_group_id on locations (make non-nullable)
+
+Every location must belong to a delivery group: route generation operates per
+location group, and the import flags MISSING_DELIVERY_GROUP. Enforce it at the
+schema level.
+
+Revision ID: f3b1c9a2d4e7
+Revises: c7d9e2b14a06
+Create Date: 2026-05-26 00:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "f3b1c9a2d4e7"
+down_revision = "c7d9e2b14a06"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Drop any locations that never got a delivery group before enforcing the
+    # constraint. Safe here because this is a dev-only database with no
+    # production data to preserve.
+    op.execute("DELETE FROM locations WHERE location_group_id IS NULL")
+    op.alter_column(
+        "locations",
+        "location_group_id",
+        existing_type=sa.Uuid(),
+        nullable=False,
+    )
+
+
+def downgrade() -> None:
+    op.alter_column(
+        "locations",
+        "location_group_id",
+        existing_type=sa.Uuid(),
+        nullable=True,
+    )

--- a/backend/python/tests/conftest.py
+++ b/backend/python/tests/conftest.py
@@ -221,9 +221,27 @@ def sample_location_group_data() -> dict[str, Any]:
     }
 
 
+@pytest_asyncio.fixture
+async def test_location_group(test_session: AsyncSession) -> Any:
+    """Create a location group for tests.
+
+    Locations require a group (location_group_id is non-nullable), and the
+    POST /location-groups endpoint only regroups *existing* locations, so tests
+    bootstrap an initial group directly through the session (as seed/ingest do).
+    """
+    from app.models.location_group import LocationGroup
+
+    group = LocationGroup(name="Test Delivery Group", color="#FF5733", notes="")
+    test_session.add(group)
+    await test_session.commit()
+    await test_session.refresh(group)
+    return group
+
+
 @pytest.fixture
 def sample_location_data() -> dict[str, Any]:
-    """Sample location data for testing."""
+    """Sample location data for testing. Callers must add a valid
+    ``location_group_id`` (e.g. from the ``test_location_group`` fixture)."""
     return {
         "school_name": "Central Elementary",
         "contact_name": "Jane Smith",

--- a/backend/python/tests/test_models.py
+++ b/backend/python/tests/test_models.py
@@ -369,6 +369,7 @@ class TestCoreModels:
         """Test Location model core operations."""
         # Create with all fields
         location = Location(
+            location_group_id=uuid4(),
             school_name="Central Elementary",
             contact_name="Jane Smith",
             address="123 Main St, City, State 12345",
@@ -386,6 +387,7 @@ class TestCoreModels:
 
         # Create with minimal fields
         location_minimal = Location(
+            location_group_id=uuid4(),
             contact_name="John Doe",
             address="456 Oak Ave, City, State 12345",
             phone_number="(555) 987-6543",
@@ -400,6 +402,8 @@ class TestCoreModels:
         # Read model
         location_read = LocationRead(
             location_id=uuid4(),
+            location_group_id=uuid4(),
+            location_group_name="Central Elementary",
             contact_name="Jane Smith",
             address="123 Main St, City, State 12345",
             phone_number="(555) 123-4567",
@@ -769,6 +773,7 @@ class TestEnumsAndSerialization:
 
         # Test default values across models
         location = Location(
+            location_group_id=uuid4(),
             contact_name="John Doe",
             address="456 Oak Ave",
             phone_number="(555) 987-6543",

--- a/backend/python/tests/test_routes.py
+++ b/backend/python/tests/test_routes.py
@@ -179,10 +179,17 @@ class TestLocationRoutes:
 
     @pytest.mark.asyncio
     async def test_create_location(
-        self, async_client: AsyncClient, sample_location_data: dict[str, Any]
+        self,
+        async_client: AsyncClient,
+        sample_location_data: dict[str, Any],
+        test_location_group: Any,
     ) -> None:
         """Test POST /locations creates a new location."""
-        response = await async_client.post("/locations/", json=sample_location_data)
+        payload = {
+            **sample_location_data,
+            "location_group_id": str(test_location_group.location_group_id),
+        }
+        response = await async_client.post("/locations/", json=payload)
         assert response.status_code == 201
         data = response.json()
         assert data["contact_name"] == sample_location_data["contact_name"]
@@ -192,12 +199,19 @@ class TestLocationRoutes:
 
     @pytest.mark.asyncio
     async def test_get_locations_with_data(
-        self, async_client: AsyncClient, sample_location_data: dict[str, Any]
+        self,
+        async_client: AsyncClient,
+        sample_location_data: dict[str, Any],
+        test_location_group: Any,
     ) -> None:
         """Test GET /locations returns paginated list of locations."""
         # Create a location first
         create_response = await async_client.post(
-            "/locations/", json=sample_location_data
+            "/locations/",
+            json={
+                **sample_location_data,
+                "location_group_id": str(test_location_group.location_group_id),
+            },
         )
         assert create_response.status_code == 201
 
@@ -210,12 +224,19 @@ class TestLocationRoutes:
 
     @pytest.mark.asyncio
     async def test_get_location_by_id(
-        self, async_client: AsyncClient, sample_location_data: dict[str, Any]
+        self,
+        async_client: AsyncClient,
+        sample_location_data: dict[str, Any],
+        test_location_group: Any,
     ) -> None:
         """Test GET /locations/{location_id} returns specific location."""
         # Create a location first
         create_response = await async_client.post(
-            "/locations/", json=sample_location_data
+            "/locations/",
+            json={
+                **sample_location_data,
+                "location_group_id": str(test_location_group.location_group_id),
+            },
         )
         location_id = create_response.json()["location_id"]
 
@@ -235,12 +256,19 @@ class TestLocationRoutes:
 
     @pytest.mark.asyncio
     async def test_update_location(
-        self, async_client: AsyncClient, sample_location_data: dict[str, Any]
+        self,
+        async_client: AsyncClient,
+        sample_location_data: dict[str, Any],
+        test_location_group: Any,
     ) -> None:
         """Test PATCH /locations/{location_id} updates a location."""
         # Create a location first
         create_response = await async_client.post(
-            "/locations/", json=sample_location_data
+            "/locations/",
+            json={
+                **sample_location_data,
+                "location_group_id": str(test_location_group.location_group_id),
+            },
         )
         location_id = create_response.json()["location_id"]
 
@@ -255,12 +283,19 @@ class TestLocationRoutes:
 
     @pytest.mark.asyncio
     async def test_delete_location(
-        self, async_client: AsyncClient, sample_location_data: dict[str, Any]
+        self,
+        async_client: AsyncClient,
+        sample_location_data: dict[str, Any],
+        test_location_group: Any,
     ) -> None:
         """Test DELETE /locations/{location_id} deletes a location."""
         # Create a location first
         create_response = await async_client.post(
-            "/locations/", json=sample_location_data
+            "/locations/",
+            json={
+                **sample_location_data,
+                "location_group_id": str(test_location_group.location_group_id),
+            },
         )
         location_id = create_response.json()["location_id"]
 
@@ -271,6 +306,36 @@ class TestLocationRoutes:
         # Verify deletion
         get_response = await async_client.get(f"/locations/{location_id}")
         assert get_response.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_get_locations_includes_group_name(
+        self,
+        async_client: AsyncClient,
+        sample_location_data: dict[str, Any],
+        test_location_group: Any,
+    ) -> None:
+        """GET /locations (list + single) exposes location_group_name. Both
+        paths must eager-load location_group, else reading the name lazy-loads
+        and 500s on the async session."""
+        create_response = await async_client.post(
+            "/locations/",
+            json={
+                **sample_location_data,
+                "location_group_id": str(test_location_group.location_group_id),
+            },
+        )
+        assert create_response.status_code == 201
+        location_id = create_response.json()["location_id"]
+
+        listing = await async_client.get("/locations/")
+        item = next(
+            i for i in listing.json()["items"] if i["location_id"] == location_id
+        )
+        assert item["location_group_name"] == test_location_group.name
+
+        single = await async_client.get(f"/locations/{location_id}")
+        assert single.status_code == 200
+        assert single.json()["location_group_name"] == test_location_group.name
 
 
 class TestLocationGroupRoutes:
@@ -289,24 +354,28 @@ class TestLocationGroupRoutes:
         async_client: AsyncClient,
         sample_location_data: dict[str, Any],
         sample_location_group_data: dict[str, Any],
+        test_location_group: Any,
     ) -> None:
-        """POST /location-groups creates a group, links the given locations,
-        and returns an accurate num_locations.
+        """POST /location-groups creates a group, links (reassigns) the given
+        locations, and returns an accurate num_locations.
 
-        Regression test for two bugs: (1) a 500 from reading the computed
-        num_locations off a lazily-loaded relationship on the async session,
-        and (2) brand-new (ungrouped) locations never being linked because the
-        assignment was nested under `if location_group_id is not None`.
+        Regression test for the 500 from reading the computed num_locations off
+        a lazily-loaded relationship on the async session, and for the FK
+        actually being updated to the new group.
         """
-        # Create two ungrouped locations
+        # Create two locations (each starts in the bootstrap group)
         location_ids = []
         for i in range(2):
-            data = {**sample_location_data, "contact_name": f"Contact {i}"}
+            data = {
+                **sample_location_data,
+                "contact_name": f"Contact {i}",
+                "location_group_id": str(test_location_group.location_group_id),
+            }
             create_response = await async_client.post("/locations/", json=data)
             assert create_response.status_code == 201
             location_ids.append(create_response.json()["location_id"])
 
-        # Create a group that references them
+        # Create a new group that takes over those locations
         response = await async_client.post(
             "/location-groups/",
             json={**sample_location_group_data, "location_ids": location_ids},
@@ -316,7 +385,7 @@ class TestLocationGroupRoutes:
         assert group["name"] == sample_location_group_data["name"]
         assert group["num_locations"] == 2
 
-        # Each location now reports the group via its FK
+        # Each location now reports the new group via its FK
         for location_id in location_ids:
             loc = (await async_client.get(f"/locations/{location_id}")).json()
             assert loc["location_group_id"] == group["location_group_id"]
@@ -339,22 +408,24 @@ class TestLocationGroupRoutes:
         self,
         async_client: AsyncClient,
         sample_location_data: dict[str, Any],
-        sample_location_group_data: dict[str, Any],
+        test_location_group: Any,
     ) -> None:
         """GET /location-groups returns groups with num_locations populated."""
-        create_response = await async_client.post(
-            "/locations/", json=sample_location_data
-        )
-        location_id = create_response.json()["location_id"]
         await async_client.post(
-            "/location-groups/",
-            json={**sample_location_group_data, "location_ids": [location_id]},
+            "/locations/",
+            json={
+                **sample_location_data,
+                "location_group_id": str(test_location_group.location_group_id),
+            },
         )
 
         response = await async_client.get("/location-groups/")
         assert response.status_code == 200
         groups = response.json()
         assert len(groups) == 1
+        assert groups[0]["location_group_id"] == str(
+            test_location_group.location_group_id
+        )
         assert groups[0]["num_locations"] == 1
 
     @pytest.mark.asyncio
@@ -363,11 +434,16 @@ class TestLocationGroupRoutes:
         async_client: AsyncClient,
         sample_location_data: dict[str, Any],
         sample_location_group_data: dict[str, Any],
+        test_location_group: Any,
     ) -> None:
         """Unknown location_ids are warned and skipped, not fatal — the group
         is still created and links only the locations that exist."""
         create_response = await async_client.post(
-            "/locations/", json=sample_location_data
+            "/locations/",
+            json={
+                **sample_location_data,
+                "location_group_id": str(test_location_group.location_group_id),
+            },
         )
         location_id = create_response.json()["location_id"]
         unknown_id = str(uuid4())
@@ -389,22 +465,18 @@ class TestLocationGroupRoutes:
         async_client: AsyncClient,
         sample_location_data: dict[str, Any],
         sample_location_group_data: dict[str, Any],
+        test_location_group: Any,
     ) -> None:
-        """A location already in group A is moved to a new group B when B's
-        create references it (and A loses it)."""
+        """A location is moved from its current group to a new group when the
+        new group's create references it (and the old group loses it)."""
         create_response = await async_client.post(
-            "/locations/", json=sample_location_data
-        )
-        location_id = create_response.json()["location_id"]
-
-        await async_client.post(
-            "/location-groups/",
+            "/locations/",
             json={
-                **sample_location_group_data,
-                "name": "Group A",
-                "location_ids": [location_id],
+                **sample_location_data,
+                "location_group_id": str(test_location_group.location_group_id),
             },
         )
+        location_id = create_response.json()["location_id"]
 
         group_b = (
             await async_client.post(
@@ -422,35 +494,34 @@ class TestLocationGroupRoutes:
         loc = (await async_client.get(f"/locations/{location_id}")).json()
         assert loc["location_group_id"] == group_b["location_group_id"]
 
-        # A no longer counts it
+        # The original (bootstrap) group no longer counts it
         groups = {
-            g["name"]: g for g in (await async_client.get("/location-groups/")).json()
+            g["location_group_id"]: g
+            for g in (await async_client.get("/location-groups/")).json()
         }
-        assert groups["Group A"]["num_locations"] == 0
-        assert groups["Group B"]["num_locations"] == 1
+        assert groups[str(test_location_group.location_group_id)]["num_locations"] == 0
+        assert groups[group_b["location_group_id"]]["num_locations"] == 1
 
     @pytest.mark.asyncio
     async def test_update_location_group(
         self,
         async_client: AsyncClient,
         sample_location_data: dict[str, Any],
-        sample_location_group_data: dict[str, Any],
+        test_location_group: Any,
     ) -> None:
         """PATCH /location-groups/{id} updates fields and returns the group
         with num_locations populated (regression: previously 500'd reading the
         lazily-loaded num_locations)."""
-        location_id = (
-            await async_client.post("/locations/", json=sample_location_data)
-        ).json()["location_id"]
-        group = (
-            await async_client.post(
-                "/location-groups/",
-                json={**sample_location_group_data, "location_ids": [location_id]},
-            )
-        ).json()
+        await async_client.post(
+            "/locations/",
+            json={
+                **sample_location_data,
+                "location_group_id": str(test_location_group.location_group_id),
+            },
+        )
 
         response = await async_client.patch(
-            f"/location-groups/{group['location_group_id']}",
+            f"/location-groups/{test_location_group.location_group_id}",
             json={"name": "Renamed Group"},
         )
         assert response.status_code == 200
@@ -467,6 +538,38 @@ class TestLocationGroupRoutes:
             f"/location-groups/{uuid4()}", json={"name": "Nope"}
         )
         assert response.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_delete_empty_location_group(
+        self, async_client: AsyncClient, test_location_group: Any
+    ) -> None:
+        """DELETE /location-groups/{id} removes a group that has no locations."""
+        response = await async_client.delete(
+            f"/location-groups/{test_location_group.location_group_id}"
+        )
+        assert response.status_code == 204
+        assert (await async_client.get("/location-groups/")).json() == []
+
+    @pytest.mark.asyncio
+    async def test_delete_location_group_with_locations_conflicts(
+        self,
+        async_client: AsyncClient,
+        sample_location_data: dict[str, Any],
+        test_location_group: Any,
+    ) -> None:
+        """DELETE /location-groups/{id} returns 409 when the group still has
+        locations — they require a group, so can't be orphaned."""
+        await async_client.post(
+            "/locations/",
+            json={
+                **sample_location_data,
+                "location_group_id": str(test_location_group.location_group_id),
+            },
+        )
+        response = await async_client.delete(
+            f"/location-groups/{test_location_group.location_group_id}"
+        )
+        assert response.status_code == 409
 
 
 class TestRouteRoutes:


### PR DESCRIPTION
## Summary

Enforces the rule that all locations must have a group.

## Changes

- **Model + migration:** `LocationBase.location_group_id` is now non-nullable. The migration deletes any existing groupless rows (safe — dev-only, no prod data) then sets the column `NOT NULL`.
- **`location_group_name`:** added to `LocationRead` as a non-null `str` (computed from the now-guaranteed group) so list/detail views can show the delivery group by name. `location_group` is eager-loaded in the list / single / create / update paths to avoid async lazy-load 500s.
- **Import + seed:** `ValidatedLocationImportEntry.delivery_group` is now required, so ingest always resolves a group (dropped the `else None` fallback that would have violated the constraint). Seed no longer creates unassigned locations.
- **Delete group:** locations can't be orphaned anymore, so `DELETE /location-groups/{id}` now returns **409** when the group still has locations (previously it nulled out their FK).

## Tests
- New `test_location_group` fixture — locations bootstrap into a group (mirroring how seed/ingest create groups + locations together; the `POST /location-groups` endpoint only *regroups* existing locations).
- Coverage for `location_group_name` on list + single GET, and the delete-empty (204) / delete-with-locations (409) behaviour. Existing location/location-group tests updated to supply a group.
- Full backend suite (126) + ruff / ruff format / mypy green.


🤖 Generated with [Claude Code](https://claude.com/claude-code)