### PR TITLE
Add driver_id filter to GET /routes

### DIFF
--- a/backend/python/app/dependencies/auth.py
+++ b/backend/python/app/dependencies/auth.py
@@ -228,26 +228,36 @@ async def resolve_route_list_driver_filter(
     access_token: str = Depends(get_access_token),
     session: AsyncSession = Depends(get_session),
 ) -> UUID | None:
-    """Resolve the effective ``driver_id`` filter for GET /routes, enforcing
-    that a driver can only ever see their own routes.
+    """Sole auth dependency for GET /routes: gates access to drivers/admins AND
+    resolves the effective ``driver_id`` filter, so the token is verified
+    exactly once (mirroring ``require_route_assigned_or_admin`` for
+    GET /routes/{route_id}).
 
-    This is an *ownership* check on top of the endpoint's role gate
-    (``require_driver_or_admin``): without it, the role gate alone would let any
-    authenticated driver read another driver's routes by passing their id —
-    derive the scope from the token instead of trusting the client value.
+    Without the ownership half, a plain ``require_driver_or_admin`` role gate
+    would let any authenticated driver read another driver's routes by passing
+    their id — so the scope is derived from the token, never the client value:
+
+    - admins may pass any ``driver_id`` (or omit it for all routes);
+    - drivers are always scoped to themselves — omitting ``driver_id`` returns
+      their own routes, and passing another driver's id is rejected with 403.
 
     Returns the driver_id to filter by, or ``None`` for "all routes" (admins
-    only). The token is verified here (with ``email_verified`` enforced for
-    everyone, admins included).
+    only). ``email_verified`` is enforced for everyone, admins included.
     """
     decoded_token = _verified_token(access_token)
+    role = decoded_token.get("role")
 
-    if decoded_token.get("role") == "admin":
+    if role == "admin":
         # Admins may scope to any driver, or see everything (driver_id is None).
         return driver_id
 
-    # Non-admin: the role gate restricts this to drivers. Force self-scoping so
-    # one driver can never read another driver's routes.
+    if role != "driver":
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You are not authorized to make this request.",
+        )
+
+    # Driver: force self-scoping so one driver can never read another's routes.
     own_driver_id = await driver_service.get_driver_id_by_auth_id(
         session, decoded_token["uid"]
     )

--- a/backend/python/app/dependencies/auth.py
+++ b/backend/python/app/dependencies/auth.py
@@ -4,7 +4,7 @@ from typing import Any
 from uuid import UUID
 
 import firebase_admin.auth
-from fastapi import Depends, HTTPException, Request, status
+from fastapi import Depends, HTTPException, Query, Request, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
@@ -213,6 +213,55 @@ async def require_route_assigned_or_admin(
 require_admin = require_authorization_by_role({"admin"})
 require_driver = require_authorization_by_role({"driver"})
 require_driver_or_admin = require_authorization_by_role({"driver", "admin"})
+
+
+async def resolve_route_list_driver_filter(
+    driver_id: UUID | None = Query(
+        None,
+        description=(
+            "Filter routes by assigned driver. Admins may pass any driver_id, "
+            "or omit it to get all routes. Drivers are always scoped to "
+            "themselves: omitting it returns their own routes, and passing "
+            "another driver's id is rejected with 403."
+        ),
+    ),
+    access_token: str = Depends(get_access_token),
+    session: AsyncSession = Depends(get_session),
+) -> UUID | None:
+    """Resolve the effective ``driver_id`` filter for GET /routes, enforcing
+    that a driver can only ever see their own routes.
+
+    This is an *ownership* check on top of the endpoint's role gate
+    (``require_driver_or_admin``): without it, the role gate alone would let any
+    authenticated driver read another driver's routes by passing their id —
+    derive the scope from the token instead of trusting the client value.
+
+    Returns the driver_id to filter by, or ``None`` for "all routes" (admins
+    only). The token is verified here (with ``email_verified`` enforced for
+    everyone, admins included).
+    """
+    decoded_token = _verified_token(access_token)
+
+    if decoded_token.get("role") == "admin":
+        # Admins may scope to any driver, or see everything (driver_id is None).
+        return driver_id
+
+    # Non-admin: the role gate restricts this to drivers. Force self-scoping so
+    # one driver can never read another driver's routes.
+    own_driver_id = await driver_service.get_driver_id_by_auth_id(
+        session, decoded_token["uid"]
+    )
+    if own_driver_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="No driver record found for current user",
+        )
+    if driver_id is not None and driver_id != own_driver_id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Drivers may only view their own routes.",
+        )
+    return own_driver_id
 
 
 def get_current_user_email(access_token: str = Depends(get_access_token)) -> str:

--- a/backend/python/app/routers/route_routes.py
+++ b/backend/python/app/routers/route_routes.py
@@ -36,6 +36,10 @@ async def get_routes(
         False,
         description="If true, only return unassigned routes. If false, return all routes regardless of assignment status.",
     ),
+    driver_id: UUID | None = Query(
+        None,
+        description="If set, only return routes assigned to this driver. Powers the driver homepage feed.",
+    ),
     start_date: str = Query(None, description="Filter route groups from this date"),
     end_date: str = Query(None, description="Filter route groups until this date"),
     pagination: PaginationParams = Depends(get_pagination),
@@ -47,9 +51,16 @@ async def get_routes(
     Returns routes with their drive dates - routes can appear multiple times for different dates.
     When unassigned_only is False, returns all routes (no assignment filter).
     When unassigned_only is True, returns only routes that are unassigned for the given route group.
+    When driver_id is set, returns only routes assigned to that driver.
     """
