### PR TITLE
Design system: bake Figma text weights into text-p1 and text-button

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -122,15 +122,20 @@ don't borrow `text-h3`.
 **`text-p1/p2/p3` are responsive** — Mobile/Pn below the `tablet` breakpoint,
 Desktop/Pn from tablet up. This is the default for body/paragraph text:
 
-| Class     | Mobile (<500px) | Tablet & Desktop (≥500px) |
-| --------- | --------------- | ------------------------- |
-| `text-p1` | 18px / 1.333    | 16px / 1.5                |
-| `text-p2` | 16px / 1.5      | 14px / 1.286              |
-| `text-p3` | 14px / 1.286    | 12px / 1.5                |
+| Class     | Mobile (<500px)        | Tablet & Desktop (≥500px) |
+| --------- | ---------------------- | ------------------------- |
+| `text-p1` | 18px / 1.333 · Regular | 16px / 1.5 · **Medium**   |
+| `text-p2` | 16px / 1.5 · Regular   | 14px / 1.286 · Regular    |
+| `text-p3` | 14px / 1.286 · Regular | 12px / 1.5 · Regular      |
 
 ```tsx
 <p className="text-p1">Body text</p> // one class, adapts at the breakpoint
 ```
+
+**Weight is baked in.** Per Figma, P1's weight is responsive — Regular on
+mobile, **Medium** from tablet up — so `text-p1` sets it for you. P2/P3 are
+Regular (the default) at every tier. Don't add a `font-*` utility to override
+`text-p1`'s weight.
 
 For the rare element whose size must **not** change across tiers, use the
 static **`text-m-p1/p2/p3`** utilities (the Mobile sizes — 18 / 16 / 14px):
