### PR TITLE
OpenAPI sync: fix Docker-only pre-commit hook + auto-commit drift fixes from CI

### DIFF
--- a/.github/workflows/openapi-sync.yml
+++ b/.github/workflows/openapi-sync.yml
@@ -93,29 +93,24 @@ jobs:
         working-directory: ./frontend
         run: pnpm install --frozen-lockfile
 
-      # Dump the schema by introspecting the app (no server, no DB) and
-      # re-normalize it through the same script `pnpm generate:api` uses, so
-      # the comparison is byte-for-byte.
-      - name: Regenerate openapi.json from the backend
+      # Regenerate the full client — openapi.json AND the generated TS — using
+      # the same no-server script the pre-commit hook runs, so CI and local
+      # produce byte-identical output. In CI it resolves to the system python3
+      # (backend deps installed above); no venv or container is needed.
+      - name: Regenerate the OpenAPI client (schema + TS)
         if: steps.changes.outputs.contract == 'true'
         env:
-          PYTHONPATH: ${{ github.workspace }}/backend/python
-          APP_ENV: testing
           GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}
-        run: |
-          python backend/python/scripts/dump_openapi_schema.py /tmp/openapi-raw.json
-          cd frontend
-          OPENAPI_FILE=/tmp/openapi-raw.json node scripts/fetch-openapi.mjs
+        run: ./scripts/regen-openapi.sh
 
-      # If the regen changed openapi.json, auto-commit it back to the PR branch.
-      # The fetch-openapi.mjs normalization makes the dump byte-deterministic, so
+      # If the regen changed anything, auto-commit it back to the PR branch. We
+      # sync BOTH frontend/openapi.json and the generated TS client, so a PR
+      # whose author skipped the hook still lands a fully-synced contract. The
+      # regen is byte-deterministic (pinned openapi-ts + normalized schema), so
       # the push re-triggers this workflow, the second run finds nothing to
-      # change, and it terminates — no commit ping-pong.
-      #
-      # Note: only openapi.json is synced here (it's all CI verifies). The
-      # generated TS client stays the pre-commit hook's job, to keep derived-code
-      # formatter/version skew out of CI.
-      - name: Sync openapi.json
+      # change, and it terminates — no commit ping-pong. We commit with
+      # --no-verify so the pre-commit hook doesn't re-run the whole regen here.
+      - name: Sync OpenAPI client
         if: steps.changes.outputs.contract == 'true'
         env:
           # True only when the App token was minted (same-repo PR) — i.e. when
@@ -123,28 +118,28 @@ jobs:
           CAN_PUSH: ${{ steps.app-token.outputs.token != '' }}
           HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
-          if git diff --quiet -- frontend/openapi.json; then
-            echo "✔ frontend/openapi.json is in sync with the backend schema."
+          if git diff --quiet -- frontend/openapi.json frontend/src/api/generated; then
+            echo "✔ OpenAPI client is in sync with the backend schema."
             exit 0
           fi
 
-          echo "frontend/openapi.json is out of sync with the backend schema."
+          echo "OpenAPI client is out of sync with the backend schema."
 
           if [ "$CAN_PUSH" = "true" ]; then
             # Loop-breaker: if the branch tip is already a bot sync commit and
-            # openapi.json STILL doesn't match, the regen isn't deterministic —
+            # the client STILL doesn't match, the regen isn't deterministic —
             # pushing again would loop forever. Fail loudly instead.
             if [ "$(git log -1 --format='%an')" = "f4k-openapi-sync[bot]" ]; then
-              echo "::error::openapi.json is still out of sync right after a bot sync commit — the regen looks non-deterministic. Refusing to push again (would loop). Investigate dump_openapi_schema.py / fetch-openapi.mjs."
-              git diff -- frontend/openapi.json
+              echo "::error::OpenAPI client is still out of sync right after a bot sync commit — the regen looks non-deterministic. Refusing to push again (would loop). Investigate scripts/regen-openapi.sh."
+              git diff -- frontend/openapi.json frontend/src/api/generated
               exit 1
             fi
 
             echo "→ Committing the regenerated client back to '$HEAD_REF'…"
             git config user.name "f4k-openapi-sync[bot]"
             git config user.email "f4k-openapi-sync[bot]@users.noreply.github.com"
-            git add frontend/openapi.json
-            git commit -m "chore: sync frontend/openapi.json with backend schema"
+            git add frontend/openapi.json frontend/src/api/generated
+            git commit --no-verify -m "chore: sync OpenAPI client with backend schema"
             git push origin "HEAD:$HEAD_REF"
             echo "✔ Pushed. The updated PR will re-run checks against the synced client."
             exit 0
