### PR TITLE
route list counts

### DIFF
--- a/backend/python/app/models/route.py
+++ b/backend/python/app/models/route.py
@@ -137,6 +137,8 @@ class RouteWithDateRead(SQLModel):
     notes: str
     length: float
     drive_date: datetime
+    num_stops: int
+    box_total: int
 
 
 class SuggestedDriverResponse(SQLModel):

--- a/backend/python/app/services/implementations/route_service.py
+++ b/backend/python/app/services/implementations/route_service.py
@@ -3,7 +3,7 @@ from datetime import datetime, timezone
 from uuid import UUID
 
 from fastapi import HTTPException
-from sqlalchemy import func
+from sqlalchemy import Integer, case, cast, func
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import col, select
 
@@ -18,6 +18,7 @@ from app.models.route import (
 from app.models.route_group import RouteGroup
 from app.models.route_snapshot import RouteSnapshot
 from app.models.route_stop import RouteStop
+from app.models.route_stop_snapshot import RouteStopSnapshot
 from app.models.system_settings import SystemSettings
 from app.models.user import User
 from app.schemas.pagination import PaginatedResponse, PaginationParams
@@ -57,13 +58,31 @@ class RouteService:
         to routes assigned to that specific driver (powers the driver homepage
         feed). The date range filters on the route's RouteGroup.drive_date.
         """
+        live_box_count = case(
+            (
+                col(Location.num_children).isnot(None),
+                cast(func.ceil(col(Location.num_children) / 2.0), Integer),
+            ),
+            else_=col(Location.num_boxes),
+        )
+
         route_totals = (
             select(
                 col(RouteStop.route_id).label("route_id"),
                 func.count(col(RouteStop.route_stop_id)).label("num_stops"),
-                func.coalesce(func.sum(col(Location.num_boxes)), 0).label("box_total"),
+                func.coalesce(
+                    func.sum(func.coalesce(RouteStopSnapshot.num_boxes, live_box_count)),
+                    0,
+                ).label("box_total"),
             )
-            .join(Location, col(Location.location_id) == col(RouteStop.location_id))
+            .select_from(RouteStop)
+            .outerjoin(
+                RouteStopSnapshot,
+                RouteStopSnapshot.route_stop_id == RouteStop.route_stop_id,  # type: ignore[arg-type]
+            )
+            .outerjoin(
+                Location, col(Location.location_id) == col(RouteStop.location_id)
+            )
             .group_by(col(RouteStop.route_id))
             .subquery()
         )

--- a/backend/python/app/services/implementations/route_service.py
+++ b/backend/python/app/services/implementations/route_service.py
@@ -71,7 +71,9 @@ class RouteService:
                 col(RouteStop.route_id).label("route_id"),
                 func.count(col(RouteStop.route_stop_id)).label("num_stops"),
                 func.coalesce(
-                    func.sum(func.coalesce(RouteStopSnapshot.num_boxes, live_box_count)),
+                    func.sum(
+                        func.coalesce(RouteStopSnapshot.num_boxes, live_box_count)
+                    ),
                     0,
                 ).label("box_total"),
             )

--- a/backend/python/app/services/implementations/route_service.py
+++ b/backend/python/app/services/implementations/route_service.py
@@ -57,9 +57,31 @@ class RouteService:
         to routes assigned to that specific driver (powers the driver homepage
         feed). The date range filters on the route's RouteGroup.drive_date.
         """
-        statement = select(Route, RouteGroup.drive_date).join(
-            RouteGroup,
-            RouteGroup.route_group_id == Route.route_group_id,  # type: ignore[arg-type]
+        route_totals = (
+            select(
+                RouteStop.route_id.label("route_id"),
+                func.count(RouteStop.route_stop_id).label("num_stops"),
+                func.coalesce(func.sum(Location.num_boxes), 0).label("box_total"),
+            )
+            .join(Location, Location.location_id == RouteStop.location_id)
+            .group_by(RouteStop.route_id)
+            .subquery()
+        )
+
+        statement = (
+            select(
+                Route,
+                RouteGroup.drive_date,
+                func.coalesce(route_totals.c.num_stops, 0).label("num_stops"),
+                func.coalesce(route_totals.c.box_total, 0).label("box_total"),
+            )
+            .join(
+                RouteGroup,
+                RouteGroup.route_group_id == Route.route_group_id,  # type: ignore[arg-type]
+            )
+        )
+        statement = statement.outerjoin(
+            route_totals, route_totals.c.route_id == Route.route_id
         )
 
         if start_date:
@@ -90,6 +112,8 @@ class RouteService:
                 notes=row.Route.notes,
                 length=row.Route.length,
                 drive_date=row.drive_date,
+                num_stops=row.num_stops,
+                box_total=row.box_total,
             )
             for row in rows
         ]

