### PR TITLE
[throwaway] Verify frontend build step in lint CI

### DIFF
--- a/.github/workflows/boot-smoke.yml
+++ b/.github/workflows/boot-smoke.yml
@@ -101,7 +101,9 @@ jobs:
               docker logs f4k_backend_smoke
               exit 1
             fi
-            if curl -fsS -o /dev/null http://localhost:8080/docs; then
+            # /openapi.json forces FastAPI to build the full schema for every
+            # route, so this also catches bad response-model definitions.
+            if curl -fsS -o /dev/null http://localhost:8080/openapi.json; then
               echo "Backend booted: migrations applied and server responding."
               exit 0
             fi
@@ -110,3 +112,12 @@ jobs:
           echo "::error::Backend did not become healthy within 90s"
           docker logs f4k_backend_smoke
           exit 1
+
+      # `alembic check` runs autogenerate against the freshly migrated DB and
+      # fails if the models expect a different schema than the migration chain
+      # produces. Unit tests can't catch this: pytest builds its schema from
+      # the models directly (create_all), so a model edited without a matching
+      # migration passes tests but breaks in compose/deploys.
+      - name: Check model/migration schema drift
+        if: steps.changes.outputs.python-backend == 'true'
+        run: docker exec f4k_backend_smoke alembic check

--- a/.github/workflows/boot-smoke.yml
+++ b/.github/workflows/boot-smoke.yml
@@ -65,7 +65,9 @@ jobs:
           tags: f4k-backend:ci
           load: true
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # ignore-error: cache export to the GHA backend is flaky (layer blob
+          # not_found); a failed export should not fail the build it caches.
+          cache-to: type=gha,ignore-error=true
 
       - name: Boot backend (runs migrations, then the server)
         if: steps.changes.outputs.python-backend == 'true'

--- a/.github/workflows/boot-smoke.yml
+++ b/.github/workflows/boot-smoke.yml
@@ -1,0 +1,112 @@
+name: Backend boot smoke
+
+# Builds the real backend Docker image and boots it against a fresh Postgres,
+# exactly like `docker compose up` / a deploy would: the entrypoint runs
+# `alembic upgrade head && python server.py`. This catches problems unit tests
+# can't see — broken or multi-headed migration graphs, startup crashes, missing
+# imports — before they land on main.
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+concurrency:
+  group: boot-smoke-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  boot:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    services:
+      postgres:
+        image: postgres:12-alpine
+        env:
+          POSTGRES_PASSWORD: password
+          POSTGRES_USER: postgres
+          POSTGRES_DB: f4k
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      # Same pattern as pytest.yml: run the job on every PR so a required
+      # check always reports a status, but only do the expensive work when
+      # backend code changed.
+      - name: Filter changed files
+        uses: dorny/paths-filter@v2
+        id: changes
+        with:
+          filters: |
+            python-backend:
+              - "backend/python/**"
+
+      - name: Set up Docker Buildx
+        if: steps.changes.outputs.python-backend == 'true'
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build backend image
+        if: steps.changes.outputs.python-backend == 'true'
+        uses: docker/build-push-action@v6
+        with:
+          context: backend/python
+          tags: f4k-backend:ci
+          load: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Boot backend (runs migrations, then the server)
+        if: steps.changes.outputs.python-backend == 'true'
+        run: |
+          # Firebase Admin parses the service-account key at startup, so it
+          # needs a syntactically valid (but throwaway) RSA key.
+          DUMMY_KEY=$(openssl genrsa 2048 2>/dev/null)
+
+          docker run -d --name f4k_backend_smoke --network host \
+            -e APP_ENV=development \
+            -e POSTGRES_USER=postgres \
+            -e POSTGRES_PASSWORD=password \
+            -e POSTGRES_DB_DEV=f4k \
+            -e POSTGRES_DB_TEST=f4k_test \
+            -e DB_HOST=localhost \
+            -e FIREBASE_PROJECT_ID=ci-dummy \
+            -e FIREBASE_SVC_ACCOUNT_PRIVATE_KEY_ID=dummy \
+            -e FIREBASE_SVC_ACCOUNT_PRIVATE_KEY="$DUMMY_KEY" \
+            -e FIREBASE_SVC_ACCOUNT_CLIENT_EMAIL=ci-dummy@ci-dummy.iam.gserviceaccount.com \
+            -e FIREBASE_SVC_ACCOUNT_CLIENT_ID=000000000000000000000 \
+            -e FIREBASE_SVC_ACCOUNT_AUTH_URI=https://accounts.google.com/o/oauth2/auth \
+            -e FIREBASE_SVC_ACCOUNT_TOKEN_URI=https://oauth2.googleapis.com/token \
+            -e FIREBASE_SVC_ACCOUNT_AUTH_PROVIDER_X509_CERT_URL=https://www.googleapis.com/oauth2/v1/certs \
+            -e FIREBASE_SVC_ACCOUNT_CLIENT_X509_CERT_URL=https://www.googleapis.com/robot/v1/metadata/x509/dummy \
+            f4k-backend:ci
+
+      - name: Wait for healthy server
+        if: steps.changes.outputs.python-backend == 'true'
+        run: |
+          for i in $(seq 1 45); do
+            if [ "$(docker inspect -f '{{.State.Running}}' f4k_backend_smoke)" != "true" ]; then
+              echo "::error::Backend container exited during boot (migrations or startup failed)"
+              docker logs f4k_backend_smoke
+              exit 1
+            fi
+            if curl -fsS -o /dev/null http://localhost:8080/docs; then
+              echo "Backend booted: migrations applied and server responding."
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "::error::Backend did not become healthy within 90s"
+          docker logs f4k_backend_smoke
+          exit 1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -54,10 +54,13 @@ jobs:
         working-directory: ./frontend
         run: pnpm format:check
 
