### PR TITLE
Frontend: use generated RouteGroupRead for the Groups tab

### DIFF
--- a/frontend/src/api/route-groups.ts
+++ b/frontend/src/api/route-groups.ts
@@ -1,47 +1,22 @@
 import { useQuery } from '@tanstack/react-query';
 
-import axiosClient from '@/lib/axiosClient';
+import { getRouteGroupsOptions } from './generated/@tanstack/react-query.gen';
+import type { GetRouteGroupsData } from './generated/types.gen';
 
-// WIP shell: this hook is still hand-written, and RouteGroupRow is the shape
-// the Groups tab wants — not a generated API type, since the backend doesn't
-// return these aggregates yet (F4KRP-196). When it does, swap RouteGroupRow
-// for the generated type here and convert useRouteGroups to the generated
-// client; consumers importing RouteGroupRow from this module stay unchanged.
-export type RouteStatus = 'Upcoming' | 'Completed' | 'Archived';
-
-export interface RouteGroupRow {
-  id: string;
-  name: string;
-  date: string;
-  delivery_type: string;
-  num_routes: number;
-  num_locations: number;
-  num_boxes: number;
-  num_drivers_assigned: number;
-  status: RouteStatus;
-}
-
-export interface RouteGroupsParams {
-  search?: string;
-  weekdays?: string[];
-  deliveryTypes?: string[];
-  routeStatuses?: string[];
-  driverStatuses?: string[];
-}
-
-async function fetchRouteGroups(
-  params: RouteGroupsParams
-): Promise<RouteGroupRow[]> {
-  const response = await axiosClient.get<RouteGroupRow[]>('/route-groups', {
-    params,
-  });
-  return response.data;
-}
-
-export function useRouteGroups(params: RouteGroupsParams) {
+/**
+ * Fetch the (filtered) list of route groups for the admin routes "Groups" tab.
+ *
+ * The aggregate fields the tab renders (num_locations, num_boxes,
+ * num_drivers_assigned, delivery_type, status) are computed server-side and
+ * returned on RouteGroupRead (F4KRP-196). Consumers should import that
+ * generated type rather than a hand-written row shape.
+ *
+ * GET /route-groups has no full-text search param yet, so the tab's search box
+ * is local-only UI for now — only the filter chips hit the server.
+ */
+export function useRouteGroups(query: GetRouteGroupsData['query']) {
   return useQuery({
-    queryKey: ['route-groups', params],
-    queryFn: () => fetchRouteGroups(params),
+    ...getRouteGroupsOptions({ query }),
     placeholderData: [],
   });
 }

--- a/frontend/src/pages/admin/routes/components/RouteGroupsTab.tsx
+++ b/frontend/src/pages/admin/routes/components/RouteGroupsTab.tsx
@@ -1,6 +1,12 @@
 import { Link } from 'react-router-dom';
 
-import type { RouteGroupRow } from '@/api/route-groups';
+import type {
+  DeliveryTypeEnum,
+  DriveDaysOfWeekEnum,
+  DriverAssignmentStatusEnum,
+  RouteGroupRead,
+  RouteStatusEnum,
+} from '@/api/generated/types.gen';
 import FilterLinesIcon from '@/assets/icons/filter-lines.svg?react';
 import ShareIcon from '@/assets/icons/share.svg?react';
 import type { Column } from '@/common/components';
@@ -21,14 +27,17 @@ import {
 import type { GroupsTabState } from '../hooks';
 import { EmptyState } from './EmptyState';
 
-const WEEKDAYS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri'];
-const DELIVERY_TYPES = ['School', 'Family'];
-const ROUTE_STATUSES = ['Upcoming', 'Completed', 'Archived'];
-const DRIVER_STATUSES = ['Assigned', 'Unassigned'];
+const WEEKDAYS: DriveDaysOfWeekEnum[] = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri'];
+const DELIVERY_TYPES: DeliveryTypeEnum[] = ['School', 'Family'];
+const ROUTE_STATUSES: RouteStatusEnum[] = ['Upcoming', 'Completed', 'Archived'];
+const DRIVER_STATUSES: DriverAssignmentStatusEnum[] = [
+  'Assigned',
+  'Unassigned',
+];
 
-const COLUMNS: Column<RouteGroupRow>[] = [
+const COLUMNS: Column<RouteGroupRead>[] = [
   { key: 'name', header: 'Name', render: (row) => row.name },
-  { key: 'date', header: 'Date', render: (row) => row.date },
+  { key: 'drive_date', header: 'Date', render: (row) => row.drive_date },
   {
     key: 'delivery_type',
     header: 'Delivery Type',
@@ -89,7 +98,7 @@ export function RouteGroupsTab({
       <DataTable
         columns={COLUMNS}
         rows={rows}
-        getRowKey={(r) => r.id}
+        getRowKey={(r) => r.route_group_id}
         emptyState={
           <EmptyState
             title="No routes yet"

--- a/frontend/src/pages/admin/routes/hooks/useGroupsTabState.ts
+++ b/frontend/src/pages/admin/routes/hooks/useGroupsTabState.ts
@@ -12,11 +12,13 @@ import type { UseSearchReturn } from '@/common/hooks';
 import { useSearch } from '@/common/hooks';
 
 export interface GroupsFilterState {
-  weekdays: Set<string>;
-  deliveryTypes: Set<string>;
-  routeStatuses: Set<string>;
-  driverStatuses: Set<string>;
+  weekdays: Set<DriveDaysOfWeekEnum>;
+  deliveryTypes: Set<DeliveryTypeEnum>;
+  routeStatuses: Set<RouteStatusEnum>;
+  driverStatuses: Set<DriverAssignmentStatusEnum>;
 }
+
+type SetElement<S> = S extends Set<infer V> ? V : never;
 
 const emptyFilters = (): GroupsFilterState => ({
   weekdays: new Set(),
@@ -42,7 +44,10 @@ export interface GroupsTabState {
   draftFilters: GroupsFilterState;
   hasActiveFilters: boolean;
   openFilters: () => void;
-  toggleDraft: (key: keyof GroupsFilterState, value: string) => void;
+  toggleDraft: <K extends keyof GroupsFilterState>(
+    key: K,
+    value: SetElement<GroupsFilterState[K]>
+  ) => void;
   handleApply: () => void;
 }
 
@@ -58,25 +63,24 @@ export function useGroupsTabState(): GroupsTabState {
     (s) => s.size > 0
   );
 
-  // Filter chips carry exactly the enum values (see the typed constant arrays
-  // in RouteGroupsTab), so casting the string Sets to the enum arrays the API
-  // expects is safe. Search is local-only UI — the endpoint has no search param.
+  // Search is local-only UI — the endpoint has no search param yet, so only the
+  // filter chips hit the server.
   const { data: rows = [], isLoading } = useRouteGroups({
     weekday:
       appliedFilters.weekdays.size > 0
-        ? ([...appliedFilters.weekdays] as DriveDaysOfWeekEnum[])
+        ? [...appliedFilters.weekdays]
         : undefined,
     delivery_type:
       appliedFilters.deliveryTypes.size > 0
-        ? ([...appliedFilters.deliveryTypes] as DeliveryTypeEnum[])
+        ? [...appliedFilters.deliveryTypes]
         : undefined,
     route_status:
       appliedFilters.routeStatuses.size > 0
-        ? ([...appliedFilters.routeStatuses] as RouteStatusEnum[])
+        ? [...appliedFilters.routeStatuses]
         : undefined,
     driver_assignment_status:
       appliedFilters.driverStatuses.size > 0
-        ? ([...appliedFilters.driverStatuses] as DriverAssignmentStatusEnum[])
+        ? [...appliedFilters.driverStatuses]
         : undefined,
   });
 
@@ -85,7 +89,10 @@ export function useGroupsTabState(): GroupsTabState {
     setFilterOpen(true);
   };
 
-  const toggleDraft = (key: keyof GroupsFilterState, value: string) => {
+  const toggleDraft = <K extends keyof GroupsFilterState>(
+    key: K,
+    value: SetElement<GroupsFilterState[K]>
+  ) => {
     setDraftFilters((prev) => {
       const next = new Set(prev[key]);
       if (next.has(value)) next.delete(value);

--- a/frontend/src/pages/admin/routes/hooks/useGroupsTabState.ts
+++ b/frontend/src/pages/admin/routes/hooks/useGroupsTabState.ts
@@ -1,6 +1,12 @@
 import { useState } from 'react';
 
-import type { RouteGroupRow } from '@/api/route-groups';
+import type {
+  DeliveryTypeEnum,
+  DriveDaysOfWeekEnum,
+  DriverAssignmentStatusEnum,
+  RouteGroupRead,
+  RouteStatusEnum,
+} from '@/api/generated/types.gen';
 import { useRouteGroups } from '@/api/route-groups';
 import type { UseSearchReturn } from '@/common/hooks';
 import { useSearch } from '@/common/hooks';
@@ -27,7 +33,7 @@ const copyFilters = (f: GroupsFilterState): GroupsFilterState => ({
 });
 
 export interface GroupsTabState {
-  rows: RouteGroupRow[];
+  rows: RouteGroupRead[];
   isLoading: boolean;
   search: UseSearchReturn;
   filterOpen: boolean;
@@ -52,23 +58,25 @@ export function useGroupsTabState(): GroupsTabState {
     (s) => s.size > 0
   );
 
+  // Filter chips carry exactly the enum values (see the typed constant arrays
+  // in RouteGroupsTab), so casting the string Sets to the enum arrays the API
+  // expects is safe. Search is local-only UI — the endpoint has no search param.
   const { data: rows = [], isLoading } = useRouteGroups({
-    search: search.value || undefined,
-    weekdays:
+    weekday:
       appliedFilters.weekdays.size > 0
-        ? [...appliedFilters.weekdays]
+        ? ([...appliedFilters.weekdays] as DriveDaysOfWeekEnum[])
         : undefined,
-    deliveryTypes:
+    delivery_type:
       appliedFilters.deliveryTypes.size > 0
-        ? [...appliedFilters.deliveryTypes]
+        ? ([...appliedFilters.deliveryTypes] as DeliveryTypeEnum[])
         : undefined,
-    routeStatuses:
+    route_status:
       appliedFilters.routeStatuses.size > 0
-        ? [...appliedFilters.routeStatuses]
+        ? ([...appliedFilters.routeStatuses] as RouteStatusEnum[])
         : undefined,
-    driverStatuses:
+    driver_assignment_status:
       appliedFilters.driverStatuses.size > 0
-        ? [...appliedFilters.driverStatuses]
+        ? ([...appliedFilters.driverStatuses] as DriverAssignmentStatusEnum[])
         : undefined,
   });
 


### PR DESCRIPTION
Stacked on #144 (F4KRP-196). Merge #144 first.

## What

Now that GET /route-groups returns the aggregate fields (#144), the Groups tab no longer needs a hand-written row type. This swaps the bespoke `RouteGroupRow` / `RouteStatus` / `RouteGroupsParams` types and the manual `axiosClient` fetch in `route-groups.ts` for the generated `RouteGroupRead` type and the generated `getRouteGroupsOptions` client — matching the `addresses.ts` / `system-settings.ts` convention.

Files:
- `src/api/route-groups.ts` — `useRouteGroups` is now a thin wrapper over `getRouteGroupsOptions`, typed with `GetRouteGroupsData['query']`. Removed `RouteGroupRow`, `RouteStatus`, `RouteGroupsParams`, and `fetchRouteGroups`.
- `src/pages/admin/routes/components/RouteGroupsTab.tsx` — `Column<RouteGroupRead>`; `row.date` → `row.drive_date`; `getRowKey` `r.id` → `r.route_group_id`; filter constant arrays typed with the generated enums.
- `src/pages/admin/routes/hooks/useGroupsTabState.ts` — uses `RouteGroupRead[]` and the generated enum types.

## Bonus fix

The old filter params (`weekdays`, `deliveryTypes`, `routeStatuses`, `driverStatuses`) never matched the backend's actual query names (`weekday`, `delivery_type`, `route_status`, `driver_assignment_status`), so the filter chips were **silently no-ops**. They now send the correct param names with proper enum types and actually filter. The search box stays local-only UI — the endpoint has no search param yet.

## Testing

- `tsc -b`, `eslint . --max-warnings=0`, and `prettier --check` all pass.
- Manual: open the admin routes Groups tab, confirm rows render (incl. aggregate columns) and the Weekday / Delivery Type / Route Status / Driver Status chips now filter the list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)