@@ -153,14 +148,11 @@ jobs:
           # Fork PR or push to main: we can't push a fix, so fail with a
           # ready-to-apply patch (the manual fallback, also used when the hook
           # wasn't installed).
-          echo "::error::frontend/openapi.json is out of sync and this run can't auto-fix it (fork PR or push to main)."
+          echo "::error::OpenAPI client is out of sync and this run can't auto-fix it (fork PR or push to main)."
           echo "Copy the whole block below — from the 'git apply' line through the"
           echo "closing 'PATCH' — and paste it into your shell at the repo root:"
           echo ""
           echo "git apply <<'PATCH'"
-          git diff -- frontend/openapi.json
+          git diff -- frontend/openapi.json frontend/src/api/generated
           echo "PATCH"
-          echo ""
-          echo "Then run 'pnpm openapi-ts' in frontend/ and commit. (No backend needed —"
-          echo "openapi-ts reads the local openapi.json.)"
           exit 1

--- a/.github/workflows/openapi-sync.yml
+++ b/.github/workflows/openapi-sync.yml
@@ -8,13 +8,43 @@ on:
     branches:
       - main
 
+# The job pushes back to PR branches using a token minted from the
+# f4k-openapi-sync GitHub App (below), not GITHUB_TOKEN — so the default token
+# only needs read access here.
+permissions:
+  contents: read
+
 jobs:
   openapi-sync:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
+      # Mint a short-lived token from the f4k-openapi-sync GitHub App so we can
+      # commit the regenerated client straight back to the PR branch. We use the
+      # App (not GITHUB_TOKEN) on purpose: a GITHUB_TOKEN push does NOT trigger
+      # other workflows, so lint/pytest wouldn't re-run on the fix. An App push
+      # does, so the corrected commit gets fully checked.
+      #
+      # Gated to same-repo PRs: fork PRs don't receive secrets, so the token
+      # can't be minted there and we fall back to verify-only (see the final
+      # step). On push-to-main this step is skipped too.
+      - name: Generate GitHub App token
+        id: app-token
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          # On a same-repo PR, check out the PR branch tip with the App token so
+          # we can commit & push back. Otherwise (push to main, fork PR) the
+          # token output is empty and we get the usual read-only checkout of the
+          # event ref.
+          token: ${{ steps.app-token.outputs.token || github.token }}
+          ref: ${{ github.event.pull_request.head.ref || github.ref }}
 
       # Only do work when something that could change the contract changed.
       # The job still runs (and reports success) otherwise, so it can be a
@@ -77,21 +107,60 @@ jobs:
           cd frontend
           OPENAPI_FILE=/tmp/openapi-raw.json node scripts/fetch-openapi.mjs
 
-      - name: Fail if openapi.json is out of date
+      # If the regen changed openapi.json, auto-commit it back to the PR branch.
+      # The fetch-openapi.mjs normalization makes the dump byte-deterministic, so
+      # the push re-triggers this workflow, the second run finds nothing to
+      # change, and it terminates — no commit ping-pong.
+      #
+      # Note: only openapi.json is synced here (it's all CI verifies). The
+      # generated TS client stays the pre-commit hook's job, to keep derived-code
+      # formatter/version skew out of CI.
+      - name: Sync openapi.json
         if: steps.changes.outputs.contract == 'true'
