### PR TITLE
Native frontend dev workflow for Windows; drop CHOKIDAR_USEPOLLING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,8 +106,7 @@ this is, but running locally is a good temporary fix.
 
 1. Install Node 24+ and pnpm 11+ on Windows (e.g. via [nvm-windows](https://github.com/coreybutler/nvm-windows) and `npm install -g pnpm`).
 2. From `frontend/`: `pnpm install`.
-
-No `.env` is required for native dev — the only frontend env var, `VITE_API_BASE_URL`, defaults to `http://localhost:8080` in code (`src/lib/axiosClient.ts`). Only create `frontend/.env` if you need to override that.
+3. From `frontend/`: `cp .env.example .env` (same `frontend/.env` Docker mounts via `env_file`). The default `VITE_API_BASE_URL=http://localhost:8080` points at the backend container's exposed port; override it if your backend runs elsewhere.
 
 ### Daily workflow
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,6 +70,14 @@ docker-compose exec frontend pnpm lint:fix
 docker-compose exec frontend pnpm format
 ```
 
+> If you run the frontend natively on Windows (see [Running the frontend on Windows](#running-the-frontend-on-windows)), the `frontend` container won't be running — run these directly from `frontend/` instead:
+>
+> ```bash
+> pnpm lint
+> pnpm lint:fix
+> pnpm format
+> ```
+
 Config: `frontend/eslint.config.js`, `frontend/.prettierrc`, `frontend/tsconfig.json`
 
 ### Package Manager
@@ -98,12 +106,13 @@ this is, but running locally is a good temporary fix.
 
 1. Install Node 24+ and pnpm 11+ on Windows (e.g. via [nvm-windows](https://github.com/coreybutler/nvm-windows) and `npm install -g pnpm`).
 2. From `frontend/`: `pnpm install`.
+3. Make sure `frontend/.env` exists (Docker mounts this same file via `env_file`). Copy it from `frontend/.env.example` if you don't have one yet: `cp .env.example .env`.
 
 ### Daily workflow
 
 ```bash
-# Terminal 1 — backend + db only (frontend service is fine to leave running in Docker, just won't be used)
-docker compose up backend db
+# Terminal 1 — backend + db only (stop or don't start the Docker frontend; it would conflict on port 3000)
+docker-compose up backend db
 
 # Terminal 2 — frontend on the host
 cd frontend

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,10 +88,11 @@ Always commit `pnpm-lock.yaml`.
 ## Running the frontend on Windows
 
 If you're on Windows, you'll get a much faster dev loop by running the frontend
-**natively** (outside Docker) while keeping the backend and database in Docker.
+**natively** (outside Docker) using `pnpm dev`, while keeping the backend and database in Docker.
 The Docker bind-mount path on Windows (host NTFS ↔ Linux container) makes Vite's
 cold start very slow — we measured ~80–180 s for a single cold page load in the
-container, vs **~9 s natively** on the same machine.
+container, vs **~9 s natively** on the same machine. We aren't entirely sure why
+this is, but running locally is a good temporary fix.
 
 ### Setup (one time)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,6 +85,41 @@ pnpm remove <pkg>     # remove package
 
 Always commit `pnpm-lock.yaml`.
 
+## Running the frontend on Windows
+
+If you're on Windows, you'll get a much faster dev loop by running the frontend
+**natively** (outside Docker) while keeping the backend and database in Docker.
+The Docker bind-mount path on Windows (host NTFS ↔ Linux container) makes Vite's
+cold start very slow — we measured ~80–180 s for a single cold page load in the
+container, vs **~9 s natively** on the same machine.
+
+### Setup (one time)
+
+1. Install Node 24+ and pnpm 11+ on Windows (e.g. via [nvm-windows](https://github.com/coreybutler/nvm-windows) and `npm install -g pnpm`).
+2. From `frontend/`: `pnpm install`.
+
+### Daily workflow
+
+```bash
+# Terminal 1 — backend + db only (frontend service is fine to leave running in Docker, just won't be used)
+docker compose up backend db
+
+# Terminal 2 — frontend on the host
+cd frontend
+pnpm dev
+```
+
+Open http://localhost:3000 as usual. The axios client defaults to
+`http://localhost:8080` for the API, so it talks directly to the backend
+container's exposed port (override with `VITE_API_BASE_URL` if needed).
+
+### Why not just use Docker?
+
+It works, it's just slow on Windows. macOS and Linux users don't see the
+problem because their Docker filesystem bridge is fast. Long-term we may move
+the repo into the WSL2 filesystem (`\\wsl$\Ubuntu\...`) to fix this for
+everyone; in the meantime, running the frontend natively is the cheapest fix.
+
 ## Testing
 
 ### Backend

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,7 +106,8 @@ this is, but running locally is a good temporary fix.
 
 1. Install Node 24+ and pnpm 11+ on Windows (e.g. via [nvm-windows](https://github.com/coreybutler/nvm-windows) and `npm install -g pnpm`).
 2. From `frontend/`: `pnpm install`.
-3. Make sure `frontend/.env` exists (Docker mounts this same file via `env_file`). Copy it from `frontend/.env.example` if you don't have one yet: `cp .env.example .env`.
+
+No `.env` is required for native dev — the only frontend env var, `VITE_API_BASE_URL`, defaults to `http://localhost:8080` in code (`src/lib/axiosClient.ts`). Only create `frontend/.env` if you need to override that.
 
 ### Daily workflow
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,13 +114,6 @@ Open http://localhost:3000 as usual. The axios client defaults to
 `http://localhost:8080` for the API, so it talks directly to the backend
 container's exposed port (override with `VITE_API_BASE_URL` if needed).
 
-### Why not just use Docker?
-
-It works, it's just slow on Windows. macOS and Linux users don't see the
-problem because their Docker filesystem bridge is fast. Long-term we may move
-the repo into the WSL2 filesystem (`\\wsl$\Ubuntu\...`) to fix this for
-everyone; in the meantime, running the frontend natively is the cheapest fix.
-
 ## Testing
 
 ### Backend

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ cd food4kids
 
 You need two env files: `.env` (backend) and `frontend/.env` (frontend). Never commit these files.
 
-The backend `.env` is stored in Google Secret Manager and pulled via a script. The frontend `.env` must be obtained from the PL (a `frontend/.env.example` template is provided). Currently there are no env variables for the frontend, but may be subject to change.
+The backend `.env` is stored in Google Secret Manager and pulled via a script. For the frontend, copy the `frontend/.env.example` template to `frontend/.env`. It currently holds a single variable, `VITE_API_BASE_URL` (the backend API URL, defaulting to `http://localhost:8080`).
 
 #### Pull backend `.env` via Google Secret Manager
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,8 +9,6 @@ services:
       - frontend_node_modules:/app/node_modules
     ports:
       - 3000:3000
-    environment:
-      - CHOKIDAR_USEPOLLING=true
     env_file:
       - ./frontend/.env
   backend:

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,3 @@
+# Base URL of the backend API. Defaults to http://localhost:8080 in code
+# (src/lib/axiosClient.ts) if unset; set it here to override.
+VITE_API_BASE_URL=http://localhost:8080


### PR DESCRIPTION
## Summary

- Document running the frontend natively on Windows as a workaround for the slow Docker bind-mount path
- Drop `CHOKIDAR_USEPOLLING=true` from `docker-compose.yml` — it was burning ~47% of a core continuously at idle for no benefit on Vite 7

## Why

Several of us have hit very slow frontend cold loads in Docker on Windows — minutes-long white screens that don't reproduce on macOS. Tried isolating it across:

| | cold `main.tsx` |
|---|---|
| Docker, HEAD, pnpm 9 (current) | ~80 s |
| Docker, HEAD, pnpm 11 | >60 s, wedged |
| Docker, commit from 5 weeks ago (`90c04d2`) | **179–184 s** |
| Docker, HEAD, with optimizeDeps + polling off | ~80 s first time, then warm-cached |
| **Native (no Docker), HEAD, pnpm 11** | **~9 s** |

A code-side regression doesn't fit — the 5-week-old commit is actually *slower* than HEAD. Pnpm version doesn't matter (tried 9 and 11). A Docker Desktop restart didn't help. The constant is the Windows bind-mount IO path, and the same code runs ~9× faster the moment you take Vite out of that path.

So the practical answer for now is: Windows devs run the frontend natively, keep the backend + db in Docker. Documenting that. Long-term fix (move repo into WSL2 filesystem) is mentioned but not blocking.

## Changes

- **`docker-compose.yml`**: remove `CHOKIDAR_USEPOLLING=true` from the frontend service. Measured idle CPU drop from ~47% → ~0.1%. Vite 7 doesn't need polling — chokidar's native fs events work fine.
- **`CONTRIBUTING.md`**: new section "Running the frontend on Windows" with the one-time setup, daily workflow, and a brief explanation.

## Notes for review

- @ludavidca — adding you because you ran into this earlier and tried `optimizeDeps.include` + lazy loading in #(your reverted PR). Worth knowing: removing polling alone didn't fix cold load in my testing (~80s either way), and `optimizeDeps.include` *with polling still on* actually wedged Vite (>240 s). So a future "fix it in Docker" attempt should drop polling first, then layer optimizeDeps. That said, this PR doesn't ship optimizeDeps because native dev is a much bigger win and avoids the trap.
- This change does not affect macOS / Linux dev workflows.

## Test plan

- [ ] On Windows: pull, `docker compose up backend db`, then in `frontend/` run `pnpm install && pnpm dev`. Confirm the page loads at http://localhost:3000 and API calls succeed against the backend container.
- [ ] On Windows: run `docker compose up` (full stack) and confirm the frontend container starts without `CHOKIDAR_USEPOLLING` and the page still renders (just slowly, as today).
- [ ] On macOS: `docker compose up` and confirm nothing regressed.