### PR TITLE
Merge alembic heads + add backend boot smoke CI check

### DIFF
--- a/.github/workflows/boot-smoke.yml
+++ b/.github/workflows/boot-smoke.yml
@@ -79,6 +79,7 @@ jobs:
           FIREBASE_SVC_ACCOUNT_CLIENT_ID: ${{ secrets.FIREBASE_SVC_ACCOUNT_CLIENT_ID }}
           FIREBASE_SVC_ACCOUNT_CLIENT_X509_CERT_URL: ${{ secrets.FIREBASE_SVC_ACCOUNT_CLIENT_X509_CERT_URL }}
           FIREBASE_WEB_API_KEY: ${{ secrets.FIREBASE_WEB_API_KEY }}
+          GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}
         run: |
           if [ -n "$FIREBASE_PROJECT_ID" ]; then
             echo "Real Firebase credentials available — authed API smoke enabled."
@@ -114,6 +115,7 @@ jobs:
             -e FIREBASE_SVC_ACCOUNT_AUTH_PROVIDER_X509_CERT_URL=https://www.googleapis.com/oauth2/v1/certs \
             -e FIREBASE_SVC_ACCOUNT_CLIENT_X509_CERT_URL \
             -e FIREBASE_WEB_API_KEY \
+            -e GOOGLE_MAPS_API_KEY \
             f4k-backend:ci
 
       - name: Wait for healthy server

--- a/.github/workflows/boot-smoke.yml
+++ b/.github/workflows/boot-smoke.yml
@@ -101,7 +101,9 @@ jobs:
               docker logs f4k_backend_smoke
               exit 1
             fi
-            if curl -fsS -o /dev/null http://localhost:8080/docs; then
+            # /openapi.json forces FastAPI to build the full schema for every
+            # route, so this also catches bad response-model definitions.
+            if curl -fsS -o /dev/null http://localhost:8080/openapi.json; then
               echo "Backend booted: migrations applied and server responding."
               exit 0
             fi
@@ -110,3 +112,12 @@ jobs:
           echo "::error::Backend did not become healthy within 90s"
           docker logs f4k_backend_smoke
           exit 1
+
+      # `alembic check` runs autogenerate against the freshly migrated DB and
+      # fails if the models expect a different schema than the migration chain
+      # produces. Unit tests can't catch this: pytest builds its schema from
+      # the models directly (create_all), so a model edited without a matching
+      # migration passes tests but breaks in compose/deploys.
+      - name: Check model/migration schema drift
+        if: steps.changes.outputs.python-backend == 'true'
+        run: docker exec f4k_backend_smoke alembic check

--- a/.github/workflows/boot-smoke.yml
+++ b/.github/workflows/boot-smoke.yml
@@ -71,10 +71,31 @@ jobs:
 
       - name: Boot backend (runs migrations, then the server)
         if: steps.changes.outputs.python-backend == 'true'
+        env:
+          FIREBASE_PROJECT_ID: ${{ secrets.FIREBASE_PROJECT_ID }}
+          FIREBASE_SVC_ACCOUNT_PRIVATE_KEY_ID: ${{ secrets.FIREBASE_SVC_ACCOUNT_PRIVATE_KEY_ID }}
+          FIREBASE_SVC_ACCOUNT_PRIVATE_KEY: ${{ secrets.FIREBASE_SVC_ACCOUNT_PRIVATE_KEY }}
+          FIREBASE_SVC_ACCOUNT_CLIENT_EMAIL: ${{ secrets.FIREBASE_SVC_ACCOUNT_CLIENT_EMAIL }}
+          FIREBASE_SVC_ACCOUNT_CLIENT_ID: ${{ secrets.FIREBASE_SVC_ACCOUNT_CLIENT_ID }}
+          FIREBASE_SVC_ACCOUNT_CLIENT_X509_CERT_URL: ${{ secrets.FIREBASE_SVC_ACCOUNT_CLIENT_X509_CERT_URL }}
+          FIREBASE_WEB_API_KEY: ${{ secrets.FIREBASE_WEB_API_KEY }}
         run: |