+    if unassigned_only and driver_id is not None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Cannot combine unassigned_only with driver_id: a route is "
+            "either unassigned or assigned to a specific driver, not both.",
+        )
     return await route_service.get_routes(
-        session, unassigned_only, start_date, end_date, pagination
+        session, unassigned_only, start_date, end_date, pagination, driver_id
     )
 
 

--- a/backend/python/app/routers/route_routes.py
+++ b/backend/python/app/routers/route_routes.py
@@ -6,7 +6,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies.auth import (
     require_admin,
-    require_driver_or_admin,
     require_route_assigned_or_admin,
     resolve_route_list_driver_filter,
 )
@@ -42,7 +41,6 @@ async def get_routes(
     pagination: PaginationParams = Depends(get_pagination),
     session: AsyncSession = Depends(get_session),
     driver_id: UUID | None = Depends(resolve_route_list_driver_filter),
-    _auth: bool = Depends(require_driver_or_admin),
 ) -> PaginatedResponse[RouteWithDateRead]:
     """
     Get routes with pagination and optional filtering for unassigned routes and date range.
@@ -50,6 +48,7 @@ async def get_routes(
     When unassigned_only is False, returns all routes (no assignment filter).
     When unassigned_only is True, returns only routes that are unassigned for the given route group.
 
+    Requires a driver or admin caller.
     Admins may scope to any driver via driver_id (or omit it for all routes).
     Drivers are always scoped to their own routes: omitting driver_id returns
     their own routes, and requesting another driver's is rejected.

--- a/backend/python/app/routers/route_routes.py
+++ b/backend/python/app/routers/route_routes.py
@@ -8,6 +8,7 @@ from app.dependencies.auth import (
     require_admin,
     require_driver_or_admin,
     require_route_assigned_or_admin,
+    resolve_route_list_driver_filter,
 )
 from app.models import get_session
 from app.models.route import (
@@ -36,14 +37,11 @@ async def get_routes(
         False,
         description="If true, only return unassigned routes. If false, return all routes regardless of assignment status.",
     ),
-    driver_id: UUID | None = Query(
-        None,
-        description="If set, only return routes assigned to this driver. Powers the driver homepage feed.",
-    ),
     start_date: str = Query(None, description="Filter route groups from this date"),
     end_date: str = Query(None, description="Filter route groups until this date"),
     pagination: PaginationParams = Depends(get_pagination),
     session: AsyncSession = Depends(get_session),
+    driver_id: UUID | None = Depends(resolve_route_list_driver_filter),
     _auth: bool = Depends(require_driver_or_admin),
 ) -> PaginatedResponse[RouteWithDateRead]:
     """
