### PR TITLE
Design system: add blue-400 border to primary Button

### DIFF
--- a/frontend/src/common/components/Button.variants.ts
+++ b/frontend/src/common/components/Button.variants.ts
@@ -13,7 +13,8 @@ export const buttonVariants = cva(
   {
     variants: {
       variant: {
-        primary: 'bg-blue-300 text-grey-100 hover:bg-blue-400',
+        primary:
+          'bg-blue-300 text-grey-100 border border-blue-400 hover:bg-blue-400',
         secondary:
           'bg-grey-200 text-grey-500 border border-grey-300 hover:bg-grey-300',
         tertiary: 'bg-grey-100 text-grey-500 border border-grey-300',


### PR DESCRIPTION
## What

Adds the `border border-blue-400` that the Figma **Button** component specs around the `blue-300` fill. The `primary` variant was the only one missing its border — `secondary` and `tertiary` already carry theirs.

```diff
-        primary: 'bg-blue-300 text-grey-100 hover:bg-blue-400',
+        primary:
+          'bg-blue-300 text-grey-100 border border-blue-400 hover:bg-blue-400',
```

## Why

Surfaced while doing a pixel-perfect overlay of the login design — the primary button rendered without the subtle 1px blue-400 (`#195586`) edge the design has.

## Notes

- The shared base already sets `disabled:border-transparent`, so the disabled state is unaffected.
- Pure presentational change; box stays 44px tall (border-box).

## Verification

- `pnpm lint` ✅  ·  `prettier --check` ✅  ·  `tsc -b` ✅
- Confirmed in the login overlay: button now renders as a single thin outline against the design (height + border coincide).

🤖 Generated with [Claude Code](https://claude.com/claude-code)