-          # Firebase Admin parses the service-account key at startup, so it
-          # needs a syntactically valid (but throwaway) RSA key.
-          DUMMY_KEY=$(openssl genrsa 2048 2>/dev/null)
+          if [ -n "$FIREBASE_PROJECT_ID" ]; then
+            echo "Real Firebase credentials available — authed API smoke enabled."
+            echo "AUTH_SMOKE=true" >> "$GITHUB_ENV"
+          else
+            # Forks and dependabot PRs can't read repo secrets. Firebase Admin
+            # parses the service-account key at startup, so boot with a
+            # syntactically valid throwaway key and skip the authed smoke.
+            echo "::warning::Firebase secrets unavailable — booting with a dummy key; seed + authed API smoke SKIPPED."
+            echo "AUTH_SMOKE=false" >> "$GITHUB_ENV"
+            export FIREBASE_PROJECT_ID=ci-dummy
+            export FIREBASE_SVC_ACCOUNT_PRIVATE_KEY_ID=dummy
+            export FIREBASE_SVC_ACCOUNT_PRIVATE_KEY="$(openssl genrsa 2048 2>/dev/null)"
+            export FIREBASE_SVC_ACCOUNT_CLIENT_EMAIL=ci-dummy@ci-dummy.iam.gserviceaccount.com
+            export FIREBASE_SVC_ACCOUNT_CLIENT_ID=000000000000000000000
+            export FIREBASE_SVC_ACCOUNT_CLIENT_X509_CERT_URL=https://www.googleapis.com/robot/v1/metadata/x509/dummy
+          fi
 
           docker run -d --name f4k_backend_smoke --network host \
             -e APP_ENV=development \
@@ -83,15 +104,16 @@ jobs:
             -e POSTGRES_DB_DEV=f4k \
             -e POSTGRES_DB_TEST=f4k_test \
             -e DB_HOST=localhost \
-            -e FIREBASE_PROJECT_ID=ci-dummy \
-            -e FIREBASE_SVC_ACCOUNT_PRIVATE_KEY_ID=dummy \
-            -e FIREBASE_SVC_ACCOUNT_PRIVATE_KEY="$DUMMY_KEY" \
-            -e FIREBASE_SVC_ACCOUNT_CLIENT_EMAIL=ci-dummy@ci-dummy.iam.gserviceaccount.com \
-            -e FIREBASE_SVC_ACCOUNT_CLIENT_ID=000000000000000000000 \
+            -e FIREBASE_PROJECT_ID \
+            -e FIREBASE_SVC_ACCOUNT_PRIVATE_KEY_ID \
+            -e FIREBASE_SVC_ACCOUNT_PRIVATE_KEY \
+            -e FIREBASE_SVC_ACCOUNT_CLIENT_EMAIL \
+            -e FIREBASE_SVC_ACCOUNT_CLIENT_ID \
             -e FIREBASE_SVC_ACCOUNT_AUTH_URI=https://accounts.google.com/o/oauth2/auth \
             -e FIREBASE_SVC_ACCOUNT_TOKEN_URI=https://oauth2.googleapis.com/token \
             -e FIREBASE_SVC_ACCOUNT_AUTH_PROVIDER_X509_CERT_URL=https://www.googleapis.com/oauth2/v1/certs \
-            -e FIREBASE_SVC_ACCOUNT_CLIENT_X509_CERT_URL=https://www.googleapis.com/robot/v1/metadata/x509/dummy \
+            -e FIREBASE_SVC_ACCOUNT_CLIENT_X509_CERT_URL \
+            -e FIREBASE_WEB_API_KEY \
             f4k-backend:ci
 
       - name: Wait for healthy server
@@ -123,3 +145,48 @@ jobs:
       - name: Check model/migration schema drift
         if: steps.changes.outputs.python-backend == 'true'
         run: docker exec f4k_backend_smoke alembic check
