### PR TITLE
fix: GET /jobs/{job_id} returns 404 instead of 500 for unknown job

### DIFF
--- a/backend/python/app/routers/job_routes.py
+++ b/backend/python/app/routers/job_routes.py
@@ -61,6 +61,9 @@ async def get_job(
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND, detail="Job not found"
             )
+    except HTTPException:
+        # Don't let the 404 get swallowed and rewrapped as a 500 below.
+        raise
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(e)

--- a/backend/python/tests/test_routes.py
+++ b/backend/python/tests/test_routes.py
@@ -959,3 +959,33 @@ class TestAnnouncementRoutes:
         fake_id = uuid4()
         response = await async_client.delete(f"/announcements/{fake_id}")
         assert response.status_code == 404
+
+
+class TestJobRoutes:
+    """Test suite for job API routes."""
+
+    @pytest.mark.asyncio
+    async def test_get_job_not_found(self, async_client: AsyncClient) -> None:
+        """GET /jobs/{id} returns 404 (not 500) for an unknown job.
+
+        Regression: the 404 HTTPException was raised inside a try whose bare
+        `except Exception` swallowed it and rewrapped it as a 500.
+        """
+        response = await async_client.get(f"/jobs/{uuid4()}")
+        assert response.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_get_job(
+        self, async_client: AsyncClient, test_session: AsyncSession
+    ) -> None:
+        """GET /jobs/{id} returns the job."""
+        from app.models.job import Job
+
+        job = Job()
+        test_session.add(job)
+        await test_session.commit()
+        await test_session.refresh(job)
+
+        response = await async_client.get(f"/jobs/{job.job_id}")
+        assert response.status_code == 200
+        assert response.json()["job_id"] == str(job.job_id)


### PR DESCRIPTION
## Summary

`get_job` raised its `404` `HTTPException` *inside* a `try` whose bare `except Exception` caught it and rewrapped it as a `500` — so "job not found" never actually surfaced as a 404. Re-raise `HTTPException` before the generic handler.

Found during the endpoint test-coverage audit.

## Tests

New `TestJobRoutes`:
- `test_get_job_not_found` — unknown id returns 404 (verified it fails as a **500** against the unfixed code, so the regression test has teeth)
- `test_get_job` — happy path

All 128 backend tests pass; ruff / ruff format / mypy clean.

## Note

The audit also flagged `GET /route-groups?include_routes=true` as a possible lazy-load 500, but I verified empirically that it returns 200 correctly (the service already `refresh`es `membership.route`), so there's **no bug there** — that one becomes test-only coverage in the separate test-backfill PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)