### PR TITLE
Load Nunito Sans 500 (Medium) weight

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -7,7 +7,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;500;600;700;800&family=Nunito+Sans:wght@300;400;600;700&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;500;600;700;800&family=Nunito+Sans:wght@300;400;500;600;700&display=swap"
       rel="stylesheet"
     />
     <title>Food4Kids</title>


### PR DESCRIPTION
## What

The Google Fonts request was missing **500** for Nunito Sans:

```diff
- family=Nunito+Sans:wght@300;400;600;700
+ family=Nunito+Sans:wght@300;400;500;600;700
```

## Why

Everywhere the app renders Nunito Sans **Medium (500)**, the browser had no 500 face and silently fell back to **Regular (400)** — so that text rendered lighter than the design. This affects, among others:

- the login email/password **placeholders** and **subtitle** (`tablet:font-medium`)
- **"Remember me"**, **"Forgot your password?"**, the footer
- **`text-p1`'s Desktop = Medium weight** from #164 — which means that DS change was effectively invisible app-wide until now

(`fonts.check('500 …')` returned `true` only because the browser synthesizes the missing weight from 400 — there was no real 500 face.)

## Verification

Loaded the corrected URL and inspected `document.fonts`:
- before: Nunito Sans faces `[300, 400, 600, 700]`
- after: `[300, 400, **500**, 600, 700]` — a genuine 500 face now loads

Found while doing a pixel-perfect overlay of the login screen; the design's Medium body text was visibly heavier than the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)