+
+      # End-to-end authed smoke: seed the DB (creates sign-in-able Firebase
+      # users — admin1@f4k.dev etc., see app/seed_database.py), log in through
+      # the API, make an authenticated call, and read seeded data back. This
+      # exercises the full stack: Firebase REST sign-in, Admin SDK token
+      # verification, and DB queries against the real migrated schema (which
+      # pytest can't cover — it builds its schema from the models directly).
+      - name: Seed database
+        if: steps.changes.outputs.python-backend == 'true' && env.AUTH_SMOKE == 'true'
+        run: docker exec f4k_backend_smoke python -m app.seed_database
+
+      - name: Authed API smoke
+        if: steps.changes.outputs.python-backend == 'true' && env.AUTH_SMOKE == 'true'
+        run: |
+          RESP=$(curl -fsS -X POST http://localhost:8080/auth/login \
+            -H "Content-Type: application/json" \
+            -d '{"email":"admin1@f4k.dev","password":"test123"}')
+          TOKEN=$(jq -r .access_token <<<"$RESP")
+          USER_ID=$(jq -r .id <<<"$RESP")
+          if [ -z "$TOKEN" ] || [ "$TOKEN" = "null" ]; then
+            echo "::error::Login succeeded but returned no access_token"
+            exit 1
+          fi
+          echo "Login OK"
+
+          # Authenticated call — round-trips Admin SDK verify_id_token
+          CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
+            "http://localhost:8080/auth/logout/$USER_ID" \
+            -H "Authorization: Bearer $TOKEN")
+          if [ "$CODE" != "204" ]; then
+            echo "::error::Authed logout returned HTTP $CODE (expected 204)"
+            exit 1
+          fi
+          echo "Authed call OK"
+
+          TOTAL=$(curl -fsS http://localhost:8080/locations/ | jq .total)
+          if ! [ "$TOTAL" -gt 0 ] 2>/dev/null; then
+            echo "::error::Expected seeded locations, got total=$TOTAL"
+            exit 1
+          fi
+          echo "Seeded data readable ($TOTAL locations)"
+
+      - name: Dump backend logs on failure
+        if: failure() && steps.changes.outputs.python-backend == 'true'
+        run: docker logs f4k_backend_smoke 2>&1 | tail -100

--- a/.github/workflows/boot-smoke.yml
+++ b/.github/workflows/boot-smoke.yml
@@ -65,7 +65,9 @@ jobs:
           tags: f4k-backend:ci
           load: true
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # ignore-error: cache export to the GHA backend is flaky (layer blob
+          # not_found); a failed export should not fail the build it caches.
+          cache-to: type=gha,ignore-error=true
 
       - name: Boot backend (runs migrations, then the server)
         if: steps.changes.outputs.python-backend == 'true'

--- a/.github/workflows/boot-smoke.yml
+++ b/.github/workflows/boot-smoke.yml
@@ -152,9 +152,13 @@ jobs:
       # exercises the full stack: Firebase REST sign-in, Admin SDK token
       # verification, and DB queries against the real migrated schema (which
       # pytest can't cover — it builds its schema from the models directly).
+      # app/data/locations.csv (real location data) is gitignored and not in
+      # the image, so seed from the committed fake-data fixture CSV instead.
       - name: Seed database
         if: steps.changes.outputs.python-backend == 'true' && env.AUTH_SMOKE == 'true'
-        run: docker exec f4k_backend_smoke python -m app.seed_database
+        run: |
+          docker exec -e LOCATIONS_CSV_PATH=tests/data/test_locations.csv \
+            f4k_backend_smoke python -m app.seed_database
 
       - name: Authed API smoke
         if: steps.changes.outputs.python-backend == 'true' && env.AUTH_SMOKE == 'true'

--- a/.github/workflows/boot-smoke.yml
+++ b/.github/workflows/boot-smoke.yml
@@ -1,0 +1,112 @@
+name: Backend boot smoke
+
+# Builds the real backend Docker image and boots it against a fresh Postgres,
+# exactly like `docker compose up` / a deploy would: the entrypoint runs
+# `alembic upgrade head && python server.py`. This catches problems unit tests
+# can't see — broken or multi-headed migration graphs, startup crashes, missing
+# imports — before they land on main.
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+concurrency:
+  group: boot-smoke-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  boot:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    services:
+      postgres:
+        image: postgres:12-alpine
+        env:
+          POSTGRES_PASSWORD: password
+          POSTGRES_USER: postgres
+          POSTGRES_DB: f4k
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      # Same pattern as pytest.yml: run the job on every PR so a required
+      # check always reports a status, but only do the expensive work when
+      # backend code changed.
+      - name: Filter changed files
+        uses: dorny/paths-filter@v2
+        id: changes
+        with:
+          filters: |
+            python-backend:
+              - "backend/python/**"
+
+      - name: Set up Docker Buildx
+        if: steps.changes.outputs.python-backend == 'true'
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build backend image
+        if: steps.changes.outputs.python-backend == 'true'
+        uses: docker/build-push-action@v6
+        with:
+          context: backend/python
+          tags: f4k-backend:ci
+          load: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Boot backend (runs migrations, then the server)
+        if: steps.changes.outputs.python-backend == 'true'
+        run: |
+          # Firebase Admin parses the service-account key at startup, so it
+          # needs a syntactically valid (but throwaway) RSA key.
+          DUMMY_KEY=$(openssl genrsa 2048 2>/dev/null)
+
+          docker run -d --name f4k_backend_smoke --network host \
+            -e APP_ENV=development \
+            -e POSTGRES_USER=postgres \
+            -e POSTGRES_PASSWORD=password \
+            -e POSTGRES_DB_DEV=f4k \
+            -e POSTGRES_DB_TEST=f4k_test \
+            -e DB_HOST=localhost \
+            -e FIREBASE_PROJECT_ID=ci-dummy \
+            -e FIREBASE_SVC_ACCOUNT_PRIVATE_KEY_ID=dummy \
+            -e FIREBASE_SVC_ACCOUNT_PRIVATE_KEY="$DUMMY_KEY" \
+            -e FIREBASE_SVC_ACCOUNT_CLIENT_EMAIL=ci-dummy@ci-dummy.iam.gserviceaccount.com \
+            -e FIREBASE_SVC_ACCOUNT_CLIENT_ID=000000000000000000000 \
+            -e FIREBASE_SVC_ACCOUNT_AUTH_URI=https://accounts.google.com/o/oauth2/auth \
+            -e FIREBASE_SVC_ACCOUNT_TOKEN_URI=https://oauth2.googleapis.com/token \
+            -e FIREBASE_SVC_ACCOUNT_AUTH_PROVIDER_X509_CERT_URL=https://www.googleapis.com/oauth2/v1/certs \
+            -e FIREBASE_SVC_ACCOUNT_CLIENT_X509_CERT_URL=https://www.googleapis.com/robot/v1/metadata/x509/dummy \
+            f4k-backend:ci
+
+      - name: Wait for healthy server
+        if: steps.changes.outputs.python-backend == 'true'
+        run: |
+          for i in $(seq 1 45); do
+            if [ "$(docker inspect -f '{{.State.Running}}' f4k_backend_smoke)" != "true" ]; then
+              echo "::error::Backend container exited during boot (migrations or startup failed)"
+              docker logs f4k_backend_smoke
+              exit 1
+            fi
+            if curl -fsS -o /dev/null http://localhost:8080/docs; then
+              echo "Backend booted: migrations applied and server responding."
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "::error::Backend did not become healthy within 90s"
+          docker logs f4k_backend_smoke
+          exit 1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -54,10 +54,13 @@ jobs:
         working-directory: ./frontend
         run: pnpm format:check
 
-      - name: Type-check frontend
+      # `pnpm build` runs `tsc -b && vite build`, so this both type-checks and
+      # catches production-build-only failures (vite config, asset imports,
+      # build-time env usage) that tsc alone can't see.
+      - name: Build frontend
         if: steps.changes.outputs.frontend == 'true'
         working-directory: ./frontend
-        run: pnpm exec tsc -b --noEmit
+        run: pnpm build
 
 
       - name: Set up Python

--- a/backend/python/app/models/location.py
+++ b/backend/python/app/models/location.py
@@ -40,7 +40,10 @@ class LocationBase(SQLModel):
     state: LocationState = Field(default=LocationState.ACTIVE, sa_type=String)
     notes: str = Field(default="")
     note_chain_id: UUID | None = Field(
-        default=None, foreign_key="note_chains.note_chain_id", nullable=True
+        default=None,
+        foreign_key="note_chains.note_chain_id",
+        nullable=True,
+        ondelete="SET NULL",
     )
 
 

--- a/backend/python/app/models/note_chain.py
+++ b/backend/python/app/models/note_chain.py
@@ -1,6 +1,7 @@
 from typing import TYPE_CHECKING
 from uuid import UUID, uuid4
 
+from sqlalchemy import String
 from sqlmodel import Field, Relationship, SQLModel
 
 from .base import BaseModel
@@ -13,8 +14,13 @@ if TYPE_CHECKING:
 class NoteChainBase(SQLModel):
     """Shared fields between table and API models"""
 
-    read_permission: NotePermission = Field(default=NotePermission.ADMIN)
-    write_permission: NotePermission = Field(default=NotePermission.ADMIN)
+    # Stored as a string column (NOT a native PG enum), matching the migration
+    read_permission: NotePermission = Field(
+        default=NotePermission.ADMIN, sa_type=String
+    )
+    write_permission: NotePermission = Field(
+        default=NotePermission.ADMIN, sa_type=String
+    )
 
 
 class NoteChain(NoteChainBase, BaseModel, table=True):

--- a/backend/python/app/models/route.py
+++ b/backend/python/app/models/route.py
@@ -26,7 +26,10 @@ class RouteBase(SQLModel):
     expires_at: datetime | None = Field(default=None)
     ends_at_warehouse: bool = Field(default=False)
     note_chain_id: UUID | None = Field(
-        default=None, foreign_key="note_chains.note_chain_id", nullable=True
+        default=None,
+        foreign_key="note_chains.note_chain_id",
+        nullable=True,
+        ondelete="SET NULL",
     )
 
 

--- a/backend/python/app/seed_database.py
+++ b/backend/python/app/seed_database.py
@@ -164,8 +164,19 @@ SMALL_CITIES = ["cambridge", "elmira", "new hamburg"]
 WAREHOUSE_LAT, WAREHOUSE_LON = 43.402343, -80.464610
 WAREHOUSE_ADDRESS = "330 Trillium Drive, Kitchener, ON"
 
-# Database connection
-DATABASE_URL = "postgresql://postgres:postgres@f4k_db:5432/f4k"
+
+def get_database_url() -> str:
+    """Build the database URL from the environment, like migrations/env.py.
+
+    Indexes os.environ directly so a missing variable fails loudly instead
+    of silently seeding the wrong database.
+    """
+    return "postgresql://{username}:{password}@{host}:5432/{db}".format(
+        username=os.environ["POSTGRES_USER"],
+        password=os.environ["POSTGRES_PASSWORD"],
+        host=os.environ["DB_HOST"],
+        db=os.environ["POSTGRES_DB_DEV"],
+    )
 
 
 def set_timestamps(instance: BaseModel) -> None:
@@ -400,7 +411,7 @@ def main() -> None:
     print("Firebase initialized")
 
     # Create database connection
-    engine = create_engine(DATABASE_URL, echo=False)
+    engine = create_engine(get_database_url(), echo=False)
 
     with Session(engine) as session:
         try:

--- a/backend/python/migrations/versions/a9c4e7f21b38_merge_heads.py
+++ b/backend/python/migrations/versions/a9c4e7f21b38_merge_heads.py
@@ -1,0 +1,21 @@
+"""merge heads
+
+Revision ID: a9c4e7f21b38
+Revises: 4971451d79cd, e4f6a7b8c9d0
+Create Date: 2026-06-12 00:00:00.000000
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = "a9c4e7f21b38"
+down_revision = ("4971451d79cd", "e4f6a7b8c9d0")
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    pass
+
+
+def downgrade():
+    pass

--- a/backend/python/tests/test_seed_database.py
+++ b/backend/python/tests/test_seed_database.py
@@ -74,7 +74,7 @@ def _run_seed_script() -> None:
     Faker.seed(20250526)
 
     with (
-        patch.object(seed_module, "DATABASE_URL", sync_db_url),
+        patch.object(seed_module, "get_database_url", return_value=sync_db_url),
         patch.dict(os.environ, {"LOCATIONS_CSV_PATH": TEST_CSV_PATH}),
         patch("app.seed_database.initialize_firebase"),
         patch("app.seed_database.ensure_firebase_user"),


### PR DESCRIPTION
## Problem

Recently we had two PRs that made a migration, resulting in two HEAD branches, and this passed tests (because we didn't actually run/build the container in the tests.

## Fixes

1. **`a9c4e7f21b38_merge_heads.py`** — empty merge migration joining the two heads to fix the issue (same pattern as `d3f1a2b4c5e6`). 
2. **`boot-smoke.yml` CI workflow** — builds the real backend image and boots it against a fresh Postgres. The entrypoint runs `alembic upgrade head && python server.py`, and the job asserts `/docs` responds within 90s. 

## Verification

Ran the smoke check locally both ways:
- Image built from pre-fix `main` → container exits with the exact multiple-heads error ❌ (check fails, as it should)
- Image built with the merge migration → migrations apply, `/docs` returns 200 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)