@@ -139,6 +144,12 @@ static **`text-m-p1/p2/p3`** utilities (the Mobile sizes — 18 / 16 / 14px):
 // inputs are 16px at every width → the static Mobile/P2 size
 <input className="text-m-p2" />
 ```
+
+**Ramp gotcha.** The mobile and desktop scales are offset by one tier, so
+"16px body text" is **P2 (Regular) on mobile** but **P1 (Medium) on desktop**.
+For a constant-16px element that should pick up Medium on larger screens (e.g.
+the login subtitle/footer/links), reach for `text-m-p2 tablet:font-medium` —
+_not_ `text-p1`, which would also shrink the size 18→16.
 
 (For now, there's no static `text-d-*` family, but we can add it later if needed.)
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -114,8 +114,8 @@ binds tabs to H3). Don't put a `tablet:`/`desktop:` variant on them (already
 responsive).
 
 For **constant-size UI text** that is _not_ a heading — buttons — use
-**`text-button`** (Nunito 16px/20px, fixed at every width). It's why buttons
-don't borrow `text-h3`.
+**`text-button`** (Nunito **Medium** 16px/20px, fixed at every width; the
+weight is baked in). It's why buttons don't borrow `text-h3`.
 
 ### Paragraph Utilities
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -163,9 +163,21 @@
  * Desktop/Pn from tablet up. This is the default for body/paragraph text:
  *   text-p1 → 18→16px   text-p2 → 16→14px   text-p3 → 14→12px
  *
- * text-m-p1/p2/p3 are STATIC (Mobile sizes, 18/16/14) — for the rare element
- * whose size must stay constant across tiers (e.g. a 16px-everywhere field →
- * text-m-p2). Generated from the @theme --text-m-* tokens above.
+ * WEIGHT is part of the style. Per Figma, only P1 is non-Regular, and its
+ * weight is RESPONSIVE: Mobile/P1 is Regular (400), Desktop/P1 is Medium (500)
+ * — so text-p1 sets font-weight 400→500 itself (you can't express a per-tier
+ * weight with a single font-* utility). P2 and P3 are Regular (400) at every
+ * tier, i.e. the browser default, so text-p2/p3 don't set a weight.
+ *
+ * text-m-p1/p2/p3 are STATIC (Mobile sizes, 18/16/14, all Regular) — for the
+ * rare element whose size must stay constant across tiers (e.g. a 16px-
+ * everywhere field → text-m-p2). Generated from the @theme --text-m-* tokens.
+ *
+ * Ramp gotcha: the mobile and desktop scales are offset by one tier, so
+ * "16px body text" is P2 (Regular) on mobile but P1 (Medium) on desktop. For a
+ * constant-16px element that should pick up Medium on larger screens (e.g. the
+ * login subtitle/footer), use `text-m-p2 tablet:font-medium` — NOT text-p1,
+ * which would also shrink the size 18→16.
  *
  * The Desktop paragraph values live in :root (NOT @theme) on purpose: a
  * --text-* token in @theme would make Tailwind auto-generate a STATIC
@@ -223,9 +235,11 @@
 @utility text-p1 {
   font-size: var(--text-m-p1);
   line-height: var(--text-m-p1--line-height);
+  font-weight: 400; /* Mobile/P1: Nunito Sans Regular */
   @media (width >= theme(--breakpoint-tablet)) {
     font-size: var(--text-p1);
     line-height: var(--text-p1--line-height);
+    font-weight: 500; /* Desktop/P1: Nunito Sans Medium */
   }
 }
 @utility text-p2 {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -76,9 +76,12 @@
 
   /* UI/Button — a non-tier-scaled UI style (Nunito Medium, 16px/20px, constant
    * across breakpoints). Its own static token so buttons don't borrow a
-   * responsive heading size. */
+   * responsive heading size. The Medium weight is baked in (overridable by a
+   * later font-* utility) so `text-button` matches the Figma UI/Button style on
+   * its own. */
   --text-button: 1rem; /* 16px */
   --text-button--line-height: 1.25;
+  --text-button--font-weight: 500; /* Nunito Medium */
 
   /* --- Typography Scale: Mobile ---
    * text-m-* are STATIC utilities for the mobile sizes. They back the

--- a/frontend/src/pages/StyleGuide/sections/TypekitSection.tsx
+++ b/frontend/src/pages/StyleGuide/sections/TypekitSection.tsx
@@ -79,9 +79,9 @@ export function TypekitSection() {
               />
               <TypekitRow
                 label="UI/Button"
-                className="text-h3 text-grey-500 font-bold"
-                spec="Nunito | Text size: 16px | Line height: 20px"
-                code="font-nunito font-bold"
+                className="font-nunito text-button text-grey-500"
+                spec="Nunito Medium | Text size: 16px | Line height: 20px"
+                code="font-nunito text-button"
               />
             </div>
           </div>
@@ -146,9 +146,9 @@ export function TypekitSection() {
               />
               <TypekitRow
                 label="UI/Button"
-                className="text-h3 text-grey-500 font-bold"
-                spec="Nunito | Text size: 16px | Line height: 20px"
-                code="font-nunito font-bold"
+                className="font-nunito text-button text-grey-500"
+                spec="Nunito Medium | Text size: 16px | Line height: 20px"
+                code="font-nunito text-button"
               />
             </div>
           </div>

--- a/frontend/src/pages/StyleGuide/sections/TypekitSection.tsx
+++ b/frontend/src/pages/StyleGuide/sections/TypekitSection.tsx
@@ -61,8 +61,8 @@ export function TypekitSection() {
               />
               <TypekitRow
                 label="Desktop/Paragraph/P1"
-                className="text-grey-500 text-[var(--text-p1)]"
-                spec="Nunito Sans | Text size: 16px | Line height: 20px"
+                className="text-grey-500 font-medium text-[var(--text-p1)]"
+                spec="Nunito Sans Medium | Text size: 16px | Line height: 24px"
                 code="text-p1"
               />
               <TypekitRow


### PR DESCRIPTION
## What & why

Our `text-*` design tokens encoded **size + line-height but not weight**, so
text rendered Regular (400) everywhere unless a `font-*` utility was added by
hand. But the Figma type styles bake weight in — and two of them aren't
Regular. Result: text was rendering one step too light vs the design (the
login footer looking off is what surfaced this).

Audit of the finalized Figma Typekit:

| Style | Size | Weight |
| --- | --- | --- |
| Mobile/P1 | 18 | Regular (400) |
| **Desktop/P1** | 16 | **Medium (500)** |
| P2 (both tiers) | 16→14 | Regular (400) |
| P3 (both tiers) | 14→12 | Regular (400) |
| **UI/Button** | 16 | **Medium (500)** |

So only **Desktop/P1** and **UI/Button** are non-Regular.

## Changes

- **`text-p1`** now sets `font-weight: 400 → 500` at the tablet breakpoint
  (Mobile/P1 Regular → Desktop/P1 Medium). P2/P3 stay Regular (the default).
- **`text-button`** now carries `--text-button--font-weight: 500`, so buttons
  render Nunito Medium on their own (Button.variants previously applied
  `font-nunito text-button` with no weight → buttons were Regular).
- **StyleGuide** Typekit: Desktop/P1 and both UI/Button rows now render the
  correct weights (UI/Button no longer uses `text-h3 font-bold`), with accurate
  specs/line-heights.
- **Docs** (`index.css` + `README`): document the weight model and the
  type-ramp gotcha — "16px body text" is P2 (Regular) on mobile but P1 (Medium)
  on desktop, so a constant-16px element that should darken on desktop uses
  `text-m-p2 tablet:font-medium`, not `text-p1`.

## Behavior change (intended)

- Bare `text-p1` is now **Medium on desktop/tablet** app-wide (matches design).
- Buttons now render **Nunito Medium** (matches UI/Button).
- Explicit `font-*` utilities still win (emitted after the token, equal
  specificity), so the ~15 components combining `text-p1` with
  `font-medium/semibold/bold` are unchanged.

## Verification

- `eslint --max-warnings=0`, `tsc -b && vite build`, `prettier --check` all pass.
- Runtime probe of the built output:
  - `text-p1` (bare): **400 mobile / 500 desktop**; `text-p1 font-bold` = 700 both tiers.
  - `font-nunito text-button` and a real `<button>`: **500**, 16px/20px.

## Out of scope

The login page's 16px secondary text (subtitle/footer/links) needs the
call-site `text-m-p2 tablet:font-medium` pattern — that lives on Hy Lac's login
PR and will be handled via review comments there, not here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