-      - name: Type-check frontend
+      # `pnpm build` runs `tsc -b && vite build`, so this both type-checks and
+      # catches production-build-only failures (vite config, asset imports,
+      # build-time env usage) that tsc alone can't see.
+      - name: Build frontend
         if: steps.changes.outputs.frontend == 'true'
         working-directory: ./frontend
-        run: pnpm exec tsc -b --noEmit
+        run: pnpm build
 
 
       - name: Set up Python

--- a/backend/python/app/models/location.py
+++ b/backend/python/app/models/location.py
@@ -40,7 +40,10 @@ class LocationBase(SQLModel):
     state: LocationState = Field(default=LocationState.ACTIVE, sa_type=String)
     notes: str = Field(default="")
     note_chain_id: UUID | None = Field(
-        default=None, foreign_key="note_chains.note_chain_id", nullable=True
+        default=None,
+        foreign_key="note_chains.note_chain_id",
+        nullable=True,
+        ondelete="SET NULL",
     )
 
 

--- a/backend/python/app/models/note_chain.py
+++ b/backend/python/app/models/note_chain.py
@@ -1,6 +1,7 @@
 from typing import TYPE_CHECKING
 from uuid import UUID, uuid4
 
+from sqlalchemy import String
 from sqlmodel import Field, Relationship, SQLModel
 
 from .base import BaseModel
@@ -13,8 +14,13 @@ if TYPE_CHECKING:
 class NoteChainBase(SQLModel):
     """Shared fields between table and API models"""
 
-    read_permission: NotePermission = Field(default=NotePermission.ADMIN)
-    write_permission: NotePermission = Field(default=NotePermission.ADMIN)
+    # Stored as a string column (NOT a native PG enum), matching the migration
+    read_permission: NotePermission = Field(
+        default=NotePermission.ADMIN, sa_type=String
+    )
+    write_permission: NotePermission = Field(
+        default=NotePermission.ADMIN, sa_type=String
+    )
 
 
 class NoteChain(NoteChainBase, BaseModel, table=True):

--- a/backend/python/app/models/route.py
+++ b/backend/python/app/models/route.py
@@ -26,7 +26,10 @@ class RouteBase(SQLModel):
     expires_at: datetime | None = Field(default=None)
     ends_at_warehouse: bool = Field(default=False)
     note_chain_id: UUID | None = Field(
-        default=None, foreign_key="note_chains.note_chain_id", nullable=True
+        default=None,
+        foreign_key="note_chains.note_chain_id",
+        nullable=True,
+        ondelete="SET NULL",
     )
 
 

--- a/backend/python/migrations/versions/a9c4e7f21b38_merge_heads.py
+++ b/backend/python/migrations/versions/a9c4e7f21b38_merge_heads.py
@@ -1,0 +1,21 @@
+"""merge heads
+
+Revision ID: a9c4e7f21b38
+Revises: 4971451d79cd, e4f6a7b8c9d0
+Create Date: 2026-06-12 00:00:00.000000
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = "a9c4e7f21b38"
+down_revision = ("4971451d79cd", "e4f6a7b8c9d0")
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    pass
+
+
+def downgrade():
+    pass

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -250,3 +250,4 @@ docker volume rm food4kids_frontend_node_modules
 docker compose up --build
 
 ```
+


### PR DESCRIPTION
Scratch PR off #157 with a trivial `frontend/**` change so the new `pnpm build` step in `run-lint` actually executes (path filter skipped it on #157 itself). Will be closed once verified — do not merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)