@@ -51,13 +49,17 @@ async def get_routes(
     Returns routes with their drive dates - routes can appear multiple times for different dates.
     When unassigned_only is False, returns all routes (no assignment filter).
     When unassigned_only is True, returns only routes that are unassigned for the given route group.
-    When driver_id is set, returns only routes assigned to that driver.
+
+    Admins may scope to any driver via driver_id (or omit it for all routes).
+    Drivers are always scoped to their own routes: omitting driver_id returns
+    their own routes, and requesting another driver's is rejected.
     """
     if unassigned_only and driver_id is not None:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Cannot combine unassigned_only with driver_id: a route is "
-            "either unassigned or assigned to a specific driver, not both.",
+            detail="Cannot combine unassigned_only with a driver scope: "
+            "unassigned routes have no driver. (Drivers are always scoped to "
+            "themselves, so they cannot list unassigned routes.)",
         )
     return await route_service.get_routes(
         session, unassigned_only, start_date, end_date, pagination, driver_id

--- a/backend/python/app/services/implementations/route_service.py
+++ b/backend/python/app/services/implementations/route_service.py
@@ -48,12 +48,14 @@ class RouteService:
         start_date: str | None = None,
         end_date: str | None = None,
         pagination: PaginationParams | None = None,
+        driver_id: UUID | None = None,
     ) -> PaginatedResponse[RouteWithDateRead]:
         """
         Get routes with optional filtering for unassigned routes and date range.
 
-        unassigned_only filters to routes with no driver_id. The date range
-        filters on the route's RouteGroup.drive_date.
+        unassigned_only filters to routes with no driver_id. driver_id filters
+        to routes assigned to that specific driver (powers the driver homepage
+        feed). The date range filters on the route's RouteGroup.drive_date.
         """
         statement = select(Route, RouteGroup.drive_date).join(
             RouteGroup,
@@ -69,6 +71,9 @@ class RouteService:
 
         if unassigned_only:
             statement = statement.where(col(Route.driver_id).is_(None))
+
+        if driver_id is not None:
+            statement = statement.where(Route.driver_id == driver_id)
 
         statement = statement.order_by(RouteGroup.drive_date, Route.name)  # type: ignore[arg-type]
 

--- a/backend/python/requirements.txt
+++ b/backend/python/requirements.txt
@@ -1,5 +1,8 @@
 # Core web framework
-fastapi>=0.104.1
+# Pinned with an upper bound: unbounded `>=` let CI resolve fastapi 0.137.0,
+# whose included-router restructuring broke app.routes introspection. Bump
+# deliberately (and re-verify route introspection) rather than float.
+fastapi>=0.137.0,<0.138
 uvicorn[standard]>=0.24.0
 python-multipart>=0.0.6
 

--- a/backend/python/tests/conftest.py
+++ b/backend/python/tests/conftest.py
@@ -22,6 +22,7 @@ from app.dependencies.auth import (
     require_driver_or_admin,
     require_route_assigned_or_admin,
     require_self_driver_or_admin,
+    resolve_route_list_driver_filter,
 )
 from app.models import get_session
 
@@ -119,6 +120,10 @@ def _apply_auth_overrides(app: Any) -> None:
     app.dependency_overrides[require_driver_or_admin] = lambda: True
     app.dependency_overrides[require_self_driver_or_admin] = lambda: True
     app.dependency_overrides[require_route_assigned_or_admin] = lambda: True
+    # GET /routes' sole auth dependency also resolves the driver_id filter;
+    # bypass it to the "all routes" scope (driver_id=None), matching the admin
+    # view, so router tests that hit GET /routes aren't gated by token checks.
+    app.dependency_overrides[resolve_route_list_driver_filter] = lambda: None
 
 
 @pytest.fixture(scope="function")

--- a/backend/python/tests/test_auth_integration.py
+++ b/backend/python/tests/test_auth_integration.py
@@ -239,6 +239,8 @@ def firebase_auth_mock() -> Iterator[None]:
 
 class Seed(SimpleNamespace):
     self_driver_id: Any
+    other_driver_id: Any
+    route_group_id: Any
     route_id: Any
 
 
@@ -279,6 +281,7 @@ async def seed(test_session: AsyncSession) -> Seed:
 
     await test_session.commit()
     await test_session.refresh(self_driver)
+    await test_session.refresh(other_driver)
     await test_session.refresh(route_group)
 
     # SELF is assigned to the route (via driver_id); OTHER is not.
@@ -293,9 +296,10 @@ async def seed(test_session: AsyncSession) -> Seed:
     await test_session.commit()
     await test_session.refresh(route)
 
-    _ = other_driver  # seeded so OTHER resolves to a real (non-owning) driver
     return Seed(
         self_driver_id=self_driver.driver_id,
+        other_driver_id=other_driver.driver_id,
+        route_group_id=route_group.route_group_id,
         route_id=route.route_id,
     )
 
@@ -427,3 +431,165 @@ def test_every_exposed_route_is_classified() -> None:
         "ROUTE_POLICIES has entries for routes that no longer exist — remove "
         "them:\n  " + "\n  ".join(f"{m} {p}" for m, p in sorted(stale))
     )
+
+
+# ---------------------------------------------------------------------------
+# GET /routes driver-scoping (ownership *within* the DRIVER_OR_ADMIN role gate)
+# ---------------------------------------------------------------------------
+#
+# The auth matrix above only checks the role gate (any driver/admin may call
+# GET /routes). It does NOT exercise the driver_id query param, which carries a
+# finer-grained ownership rule resolved by resolve_route_list_driver_filter:
+# admins may scope to any driver (or omit it for all routes); a driver is always
+# scoped to their own routes and cannot read another driver's. These tests drive
+# the real app (auth NOT bypassed) to lock that rule in.
+
+
+@pytest_asyncio.fixture
+async def scoping_routes(test_session: AsyncSession, seed: Seed) -> dict[str, Any]:
+    """Alongside seed's self-assigned route, add an other-driver route and an
+    unassigned route in the same group, so a scoped query is distinguishable
+    from "all routes"."""
+    from app.models.route import Route
+
+    other_route = Route(
+        name="Other Route",
+        notes="",
+        length=4.0,
+        route_group_id=seed.route_group_id,
+        driver_id=seed.other_driver_id,
+    )
+    unassigned_route = Route(
+        name="Unassigned Route",
+        notes="",
+        length=5.0,
+        route_group_id=seed.route_group_id,
+    )
+    test_session.add_all([other_route, unassigned_route])
+    await test_session.commit()
+    await test_session.refresh(other_route)
+    await test_session.refresh(unassigned_route)
+    return {
+        "self_route_id": str(seed.route_id),
+        "other_route_id": str(other_route.route_id),
+        "unassigned_route_id": str(unassigned_route.route_id),
+    }
+
+
+def _route_ids(resp: Any) -> set[str]:
+    return {item["route_id"] for item in resp.json()["items"]}
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("firebase_auth_mock")
+class TestGetRoutesDriverScoping:
+    """Ownership rules for the GET /routes driver_id filter."""
+
+    async def test_driver_unscoped_sees_only_own_routes(
+        self, auth_client: AsyncClient, scoping_routes: dict[str, Any]
+    ) -> None:
+        """A driver omitting driver_id is auto-scoped to themselves — they get
+        their own route, not the other driver's or the unassigned one."""
+        resp = await auth_client.get("/routes", headers=_HEADERS[Actor.SELF])
+        assert resp.status_code == 200
+        ids = _route_ids(resp)
+        assert ids == {scoping_routes["self_route_id"]}
+
+    async def test_driver_scoped_to_self_is_allowed(
+        self, auth_client: AsyncClient, seed: Seed, scoping_routes: dict[str, Any]
+    ) -> None:
+        """A driver may pass their own driver_id explicitly."""
+        resp = await auth_client.get(
+            "/routes",
+            params={"driver_id": str(seed.self_driver_id)},
+            headers=_HEADERS[Actor.SELF],
+        )
+        assert resp.status_code == 200
+        assert _route_ids(resp) == {scoping_routes["self_route_id"]}
+
+    async def test_driver_cannot_request_another_drivers_routes(
+        self,
+        auth_client: AsyncClient,
+        seed: Seed,
+        scoping_routes: dict[str, Any],  # noqa: ARG002
+    ) -> None:
+        """A driver passing another driver's id is rejected with 403 (not
+        silently re-scoped, and never returning the other driver's routes)."""
+        resp = await auth_client.get(
+            "/routes",
+            params={"driver_id": str(seed.other_driver_id)},
+            headers=_HEADERS[Actor.SELF],
+        )
+        assert resp.status_code == 403
+
+    async def test_admin_can_scope_to_any_driver(
+        self, auth_client: AsyncClient, seed: Seed, scoping_routes: dict[str, Any]
+    ) -> None:
+        """An admin may scope to an arbitrary driver and gets exactly that
+        driver's routes."""
+        resp = await auth_client.get(
+            "/routes",
+            params={"driver_id": str(seed.other_driver_id)},
+            headers=_HEADERS[Actor.ADMIN],
+        )
+        assert resp.status_code == 200
+        assert _route_ids(resp) == {scoping_routes["other_route_id"]}
+
+    async def test_admin_unscoped_sees_all_routes(
+        self, auth_client: AsyncClient, scoping_routes: dict[str, Any]
+    ) -> None:
+        """An admin omitting driver_id sees every route regardless of
+        assignment."""
+        resp = await auth_client.get("/routes", headers=_HEADERS[Actor.ADMIN])
+        assert resp.status_code == 200
+        ids = _route_ids(resp)
+        assert ids == {
+            scoping_routes["self_route_id"],
+            scoping_routes["other_route_id"],
+            scoping_routes["unassigned_route_id"],
+        }
+
+    async def test_driver_unassigned_only_is_rejected(
+        self,
+        auth_client: AsyncClient,
+        scoping_routes: dict[str, Any],  # noqa: ARG002
+    ) -> None:
+        """A driver is auto-scoped to themselves, so unassigned_only (which
+        means driver_id IS NULL) is contradictory and rejected with 400 — a
+        driver can never list unassigned routes."""
+        resp = await auth_client.get(
+            "/routes",
+            params={"unassigned_only": "true"},
+            headers=_HEADERS[Actor.SELF],
+        )
+        assert resp.status_code == 400
+
+    async def test_admin_unassigned_only_with_driver_id_is_rejected(
+        self,
+        auth_client: AsyncClient,
+        seed: Seed,
+        scoping_routes: dict[str, Any],  # noqa: ARG002
+    ) -> None:
+        """unassigned_only + an explicit driver scope is contradictory -> 400."""
+        resp = await auth_client.get(
+            "/routes",
+            params={
+                "unassigned_only": "true",
+                "driver_id": str(seed.other_driver_id),
+            },
+            headers=_HEADERS[Actor.ADMIN],
+        )
+        assert resp.status_code == 400
+
+    async def test_admin_unassigned_only_alone_is_allowed(
+        self, auth_client: AsyncClient, scoping_routes: dict[str, Any]
+    ) -> None:
+        """unassigned_only without a driver scope still works for admins and
+        returns only the unassigned route."""
+        resp = await auth_client.get(
+            "/routes",
+            params={"unassigned_only": "true"},
+            headers=_HEADERS[Actor.ADMIN],
+        )
+        assert resp.status_code == 200
+        assert _route_ids(resp) == {scoping_routes["unassigned_route_id"]}

--- a/backend/python/tests/test_auth_integration.py
+++ b/backend/python/tests/test_auth_integration.py
@@ -35,7 +35,6 @@ from uuid import uuid4
 
 import pytest
 import pytest_asyncio
-from fastapi.routing import APIRoute
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -167,7 +166,9 @@ ROUTE_POLICIES: dict[tuple[str, str], Policy] = {
     ("DELETE", "/announcements/{announcement_id}"): Policy.DRIVER_OR_ADMIN,
     # --- upload (any driver/admin; feeds note + announcement attachments) ---
     ("POST", "/upload/"): Policy.DRIVER_OR_ADMIN,
-    ("DELETE", "/upload/{filename:path}"): Policy.DRIVER_OR_ADMIN,
+    # The route declares a :path converter (/upload/{filename:path}); the
+    # OpenAPI schema (our completeness source) renders it without the converter.
+    ("DELETE", "/upload/{filename}"): Policy.DRIVER_OR_ADMIN,
 }
 
 
@@ -411,11 +412,19 @@ def test_every_exposed_route_is_classified() -> None:
     test_route_auth_matrix above.
     """
     app = create_app()
+    # Enumerate exposed routes from the public OpenAPI schema rather than walking
+    # app.routes: FastAPI's internal route structure is version-sensitive (0.137
+    # nests included routers behind a lazy wrapper instead of flattening them
+    # into app.routes), but the generated schema's path+method map is the stable
+    # public contract for what the app exposes. Docs/openapi routes are not in
+    # the schema, which is exactly what we want (they carry no auth policy).
+    http_methods = {"GET", "POST", "PUT", "PATCH", "DELETE"}
+    schema = app.openapi()
     exposed = {
-        (method, route.path)
-        for route in app.routes
-        if isinstance(route, APIRoute)
-        for method in route.methods - {"HEAD", "OPTIONS"}
+        (method.upper(), path)
+        for path, operations in schema["paths"].items()
+        for method in operations
+        if method.upper() in http_methods
     }
     registered = set(ROUTE_POLICIES)
 

--- a/backend/python/tests/test_routes.py
+++ b/backend/python/tests/test_routes.py
@@ -1112,6 +1112,111 @@ class TestRouteRoutes:
         assert route_id in {r["route_id"] for r in unassigned_again.json()["items"]}
 
     @pytest.mark.asyncio
+    async def test_get_routes_filters_by_driver_id(
+        self,
+        async_client: AsyncClient,
+        test_session: AsyncSession,
+        test_route_group: Any,
+    ) -> None:
+        """GET /routes?driver_id=<id> returns only that driver's routes, and
+        excludes routes assigned to other drivers and unassigned routes."""
+        from app.models.driver import Driver
+        from app.models.route import Route
+        from app.models.user import User
+
+        rg_id = test_route_group.route_group_id
+
+        # Two drivers.
+        user_a = User(name="Driver A", email="driver-a@test.dev", auth_id="drv-a")
+        user_b = User(name="Driver B", email="driver-b@test.dev", auth_id="drv-b")
+        test_session.add_all([user_a, user_b])
+        driver_a = Driver(
+            user_id=user_a.user_id,
+            phone="+12125550001",
+            address="1 A St",
+            license_plate="AAA111",
+            car_make_model="Toyota Corolla",
+        )
+        driver_b = Driver(
+            user_id=user_b.user_id,
+            phone="+12125550002",
+            address="2 B St",
+            license_plate="BBB222",
+            car_make_model="Honda Civic",
+        )
+        test_session.add_all([driver_a, driver_b])
+        await test_session.commit()
+        await test_session.refresh(driver_a)
+        await test_session.refresh(driver_b)
+
+        # Two routes for A, one for B, one unassigned — all in the same group.
+        a1 = Route(
+            name="A1", length=1.0, route_group_id=rg_id, driver_id=driver_a.driver_id
+        )
+        a2 = Route(
+            name="A2", length=2.0, route_group_id=rg_id, driver_id=driver_a.driver_id
+        )
+        b1 = Route(
+            name="B1", length=3.0, route_group_id=rg_id, driver_id=driver_b.driver_id
+        )
+        unassigned = Route(name="U1", length=4.0, route_group_id=rg_id)
+        test_session.add_all([a1, a2, b1, unassigned])
+        await test_session.commit()
+        for r in (a1, a2, b1, unassigned):
+            await test_session.refresh(r)
+
+        resp = await async_client.get(f"/routes?driver_id={driver_a.driver_id}")
+        assert resp.status_code == 200
+        returned = {item["route_id"] for item in resp.json()["items"]}
+        assert returned == {str(a1.route_id), str(a2.route_id)}
+
+    @pytest.mark.asyncio
+    async def test_get_routes_driver_id_no_matches(
+        self,
+        async_client: AsyncClient,
+        test_session: AsyncSession,
+        test_route_group: Any,
+    ) -> None:
+        """GET /routes?driver_id=<id> returns an empty page for a driver with
+        no assigned routes (rather than erroring or returning everything)."""
+        from app.models.driver import Driver
+        from app.models.route import Route
+        from app.models.user import User
+
+        rg_id = test_route_group.route_group_id
+
+        # A route exists, but it's unassigned.
+        test_session.add(Route(name="Lonely", length=1.0, route_group_id=rg_id))
+        user = User(name="No Routes", email="noroutes@test.dev", auth_id="drv-none")
+        test_session.add(user)
+        driver = Driver(
+            user_id=user.user_id,
+            phone="+12125550003",
+            address="3 C St",
+            license_plate="CCC333",
+            car_make_model="Mazda 3",
+        )
+        test_session.add(driver)
+        await test_session.commit()
+        await test_session.refresh(driver)
+
+        resp = await async_client.get(f"/routes?driver_id={driver.driver_id}")
+        assert resp.status_code == 200
+        assert resp.json()["items"] == []
+        assert resp.json()["total"] == 0
+
+    @pytest.mark.asyncio
+    async def test_get_routes_driver_id_with_unassigned_only_is_400(
+        self, async_client: AsyncClient
+    ) -> None:
+        """GET /routes rejects combining driver_id with unassigned_only — a
+        route can't be both unassigned and assigned to a specific driver."""
+        resp = await async_client.get(
+            f"/routes?unassigned_only=true&driver_id={uuid4()}"
+        )
+        assert resp.status_code == 400
+
+    @pytest.mark.asyncio
     async def test_update_route_not_found(self, async_client: AsyncClient) -> None:
         """PATCH /routes/{id} returns 404 for an unknown route."""
         response = await async_client.patch(f"/routes/{uuid4()}", json={"name": "x"})

--- a/backend/python/tests/test_routes.py
+++ b/backend/python/tests/test_routes.py
@@ -1111,110 +1111,11 @@ class TestRouteRoutes:
         unassigned_again = await async_client.get("/routes?unassigned_only=true")
         assert route_id in {r["route_id"] for r in unassigned_again.json()["items"]}
 
-    @pytest.mark.asyncio
-    async def test_get_routes_filters_by_driver_id(
-        self,
-        async_client: AsyncClient,
-        test_session: AsyncSession,
-        test_route_group: Any,
-    ) -> None:
-        """GET /routes?driver_id=<id> returns only that driver's routes, and
-        excludes routes assigned to other drivers and unassigned routes."""
-        from app.models.driver import Driver
-        from app.models.route import Route
-        from app.models.user import User
-
-        rg_id = test_route_group.route_group_id
-
-        # Two drivers.
-        user_a = User(name="Driver A", email="driver-a@test.dev", auth_id="drv-a")
-        user_b = User(name="Driver B", email="driver-b@test.dev", auth_id="drv-b")
-        test_session.add_all([user_a, user_b])
-        driver_a = Driver(
-            user_id=user_a.user_id,
-            phone="+12125550001",
-            address="1 A St",
-            license_plate="AAA111",
-            car_make_model="Toyota Corolla",
-        )
-        driver_b = Driver(
-            user_id=user_b.user_id,
-            phone="+12125550002",
-            address="2 B St",
-            license_plate="BBB222",
-            car_make_model="Honda Civic",
-        )
-        test_session.add_all([driver_a, driver_b])
-        await test_session.commit()
-        await test_session.refresh(driver_a)
-        await test_session.refresh(driver_b)
-
-        # Two routes for A, one for B, one unassigned — all in the same group.
-        a1 = Route(
-            name="A1", length=1.0, route_group_id=rg_id, driver_id=driver_a.driver_id
-        )
-        a2 = Route(
-            name="A2", length=2.0, route_group_id=rg_id, driver_id=driver_a.driver_id
-        )
-        b1 = Route(
-            name="B1", length=3.0, route_group_id=rg_id, driver_id=driver_b.driver_id
-        )
-        unassigned = Route(name="U1", length=4.0, route_group_id=rg_id)
-        test_session.add_all([a1, a2, b1, unassigned])
-        await test_session.commit()
-        for r in (a1, a2, b1, unassigned):
-            await test_session.refresh(r)
-
-        resp = await async_client.get(f"/routes?driver_id={driver_a.driver_id}")
-        assert resp.status_code == 200
-        returned = {item["route_id"] for item in resp.json()["items"]}
-        assert returned == {str(a1.route_id), str(a2.route_id)}
-
-    @pytest.mark.asyncio
-    async def test_get_routes_driver_id_no_matches(
-        self,
-        async_client: AsyncClient,
-        test_session: AsyncSession,
-        test_route_group: Any,
-    ) -> None:
-        """GET /routes?driver_id=<id> returns an empty page for a driver with
-        no assigned routes (rather than erroring or returning everything)."""
-        from app.models.driver import Driver
-        from app.models.route import Route
-        from app.models.user import User
-
-        rg_id = test_route_group.route_group_id
-
-        # A route exists, but it's unassigned.
-        test_session.add(Route(name="Lonely", length=1.0, route_group_id=rg_id))
-        user = User(name="No Routes", email="noroutes@test.dev", auth_id="drv-none")
-        test_session.add(user)
-        driver = Driver(
-            user_id=user.user_id,
-            phone="+12125550003",
-            address="3 C St",
-            license_plate="CCC333",
-            car_make_model="Mazda 3",
-        )
-        test_session.add(driver)
-        await test_session.commit()
-        await test_session.refresh(driver)
-
-        resp = await async_client.get(f"/routes?driver_id={driver.driver_id}")
-        assert resp.status_code == 200
-        assert resp.json()["items"] == []
-        assert resp.json()["total"] == 0
-
-    @pytest.mark.asyncio
-    async def test_get_routes_driver_id_with_unassigned_only_is_400(
-        self, async_client: AsyncClient
-    ) -> None:
-        """GET /routes rejects combining driver_id with unassigned_only — a
-        route can't be both unassigned and assigned to a specific driver."""
-        resp = await async_client.get(
-            f"/routes?unassigned_only=true&driver_id={uuid4()}"
-        )
-        assert resp.status_code == 400
+    # NOTE: the GET /routes driver_id filter is ownership-scoped (a driver can
+    # only see their own routes; admins may scope to any). Because that rule is
+    # enforced by an auth dependency, it's exercised end-to-end against the real
+    # auth stack in tests/test_auth_integration.py::TestGetRoutesDriverScoping
+    # rather than here (this module bypasses auth).
 
     @pytest.mark.asyncio
     async def test_update_route_not_found(self, async_client: AsyncClient) -> None:

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -5529,7 +5529,7 @@
     },
     "/routes": {
       "get": {
-        "description": "Get routes with pagination and optional filtering for unassigned routes and date range.\nReturns routes with their drive dates - routes can appear multiple times for different dates.\nWhen unassigned_only is False, returns all routes (no assignment filter).\nWhen unassigned_only is True, returns only routes that are unassigned for the given route group.",
+        "description": "Get routes with pagination and optional filtering for unassigned routes and date range.\nReturns routes with their drive dates - routes can appear multiple times for different dates.\nWhen unassigned_only is False, returns all routes (no assignment filter).\nWhen unassigned_only is True, returns only routes that are unassigned for the given route group.\nWhen driver_id is set, returns only routes assigned to that driver.",
         "operationId": "get_routes",
         "parameters": [
           {
@@ -5542,6 +5542,25 @@
               "description": "If true, only return unassigned routes. If false, return all routes regardless of assignment status.",
               "title": "Unassigned Only",
               "type": "boolean"
+            }
+          },
+          {
+            "description": "If set, only return routes assigned to this driver. Powers the driver homepage feed.",
+            "in": "query",
+            "name": "driver_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "uuid",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "If set, only return routes assigned to this driver. Powers the driver homepage feed.",
+              "title": "Driver Id"
             }
           },
           {

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -5529,7 +5529,7 @@
     },
     "/routes": {
       "get": {
-        "description": "Get routes with pagination and optional filtering for unassigned routes and date range.\nReturns routes with their drive dates - routes can appear multiple times for different dates.\nWhen unassigned_only is False, returns all routes (no assignment filter).\nWhen unassigned_only is True, returns only routes that are unassigned for the given route group.\n\nAdmins may scope to any driver via driver_id (or omit it for all routes).\nDrivers are always scoped to their own routes: omitting driver_id returns\ntheir own routes, and requesting another driver's is rejected.",
+        "description": "Get routes with pagination and optional filtering for unassigned routes and date range.\nReturns routes with their drive dates - routes can appear multiple times for different dates.\nWhen unassigned_only is False, returns all routes (no assignment filter).\nWhen unassigned_only is True, returns only routes that are unassigned for the given route group.\n\nRequires a driver or admin caller.\nAdmins may scope to any driver via driver_id (or omit it for all routes).\nDrivers are always scoped to their own routes: omitting driver_id returns\ntheir own routes, and requesting another driver's is rejected.",
         "operationId": "get_routes",
         "parameters": [
           {

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -5529,7 +5529,7 @@
     },
     "/routes": {
       "get": {
-        "description": "Get routes with pagination and optional filtering for unassigned routes and date range.\nReturns routes with their drive dates - routes can appear multiple times for different dates.\nWhen unassigned_only is False, returns all routes (no assignment filter).\nWhen unassigned_only is True, returns only routes that are unassigned for the given route group.\nWhen driver_id is set, returns only routes assigned to that driver.",
+        "description": "Get routes with pagination and optional filtering for unassigned routes and date range.\nReturns routes with their drive dates - routes can appear multiple times for different dates.\nWhen unassigned_only is False, returns all routes (no assignment filter).\nWhen unassigned_only is True, returns only routes that are unassigned for the given route group.\n\nAdmins may scope to any driver via driver_id (or omit it for all routes).\nDrivers are always scoped to their own routes: omitting driver_id returns\ntheir own routes, and requesting another driver's is rejected.",
         "operationId": "get_routes",
         "parameters": [
           {
@@ -5542,25 +5542,6 @@
               "description": "If true, only return unassigned routes. If false, return all routes regardless of assignment status.",
               "title": "Unassigned Only",
               "type": "boolean"
-            }
-          },
-          {
-            "description": "If set, only return routes assigned to this driver. Powers the driver homepage feed.",
-            "in": "query",
-            "name": "driver_id",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "format": "uuid",
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "If set, only return routes assigned to this driver. Powers the driver homepage feed.",
-              "title": "Driver Id"
             }
           },
           {
@@ -5610,6 +5591,25 @@
               "minimum": 1,
               "title": "Page Size",
               "type": "integer"
+            }
+          },
+          {
+            "description": "Filter routes by assigned driver. Admins may pass any driver_id, or omit it to get all routes. Drivers are always scoped to themselves: omitting it returns their own routes, and passing another driver's id is rejected with 403.",
+            "in": "query",
+            "name": "driver_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "uuid",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter routes by assigned driver. Admins may pass any driver_id, or omit it to get all routes. Drivers are always scoped to themselves: omitting it returns their own routes, and passing another driver's id is rejected with 403.",
+              "title": "Driver Id"
             }
           }
         ],

--- a/frontend/src/api/generated/@tanstack/react-query.gen.ts
+++ b/frontend/src/api/generated/@tanstack/react-query.gen.ts
@@ -1816,7 +1816,10 @@ export const getRoutesQueryKey = (options?: Options<GetRoutesData>) =>
  * Returns routes with their drive dates - routes can appear multiple times for different dates.
  * When unassigned_only is False, returns all routes (no assignment filter).
  * When unassigned_only is True, returns only routes that are unassigned for the given route group.
- * When driver_id is set, returns only routes assigned to that driver.
+ *
+ * Admins may scope to any driver via driver_id (or omit it for all routes).
+ * Drivers are always scoped to their own routes: omitting driver_id returns
+ * their own routes, and requesting another driver's is rejected.
  */
 export const getRoutesOptions = (options?: Options<GetRoutesData>) =>
   queryOptions<
@@ -1849,7 +1852,10 @@ export const getRoutesInfiniteQueryKey = (
  * Returns routes with their drive dates - routes can appear multiple times for different dates.
  * When unassigned_only is False, returns all routes (no assignment filter).
  * When unassigned_only is True, returns only routes that are unassigned for the given route group.
- * When driver_id is set, returns only routes assigned to that driver.
+ *
+ * Admins may scope to any driver via driver_id (or omit it for all routes).
+ * Drivers are always scoped to their own routes: omitting driver_id returns
+ * their own routes, and requesting another driver's is rejected.
  */
 export const getRoutesInfiniteOptions = (options?: Options<GetRoutesData>) =>
   infiniteQueryOptions<

--- a/frontend/src/api/generated/@tanstack/react-query.gen.ts
+++ b/frontend/src/api/generated/@tanstack/react-query.gen.ts
@@ -1817,6 +1817,7 @@ export const getRoutesQueryKey = (options?: Options<GetRoutesData>) =>
  * When unassigned_only is False, returns all routes (no assignment filter).
  * When unassigned_only is True, returns only routes that are unassigned for the given route group.
  *
+ * Requires a driver or admin caller.
  * Admins may scope to any driver via driver_id (or omit it for all routes).
  * Drivers are always scoped to their own routes: omitting driver_id returns
  * their own routes, and requesting another driver's is rejected.
@@ -1853,6 +1854,7 @@ export const getRoutesInfiniteQueryKey = (
  * When unassigned_only is False, returns all routes (no assignment filter).
  * When unassigned_only is True, returns only routes that are unassigned for the given route group.
  *
+ * Requires a driver or admin caller.
  * Admins may scope to any driver via driver_id (or omit it for all routes).
  * Drivers are always scoped to their own routes: omitting driver_id returns
  * their own routes, and requesting another driver's is rejected.

--- a/frontend/src/api/generated/@tanstack/react-query.gen.ts
+++ b/frontend/src/api/generated/@tanstack/react-query.gen.ts
@@ -1816,6 +1816,7 @@ export const getRoutesQueryKey = (options?: Options<GetRoutesData>) =>
  * Returns routes with their drive dates - routes can appear multiple times for different dates.
  * When unassigned_only is False, returns all routes (no assignment filter).
  * When unassigned_only is True, returns only routes that are unassigned for the given route group.
+ * When driver_id is set, returns only routes assigned to that driver.
  */
 export const getRoutesOptions = (options?: Options<GetRoutesData>) =>
   queryOptions<
@@ -1848,6 +1849,7 @@ export const getRoutesInfiniteQueryKey = (
  * Returns routes with their drive dates - routes can appear multiple times for different dates.
  * When unassigned_only is False, returns all routes (no assignment filter).
  * When unassigned_only is True, returns only routes that are unassigned for the given route group.
+ * When driver_id is set, returns only routes assigned to that driver.
  */
 export const getRoutesInfiniteOptions = (options?: Options<GetRoutesData>) =>
   infiniteQueryOptions<

--- a/frontend/src/api/generated/sdk.gen.ts
+++ b/frontend/src/api/generated/sdk.gen.ts
@@ -1173,6 +1173,7 @@ export const updateRouteGroup = <ThrowOnError extends boolean = false>(
  * Returns routes with their drive dates - routes can appear multiple times for different dates.
  * When unassigned_only is False, returns all routes (no assignment filter).
  * When unassigned_only is True, returns only routes that are unassigned for the given route group.
+ * When driver_id is set, returns only routes assigned to that driver.
  */
 export const getRoutes = <ThrowOnError extends boolean = false>(
   options?: Options<GetRoutesData, ThrowOnError>

--- a/frontend/src/api/generated/sdk.gen.ts
+++ b/frontend/src/api/generated/sdk.gen.ts
@@ -1174,6 +1174,7 @@ export const updateRouteGroup = <ThrowOnError extends boolean = false>(
  * When unassigned_only is False, returns all routes (no assignment filter).
  * When unassigned_only is True, returns only routes that are unassigned for the given route group.
  *
+ * Requires a driver or admin caller.
  * Admins may scope to any driver via driver_id (or omit it for all routes).
  * Drivers are always scoped to their own routes: omitting driver_id returns
  * their own routes, and requesting another driver's is rejected.

--- a/frontend/src/api/generated/sdk.gen.ts
+++ b/frontend/src/api/generated/sdk.gen.ts
@@ -1173,7 +1173,10 @@ export const updateRouteGroup = <ThrowOnError extends boolean = false>(
  * Returns routes with their drive dates - routes can appear multiple times for different dates.
  * When unassigned_only is False, returns all routes (no assignment filter).
  * When unassigned_only is True, returns only routes that are unassigned for the given route group.
- * When driver_id is set, returns only routes assigned to that driver.
+ *
+ * Admins may scope to any driver via driver_id (or omit it for all routes).
+ * Drivers are always scoped to their own routes: omitting driver_id returns
+ * their own routes, and requesting another driver's is rejected.
  */
 export const getRoutes = <ThrowOnError extends boolean = false>(
   options?: Options<GetRoutesData, ThrowOnError>

--- a/frontend/src/api/generated/types.gen.ts
+++ b/frontend/src/api/generated/types.gen.ts
@@ -3378,12 +3378,6 @@ export type GetRoutesData = {
      */
     unassigned_only?: boolean;
     /**
-     * Driver Id
-     *
-     * If set, only return routes assigned to this driver. Powers the driver homepage feed.
-     */
-    driver_id?: string | null;
-    /**
      * Start Date
      *
      * Filter route groups from this date
@@ -3407,6 +3401,12 @@ export type GetRoutesData = {
      * Number of items per page
      */
     page_size?: number;
+    /**
+     * Driver Id
+     *
+     * Filter routes by assigned driver. Admins may pass any driver_id, or omit it to get all routes. Drivers are always scoped to themselves: omitting it returns their own routes, and passing another driver's id is rejected with 403.
+     */
+    driver_id?: string | null;
   };
   url: '/routes';
 };

--- a/frontend/src/api/generated/types.gen.ts
+++ b/frontend/src/api/generated/types.gen.ts
@@ -3378,6 +3378,12 @@ export type GetRoutesData = {
      */
     unassigned_only?: boolean;
     /**
+     * Driver Id
+     *
+     * If set, only return routes assigned to this driver. Powers the driver homepage feed.
+     */
+    driver_id?: string | null;
+    /**
      * Start Date
      *
      * Filter route groups from this date


### PR DESCRIPTION
## What

Adds an optional `driver_id` query param to `GET /routes` so the driver homepage can fetch a single driver's routes in one request.

## Why

- The old `GET /driver-assignments/me` endpoint was removed by the refactor I did in #147 (so there was no way to get a driver's routes) and this replaces it.

## Changes

- `driver_id` threads `route_routes.get_routes` → `route_service.get_routes`, adding `WHERE Route.driver_id == driver_id`.
- Combining `driver_id` with `unassigned_only` returns **400** — a route can't be both unassigned and assigned to a specific driver (fail fast rather than silently returning nothing).
- Tests: filter returns only that driver's routes (excludes other drivers + unassigned), empty page for a driver with none, and the 400 guard.
- Regenerated `frontend/openapi.json` + TS client for the new param.