+        env:
+          # True only when the App token was minted (same-repo PR) — i.e. when
+          # we're actually able to push a fix back.
+          CAN_PUSH: ${{ steps.app-token.outputs.token != '' }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
-          if ! git diff --exit-code frontend/openapi.json; then
-            echo "::error::frontend/openapi.json is out of sync with the backend schema."
-            echo "Normally the pre-commit hook keeps this in sync (see scripts/regen-openapi.sh)."
-            echo "To fix without a running backend, copy the whole block below — from the"
-            echo "'git apply' line through the closing 'PATCH' — and paste it into your shell"
-            echo "at the repo root:"
-            echo ""
-            echo "git apply <<'PATCH'"
-            git diff frontend/openapi.json
-            echo "PATCH"
-            echo ""
-            echo "Then run 'pnpm openapi-ts' in frontend/ and commit. (No backend needed —"
-            echo "openapi-ts reads the local openapi.json.)"
-            exit 1
+          if git diff --quiet -- frontend/openapi.json; then
+            echo "✔ frontend/openapi.json is in sync with the backend schema."
+            exit 0
           fi
+
+          echo "frontend/openapi.json is out of sync with the backend schema."
+
+          if [ "$CAN_PUSH" = "true" ]; then
+            # Loop-breaker: if the branch tip is already a bot sync commit and
+            # openapi.json STILL doesn't match, the regen isn't deterministic —
+            # pushing again would loop forever. Fail loudly instead.
+            if [ "$(git log -1 --format='%an')" = "f4k-openapi-sync[bot]" ]; then
+              echo "::error::openapi.json is still out of sync right after a bot sync commit — the regen looks non-deterministic. Refusing to push again (would loop). Investigate dump_openapi_schema.py / fetch-openapi.mjs."
+              git diff -- frontend/openapi.json
+              exit 1
+            fi
+
+            echo "→ Committing the regenerated client back to '$HEAD_REF'…"
+            git config user.name "f4k-openapi-sync[bot]"
+            git config user.email "f4k-openapi-sync[bot]@users.noreply.github.com"
+            git add frontend/openapi.json
+            git commit -m "chore: sync frontend/openapi.json with backend schema"
+            git push origin "HEAD:$HEAD_REF"
+            echo "✔ Pushed. The updated PR will re-run checks against the synced client."
+            exit 0
+          fi
+
+          # Fork PR or push to main: we can't push a fix, so fail with a
+          # ready-to-apply patch (the manual fallback, also used when the hook
+          # wasn't installed).
+          echo "::error::frontend/openapi.json is out of sync and this run can't auto-fix it (fork PR or push to main)."
+          echo "Copy the whole block below — from the 'git apply' line through the"
+          echo "closing 'PATCH' — and paste it into your shell at the repo root:"
+          echo ""
+          echo "git apply <<'PATCH'"
+          git diff -- frontend/openapi.json
+          echo "PATCH"
+          echo ""
+          echo "Then run 'pnpm openapi-ts' in frontend/ and commit. (No backend needed —"
+          echo "openapi-ts reads the local openapi.json.)"
+          exit 1

--- a/README.md
+++ b/README.md
@@ -98,7 +98,9 @@ The repo ships a pre-commit hook that keeps the frontend OpenAPI client in sync 
 git config core.hooksPath scripts/git-hooks
 ```
 
-See [frontend/README.md](frontend/README.md#api-client-generated-from-openapi) for details. CI verifies the contract regardless, as a backstop.
+To regenerate the client it needs the backend's Python deps. It finds them, in order: a host `backend/python/venv`, then a **running `f4k_backend` container** (Docker-only devs need the backend up — `docker compose up backend`), then a system `python3` that can import the deps. If none are available it **warns and skips** rather than blocking the commit — CI verifies `openapi.json` as a backstop, so drift can't merge. You can also force-skip with `SKIP_OPENAPI_REGEN=1 git commit …`.
+
+See [frontend/README.md](frontend/README.md#api-client-generated-from-openapi) for details.
 
 ### Run
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ The repo ships a pre-commit hook that keeps the frontend OpenAPI client in sync 
 git config core.hooksPath scripts/git-hooks
 ```
 
-To regenerate the client it needs the backend's Python deps. It finds them, in order: a host `backend/python/venv`, then a **running `f4k_backend` container** (Docker-only devs need the backend up — `docker compose up backend`), then a system `python3` that can import the deps. If none are available it **warns and skips** rather than blocking the commit — on pull requests, CI regenerates `openapi.json` and **commits the fix back to your branch automatically** (via the `f4k-openapi-sync` GitHub App), so drift can't merge even if the hook never ran. You can also force-skip the hook with `SKIP_OPENAPI_REGEN=1 git commit …`.
+To regenerate the client it needs the backend's Python deps. It finds them, in order: a host `backend/python/venv`, then a **running `f4k_backend` container** (Docker-only devs need the backend up — `docker compose up backend`), then a system `python3` that can import the deps. If none are available it **warns and skips** rather than blocking the commit — on pull requests, CI regenerates the client (`openapi.json` **and** the generated TS) and **commits the fix back to your branch automatically** (via the `f4k-openapi-sync` GitHub App), so drift can't merge even if the hook never ran. You can also force-skip the hook with `SKIP_OPENAPI_REGEN=1 git commit …`.
 
 See [frontend/README.md](frontend/README.md#api-client-generated-from-openapi) for details.
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ The repo ships a pre-commit hook that keeps the frontend OpenAPI client in sync 
 git config core.hooksPath scripts/git-hooks
 ```
 
-To regenerate the client it needs the backend's Python deps. It finds them, in order: a host `backend/python/venv`, then a **running `f4k_backend` container** (Docker-only devs need the backend up — `docker compose up backend`), then a system `python3` that can import the deps. If none are available it **warns and skips** rather than blocking the commit — CI verifies `openapi.json` as a backstop, so drift can't merge. You can also force-skip with `SKIP_OPENAPI_REGEN=1 git commit …`.
+To regenerate the client it needs the backend's Python deps. It finds them, in order: a host `backend/python/venv`, then a **running `f4k_backend` container** (Docker-only devs need the backend up — `docker compose up backend`), then a system `python3` that can import the deps. If none are available it **warns and skips** rather than blocking the commit — on pull requests, CI regenerates `openapi.json` and **commits the fix back to your branch automatically** (via the `f4k-openapi-sync` GitHub App), so drift can't merge even if the hook never ran. You can also force-skip the hook with `SKIP_OPENAPI_REGEN=1 git commit …`.
 
 See [frontend/README.md](frontend/README.md#api-client-generated-from-openapi) for details.
 

--- a/scripts/regen-openapi.sh
+++ b/scripts/regen-openapi.sh
@@ -13,31 +13,62 @@
 # Used by the pre-commit hook and runnable by hand:  ./scripts/regen-openapi.sh
 set -euo pipefail
 
+# Explicit escape hatch: skip the whole regen (e.g. mid-rebase, or when you know
+# the contract is unchanged). CI verifies openapi.json, so this can't merge drift.
+if [[ "${SKIP_OPENAPI_REGEN:-}" == "1" ]]; then
+  echo "openapi: SKIP_OPENAPI_REGEN=1 set — skipping client regen." >&2
+  exit 0
+fi
+
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd "$REPO_ROOT"
-
-# --- locate the backend Python interpreter (absolute path) -------------------
-if [[ -x "$REPO_ROOT/backend/python/venv/bin/python" ]]; then
-  PYTHON="$REPO_ROOT/backend/python/venv/bin/python"
-elif command -v python3 >/dev/null 2>&1; then
-  PYTHON="$(command -v python3)"
-  echo "⚠ backend/python/venv not found — falling back to system python3." >&2
-  echo "  The dump will fail unless the backend deps (FastAPI, Pydantic, …) are installed there." >&2
-else
-  echo "✘ No Python interpreter found (looked for backend/python/venv/bin/python and python3)." >&2
-  exit 1
-fi
 
 RAW_SCHEMA="$(mktemp -t openapi-raw.XXXXXX.json)"
 trap 'rm -f "$RAW_SCHEMA"' EXIT
 
+DUMP_SCRIPT="scripts/dump_openapi_schema.py"
+BACKEND_CONTAINER="${OPENAPI_BACKEND_CONTAINER:-f4k_backend}"
+
 # --- stage 1: dump the schema from the app (no server, no DB) -----------------
-# Run from backend/python so Settings' env_file=".env" resolves to the backend's
-# own config, not an unrelated root .env (which carries keys Settings rejects).
-echo "→ Dumping OpenAPI schema from the backend app…"
-( cd "$REPO_ROOT/backend/python" \
-  && APP_ENV=testing PYTHONPATH="$REPO_ROOT/backend/python" \
-     "$PYTHON" scripts/dump_openapi_schema.py "$RAW_SCHEMA" )
+# Stage 1 needs a Python env with the backend deps installed. Try, in order:
+#   1. host venv  — for devs running the backend toolchain directly
+#   2. running backend container — for Docker-only devs (no venv on the host)
+#   3. system python3, but only if it can actually import the backend deps
+# If none apply (e.g. a Docker dev whose container isn't up), warn and skip the
+# regen entirely — CI verifies openapi.json as the backstop, so a skipped local
+# regen can never let contract drift merge. Whichever tier IS selected is
+# fail-fast: a dump error there is a real problem and aborts the commit.
+#
+# We run from backend/python so Settings' env_file=".env" resolves to the
+# backend's own config, not an unrelated root .env (which carries keys Settings
+# rejects). Inside the container WORKDIR is already /app (== backend/python).
+if [[ -x "$REPO_ROOT/backend/python/venv/bin/python" ]]; then
+  echo "→ Dumping OpenAPI schema via host venv…"
+  ( cd "$REPO_ROOT/backend/python" \
+    && APP_ENV=testing PYTHONPATH="$REPO_ROOT/backend/python" \
+       "$REPO_ROOT/backend/python/venv/bin/python" "$DUMP_SCRIPT" "$RAW_SCHEMA" )
+
+elif command -v docker >/dev/null 2>&1 \
+     && docker ps --format '{{.Names}}' 2>/dev/null | grep -qx "$BACKEND_CONTAINER"; then
+  echo "→ Dumping OpenAPI schema via running '$BACKEND_CONTAINER' container…"
+  # The dump script writes to stdout when given no path; capture it on the host.
+  docker exec -e APP_ENV=testing -e PYTHONPATH=/app "$BACKEND_CONTAINER" \
+    python "$DUMP_SCRIPT" >"$RAW_SCHEMA"
+
+elif command -v python3 >/dev/null 2>&1 && python3 -c 'import fastapi' >/dev/null 2>&1; then
+  echo "⚠ No venv and no running '$BACKEND_CONTAINER' container — using system python3." >&2
+  ( cd "$REPO_ROOT/backend/python" \
+    && APP_ENV=testing PYTHONPATH="$REPO_ROOT/backend/python" \
+       python3 "$DUMP_SCRIPT" "$RAW_SCHEMA" )
+
+else
+  echo "openapi: no backend Python env available — skipping client regen." >&2
+  echo "  Looked for: host venv, a running '$BACKEND_CONTAINER' container, or a" >&2
+  echo "  system python3 with the backend deps. CI will verify openapi.json." >&2
+  echo "  To regen locally, start the backend (docker compose up backend) and" >&2
+  echo "  re-commit, or run ./scripts/regen-openapi.sh once it's up." >&2
+  exit 0
+fi
 
 # --- stages 2-3: normalize into openapi.json and generate the TS client -------
 cd frontend


### PR DESCRIPTION
Two related improvements to the OpenAPI client auto-sync from #141.

## 1. Pre-commit hook works for Docker-only devs (`scripts/regen-openapi.sh`)

The hook regenerated the client by introspecting the FastAPI app, needing Python **with the backend deps**. Its lookup was venv → system `python3`. A Docker-only dev has no venv, and their system `python3` lacks the deps — so the dump raised an import error and `set -e` blocked every backend commit.

Stage 1 now selects a runner across three fail-fast tiers:
1. **host venv** (unchanged primary)
2. **running `f4k_backend` container** — `docker exec`, dump to stdout, capture on host ← new
3. **system `python3`** — only if it can actually `import fastapi` (probed), so a deps-free python3 isn't falsely chosen

When none apply (Docker dev, container down) it **warns and skips** (`exit 0`) rather than blocking the commit. Adds a `SKIP_OPENAPI_REGEN=1` escape hatch and an `OPENAPI_BACKEND_CONTAINER` override.

## 2. CI auto-commits the fix on PRs (`.github/workflows/openapi-sync.yml`)

CI already regenerated the client to verify it — it just failed and printed a `git apply` patch on drift. Now, on **same-repo PRs**, it regenerates and commits the fix straight back to the PR branch, so the contract self-heals even if the hook never ran.

- Regenerates via the shared `scripts/regen-openapi.sh` (same no-server pipeline as the hook) and commits **both** `frontend/openapi.json` **and** the generated TS client (`frontend/src/api/generated`) — so a PR that skipped the hook still lands a fully-synced client (schema + types), not just openapi.json. Commit is `--no-verify` so the hook doesn't re-run the regen.
- Mints a short-lived token from the **`f4k-openapi-sync` GitHub App** (App ID + private key in repo secrets) and pushes with it. Using the App instead of `GITHUB_TOKEN` is deliberate: an App push **re-triggers lint/pytest** on the fix; a `GITHUB_TOKEN` push would not.
- **Fork PRs** (no secrets) and **push-to-main** keep the previous verify-and-fail-with-patch behavior.
- **Loop safety:** the regen is byte-deterministic (pinned toolchain), so the re-triggered run finds nothing to change and stops. Hard backstop: if the branch tip is already a bot sync commit and the client *still* differs, it refuses to push again and fails loudly (signals a non-deterministic regen).

### Setup done
- GitHub App `f4k-openapi-sync` created (Contents + Pull requests: read/write), installed on `food4kids` only.
- Repo secrets `APP_ID` and `APP_PRIVATE_KEY` added.

## Test plan — validated end-to-end
Ran a throwaway PR that changed the backend contract and committed with `--no-verify` (stale client):
- [x] CI regenerated and pushed a `chore: sync OpenAPI client` commit updating **both** `openapi.json` and all generated TS files.
- [x] The App push **re-triggered Lint + Pytest** on the bot commit.
- [x] The re-triggered openapi-sync run was a **no-op** ("in sync") and pushed nothing — no loop.
- [x] Docker-only hook tiers covered by the regen-openapi.sh changes (host venv / container / skip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)