--- a/backend/python/app/services/implementations/route_service.py
+++ b/backend/python/app/services/implementations/route_service.py
@@ -68,17 +68,14 @@ class RouteService:
             .subquery()
         )
 
-        statement = (
-            select(
-                Route,
-                RouteGroup.drive_date,
-                func.coalesce(route_totals.c.num_stops, 0).label("num_stops"),
-                func.coalesce(route_totals.c.box_total, 0).label("box_total"),
-            )
-            .join(
-                RouteGroup,
-                RouteGroup.route_group_id == Route.route_group_id,  # type: ignore[arg-type]
-            )
+        statement = select(
+            Route,
+            RouteGroup.drive_date,
+            func.coalesce(route_totals.c.num_stops, 0).label("num_stops"),
+            func.coalesce(route_totals.c.box_total, 0).label("box_total"),
+        ).join(
+            RouteGroup,
+            RouteGroup.route_group_id == Route.route_group_id,  # type: ignore[arg-type]
         )
         statement = statement.outerjoin(
             route_totals, route_totals.c.route_id == Route.route_id

--- a/backend/python/app/services/implementations/route_service.py
+++ b/backend/python/app/services/implementations/route_service.py
@@ -59,12 +59,12 @@ class RouteService:
         """
         route_totals = (
             select(
-                RouteStop.route_id.label("route_id"),
-                func.count(RouteStop.route_stop_id).label("num_stops"),
-                func.coalesce(func.sum(Location.num_boxes), 0).label("box_total"),
+                col(RouteStop.route_id).label("route_id"),
+                func.count(col(RouteStop.route_stop_id)).label("num_stops"),
+                func.coalesce(func.sum(col(Location.num_boxes)), 0).label("box_total"),
             )
-            .join(Location, Location.location_id == RouteStop.location_id)
-            .group_by(RouteStop.route_id)
+            .join(Location, col(Location.location_id) == col(RouteStop.location_id))
+            .group_by(col(RouteStop.route_id))
             .subquery()
         )
 

--- a/backend/python/tests/test_auth_integration.py
+++ b/backend/python/tests/test_auth_integration.py
@@ -250,8 +250,12 @@ class Seed(SimpleNamespace):
 async def seed(test_session: AsyncSession) -> Seed:
     """Create the minimal records the auth dependencies look up by auth_id."""
     from app.models.driver import Driver
+    from app.models.enum import DeliveryTypeEnum
+    from app.models.location import Location
+    from app.models.location_group import LocationGroup
     from app.models.route import Route
     from app.models.route_group import RouteGroup
+    from app.models.route_stop import RouteStop
     from app.models.user import User
 
     def _driver(auth_id: str, email: str) -> Driver:
@@ -275,6 +279,11 @@ async def seed(test_session: AsyncSession) -> Seed:
 
     self_driver = _driver("self-uid", "self@test.dev")
     other_driver = _driver("other-uid", "other@test.dev")
+    location_group = LocationGroup(
+        name="Seed Location Group",
+        color="#FF5733",
+        notes="",
+    )
 
     admin_user = User(
         first_name="Admin",
@@ -284,6 +293,7 @@ async def seed(test_session: AsyncSession) -> Seed:
         role="admin",
     )
     test_session.add(admin_user)
+    test_session.add(location_group)
 
     route_group = RouteGroup(name="Test Group", drive_date=datetime(2025, 3, 1, 8, 0))
     test_session.add(route_group)
@@ -301,9 +311,27 @@ async def seed(test_session: AsyncSession) -> Seed:
         route_group_id=route_group.route_group_id,
         driver_id=self_driver.driver_id,
     )
-    test_session.add(route)
+    location = Location(
+        location_group_id=location_group.location_group_id,
+        name="Seed Location",
+        contact_name="Seed Location",
+        address="123 Seed St",
+        phone_primary="5550000001",
+        num_boxes=4,
+        delivery_type=DeliveryTypeEnum.FAMILY,
+    )
+    test_session.add_all([route, location])
     await test_session.commit()
     await test_session.refresh(route)
+    await test_session.refresh(location)
+    test_session.add(
+        RouteStop(
+            route_id=route.route_id,
+            location_id=location.location_id,
+            stop_number=1,
+        )
+    )
+    await test_session.commit()
 
     return Seed(
         self_driver_id=self_driver.driver_id,
@@ -497,6 +525,10 @@ def _route_ids(resp: Any) -> set[str]:
     return {item["route_id"] for item in resp.json()["items"]}
 
 
+def _route_by_id(resp: Any, route_id: str) -> dict[str, Any]:
+    return next(item for item in resp.json()["items"] if item["route_id"] == route_id)
+
+
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("firebase_auth_mock")
 class TestGetRoutesDriverScoping:
@@ -511,6 +543,9 @@ class TestGetRoutesDriverScoping:
         assert resp.status_code == 200
         ids = _route_ids(resp)
         assert ids == {scoping_routes["self_route_id"]}
+        route = _route_by_id(resp, scoping_routes["self_route_id"])
+        assert route["num_stops"] == 1
+        assert route["box_total"] == 4
 
     async def test_driver_scoped_to_self_is_allowed(
         self, auth_client: AsyncClient, seed: Seed, scoping_routes: dict[str, Any]
@@ -523,6 +558,9 @@ class TestGetRoutesDriverScoping:
         )
         assert resp.status_code == 200
         assert _route_ids(resp) == {scoping_routes["self_route_id"]}
+        route = _route_by_id(resp, scoping_routes["self_route_id"])
+        assert route["num_stops"] == 1
+        assert route["box_total"] == 4
 
     async def test_driver_cannot_request_another_drivers_routes(
         self,
@@ -565,6 +603,9 @@ class TestGetRoutesDriverScoping:
             scoping_routes["other_route_id"],
             scoping_routes["unassigned_route_id"],
         }
+        route = _route_by_id(resp, scoping_routes["self_route_id"])
+        assert route["num_stops"] == 1
+        assert route["box_total"] == 4
 
     async def test_driver_unassigned_only_is_rejected(
         self,

--- a/backend/python/tests/test_routes.py
+++ b/backend/python/tests/test_routes.py
@@ -9,7 +9,7 @@ Tests cover:
 - Error handling (404s, validation errors)
 """
 
-from datetime import datetime, timedelta, timezone
+from datetime import date, datetime, timedelta, timezone
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
@@ -1051,7 +1051,8 @@ class TestRouteRoutes:
             contact_name="Route Stop A",
             address="1 Route St",
             phone_primary="5550000001",
-            num_boxes=3,
+            num_children=6,
+            num_boxes=99,
             delivery_type=DeliveryTypeEnum.FAMILY,
         )
         loc_b = Location(
@@ -1094,6 +1095,98 @@ class TestRouteRoutes:
         )
         assert route["num_stops"] == 2
         assert route["box_total"] == 8
+
+    @pytest.mark.asyncio
+    async def test_get_routes_uses_snapshotted_box_totals_for_frozen_routes(
+        self,
+        async_client: AsyncClient,
+        test_session: AsyncSession,
+        test_location_group: Any,
+    ) -> None:
+        """GET /routes uses frozen stop snapshots for completed routes."""
+        from app.models.location import Location
+        from app.models.route import Route
+        from app.models.route_group import RouteGroup
+        from app.models.route_snapshot import RouteSnapshot
+        from app.models.route_stop import RouteStop
+        from app.models.route_stop_snapshot import RouteStopSnapshot
+
+        past_group = RouteGroup(
+            name="Past Route Group",
+            notes="",
+            drive_date=datetime.combine(
+                date.today() - timedelta(days=7), datetime.min.time()
+            ),
+        )
+        loc = Location(
+            location_group_id=test_location_group.location_group_id,
+            name="Frozen Stop",
+            contact_name="Frozen Stop",
+            address="1 Frozen St",
+            phone_primary="5550000009",
+            num_children=6,
+            num_boxes=99,
+            delivery_type=DeliveryTypeEnum.FAMILY,
+        )
+        test_session.add_all([past_group, loc])
+        await test_session.commit()
+        await test_session.refresh(past_group)
+        await test_session.refresh(loc)
+
+        route = Route(
+            name="Frozen Route",
+            length=4.0,
+            route_group_id=past_group.route_group_id,
+        )
+        test_session.add(route)
+        await test_session.commit()
+        await test_session.refresh(route)
+
+        stop = RouteStop(
+            route_id=route.route_id,
+            location_id=loc.location_id,
+            stop_number=1,
+        )
+        test_session.add(stop)
+        await test_session.commit()
+        await test_session.refresh(stop)
+
+        test_session.add(
+            RouteSnapshot(
+                route_id=route.route_id,
+                start_address="Warehouse",
+                start_latitude=0.0,
+                start_longitude=0.0,
+            )
+        )
+        test_session.add(
+            RouteStopSnapshot(
+                route_stop_id=stop.route_stop_id,
+                address=loc.address,
+                contact_name=loc.contact_name,
+                phone_number=loc.phone_primary,
+                num_boxes=4,
+                notes=loc.notes,
+                latitude=loc.latitude or 0.0,
+                longitude=loc.longitude or 0.0,
+            )
+        )
+        await test_session.commit()
+
+        # Mutate the live location after the route is frozen; the list should
+        # still read the snapshotted count.
+        loc.num_children = 1
+        loc.num_boxes = 1
+        await test_session.commit()
+
+        response = await async_client.get("/routes")
+        assert response.status_code == 200
+        data = response.json()
+        route_item = next(
+            item for item in data["items"] if item["route_id"] == str(route.route_id)
+        )
+        assert route_item["num_stops"] == 1
+        assert route_item["box_total"] == 4
 
     @pytest.mark.asyncio
     async def test_get_route_by_id(

--- a/backend/python/tests/test_routes.py
+++ b/backend/python/tests/test_routes.py
@@ -1088,7 +1088,9 @@ class TestRouteRoutes:
         data = response.json()
         assert isinstance(data["items"], list)
         route = next(
-            item for item in data["items"] if item["route_id"] == str(test_route.route_id)
+            item
+            for item in data["items"]
+            if item["route_id"] == str(test_route.route_id)
         )
         assert route["num_stops"] == 2
         assert route["box_total"] == 8

--- a/backend/python/tests/test_routes.py
+++ b/backend/python/tests/test_routes.py
@@ -1037,13 +1037,61 @@ class TestRouteRoutes:
     async def test_get_routes_with_data(
         self,
         async_client: AsyncClient,
-        test_route: Any,  # noqa: ARG002
+        test_session: AsyncSession,
+        test_route: Any,
+        test_location_group: Any,
     ) -> None:
         """Test GET /routes returns paginated list of routes."""
+        from app.models.location import Location
+        from app.models.route_stop import RouteStop
+
+        loc_a = Location(
+            location_group_id=test_location_group.location_group_id,
+            name="Route Stop A",
+            contact_name="Route Stop A",
+            address="1 Route St",
+            phone_primary="5550000001",
+            num_boxes=3,
+            delivery_type=DeliveryTypeEnum.FAMILY,
+        )
+        loc_b = Location(
+            location_group_id=test_location_group.location_group_id,
+            name="Route Stop B",
+            contact_name="Route Stop B",
+            address="2 Route St",
+            phone_primary="5550000002",
+            num_boxes=5,
+            delivery_type=DeliveryTypeEnum.FAMILY,
+        )
+        test_session.add_all([loc_a, loc_b])
+        await test_session.commit()
+        await test_session.refresh(loc_a)
+        await test_session.refresh(loc_b)
+        test_session.add_all(
+            [
+                RouteStop(
+                    route_id=test_route.route_id,
+                    location_id=loc_a.location_id,
+                    stop_number=1,
+                ),
+                RouteStop(
+                    route_id=test_route.route_id,
+                    location_id=loc_b.location_id,
+                    stop_number=2,
+                ),
+            ]
+        )
+        await test_session.commit()
+
         response = await async_client.get("/routes")
         assert response.status_code == 200
         data = response.json()
         assert isinstance(data["items"], list)
+        route = next(
+            item for item in data["items"] if item["route_id"] == str(test_route.route_id)
+        )
+        assert route["num_stops"] == 2
+        assert route["box_total"] == 8
 
     @pytest.mark.asyncio
     async def test_get_route_by_id(

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -2842,6 +2842,10 @@
       "RouteWithDateRead": {
         "description": "Read response model for routes with drive date information.\n\ndrive_date is sourced from RouteGroup.drive_date via the route_group\nrelationship.",
         "properties": {
+          "box_total": {
+            "title": "Box Total",
+            "type": "integer"
+          },
           "drive_date": {
             "format": "date-time",
             "title": "Drive Date",
@@ -2859,6 +2863,10 @@
             "title": "Notes",
             "type": "string"
           },
+          "num_stops": {
+            "title": "Num Stops",
+            "type": "integer"
+          },
           "route_id": {
             "format": "uuid",
             "title": "Route Id",
@@ -2870,7 +2878,9 @@
           "name",
           "notes",
           "length",
-          "drive_date"
+          "drive_date",
+          "num_stops",
+          "box_total"
         ],
         "title": "RouteWithDateRead",
         "type": "object"

--- a/frontend/src/api/generated/types.gen.ts
+++ b/frontend/src/api/generated/types.gen.ts
@@ -1624,13 +1624,13 @@ export type RouteStatusEnum = 'Upcoming' | 'Completed' | 'Archived';
  */
 export type RouteWithDateRead = {
   /**
-   * Drive Date
-   */
-  drive_date: string;
-  /**
    * Box Total
    */
   box_total: number;
+  /**
+   * Drive Date
+   */
+  drive_date: string;
   /**
    * Length
    */
@@ -1644,13 +1644,13 @@ export type RouteWithDateRead = {
    */
   notes: string;
   /**
-   * Route Id
-   */
-  route_id: string;
-  /**
    * Num Stops
    */
   num_stops: number;
+  /**
+   * Route Id
+   */
+  route_id: string;
 };
 
 /**

--- a/frontend/src/api/generated/types.gen.ts
+++ b/frontend/src/api/generated/types.gen.ts
@@ -1628,6 +1628,10 @@ export type RouteWithDateRead = {
    */
   drive_date: string;
   /**
+   * Box Total
+   */
+  box_total: number;
+  /**
    * Length
    */
   length: number;
@@ -1643,6 +1647,10 @@ export type RouteWithDateRead = {
    * Route Id
    */
   route_id: string;
+  /**
+   * Num Stops
+   */
+  num_stops: number;
 };
 
 /**


### PR DESCRIPTION
Adds per-route stop and box totals to GET /routes so the route list can show summary counts without loading every stop.

Validated with backend route/auth integration tests, Ruff, and OpenAPI sync.