### PR TITLE
Wilson/addresses table backend aggregates

### DIFF
--- a/backend/python/app/models/location.py
+++ b/backend/python/app/models/location.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from enum import Enum
 from typing import TYPE_CHECKING
 from uuid import UUID, uuid4
@@ -206,6 +207,9 @@ class LocationRead(LocationBase):
     # Populated by the service; defaulted to False so single-row construction
     # without a service round-trip still works (will report UNSCHEDULED/INACTIVE).
     has_future_route: bool = False
+    assigned_route: str | None = None
+    last_delivery_date: datetime | None = None
+    total_deliveries: int = 0
 
     @computed_field  # type: ignore[prop-decorator]
     @property

--- a/backend/python/app/services/implementations/location_service.py
+++ b/backend/python/app/services/implementations/location_service.py
@@ -10,7 +10,7 @@ from zoneinfo import ZoneInfo
 
 import pandas as pd
 from fastapi import UploadFile
-from sqlalchemy import and_, or_
+from sqlalchemy import and_, func, or_
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 from sqlmodel import col, select
@@ -40,6 +40,7 @@ from app.models.route import Route
 from app.models.route_group import RouteGroup
 from app.models.route_snapshot import RouteSnapshot
 from app.models.route_stop import RouteStop
+from app.models.route_stop_snapshot import RouteStopSnapshot
 from app.schemas.pagination import PaginatedResponse, PaginationParams
 from app.utilities.google_maps_client import GoogleMapsClient
 from app.utilities.pagination import paginate_query
@@ -122,13 +123,23 @@ class LocationService:
     ) -> LocationRead:
         """Get a LocationRead with derived status populated.
 
-        Wraps get_location_by_id with a single-row has_future_route lookup so
-        the response includes the three-state status that the list endpoint
-        already does. Use this from routers that respond with LocationRead.
+        Wraps get_location_by_id with single-row batched lookups so the
+        response includes status, assigned route, and delivery aggregates.
+        Use this from routers that respond with LocationRead.
         """
         location = await self.get_location_by_id(session, location_id)
-        future_set = await self.load_has_future_route_set(session, [location_id])
-        return self._to_read(location, has_future_route=location_id in future_set)
+        ids = [location_id]
+        future_set = await self.load_has_future_route_set(session, ids)
+        assigned = await self.load_assigned_routes(session, ids)
+        aggregates = await self.load_delivery_aggregates(session, ids)
+        total, last_date = aggregates.get(location_id, (0, None))
+        return self._to_read(
+            location,
+            has_future_route=location_id in future_set,
+            assigned_route=assigned.get(location_id),
+            last_delivery_date=last_date,
+            total_deliveries=total,
+        )
 
     async def get_locations(
         self,
@@ -195,11 +206,18 @@ class LocationService:
 
             result, total = await paginate_query(session, statement, pagination)
             items = list(result.scalars().all())
-            future_set = await self.load_has_future_route_set(
-                session, [loc.location_id for loc in items]
-            )
+            loc_ids = [loc.location_id for loc in items]
+            future_set = await self.load_has_future_route_set(session, loc_ids)
+            assigned = await self.load_assigned_routes(session, loc_ids)
+            aggregates = await self.load_delivery_aggregates(session, loc_ids)
             reads = [
-                self._to_read(loc, has_future_route=loc.location_id in future_set)
+                self._to_read(
+                    loc,
+                    has_future_route=loc.location_id in future_set,
+                    assigned_route=assigned.get(loc.location_id),
+                    last_delivery_date=aggregates.get(loc.location_id, (0, None))[1],
+                    total_deliveries=aggregates.get(loc.location_id, (0, None))[0],
+                )
                 for loc in items
             ]
             return PaginatedResponse.create(
@@ -241,7 +259,75 @@ class LocationService:
         result = await session.execute(statement)
         return {row[0] for row in result.all()}
 
-    def _to_read(self, loc: Location, has_future_route: bool) -> LocationRead:
+    async def load_assigned_routes(
+        self, session: AsyncSession, location_ids: Iterable[UUID]
+    ) -> dict[UUID, str]:
+        """Return a mapping of location_id → route name for the soonest
+        upcoming unfrozen route group each location appears in.
+
+        One query rather than per-location N+1.
+        """
+        ids = list(location_ids)
+        if not ids:
+            return {}
+        today_start = self._today_start()
+        statement = (
+            select(RouteStop.location_id, Route.name, RouteGroup.drive_date)
+            .join(Route, Route.route_id == RouteStop.route_id)  # type: ignore[arg-type]
+            .join(RouteGroup, RouteGroup.route_group_id == Route.route_group_id)  # type: ignore[arg-type]
+            .outerjoin(
+                RouteSnapshot,
+                RouteSnapshot.route_id == Route.route_id,  # type: ignore[arg-type]
+            )
+            .where(col(RouteStop.location_id).in_(ids))
+            .where(RouteGroup.drive_date >= today_start)
+            .where(col(RouteSnapshot.route_id).is_(None))
+            .order_by(col(RouteGroup.drive_date).asc())
+        )
+        result = await session.execute(statement)
+        assigned: dict[UUID, str] = {}
+        for loc_id, route_name, _ in result.all():
+            if loc_id not in assigned:
+                assigned[loc_id] = route_name
+        return assigned
+
+    async def load_delivery_aggregates(
+        self, session: AsyncSession, location_ids: Iterable[UUID]
+    ) -> dict[UUID, tuple[int, datetime | None]]:
+        """Return a mapping of location_id → (total_deliveries, last_delivery_date)
+        for completed deliveries (RouteStopSnapshot exists).
+
+        One query rather than per-location N+1.
+        """
+        ids = list(location_ids)
+        if not ids:
+            return {}
+        statement = (
+            select(
+                RouteStop.location_id,
+                func.count().label("total"),
+                func.max(RouteGroup.drive_date).label("last_date"),
+            )
+            .join(
+                RouteStopSnapshot,
+                RouteStopSnapshot.route_stop_id == RouteStop.route_stop_id,  # type: ignore[arg-type]
+            )
+            .join(Route, Route.route_id == RouteStop.route_id)  # type: ignore[arg-type]
+            .join(RouteGroup, RouteGroup.route_group_id == Route.route_group_id)  # type: ignore[arg-type]
+            .where(col(RouteStop.location_id).in_(ids))
+            .group_by(col(RouteStop.location_id))
+        )
+        result = await session.execute(statement)
+        return {row[0]: (row[1], row[2]) for row in result.all()}
+
+    def _to_read(
+        self,
+        loc: Location,
+        has_future_route: bool,
+        assigned_route: str | None = None,
+        last_delivery_date: datetime | None = None,
+        total_deliveries: int = 0,
+    ) -> LocationRead:
         """Build a LocationRead with the derived has_future_route populated.
 
         Status is then a @computed_field on LocationRead; no separate work
@@ -249,6 +335,9 @@ class LocationService:
         """
         read = LocationRead.model_validate(loc, from_attributes=True)
         read.has_future_route = has_future_route
+        read.assigned_route = assigned_route
+        read.last_delivery_date = last_delivery_date
+        read.total_deliveries = total_deliveries
         return read
 
     async def create_location(

--- a/backend/python/tests/test_routes.py
+++ b/backend/python/tests/test_routes.py
@@ -23,7 +23,6 @@ from app.models.location import Location
 from app.models.location_group import LocationGroup
 from app.models.route import Route
 from app.models.route_group import RouteGroup
-from app.models.route_snapshot import RouteSnapshot
 from app.models.route_stop import RouteStop
 from app.models.route_stop_snapshot import RouteStopSnapshot
 

--- a/backend/python/tests/test_routes.py
+++ b/backend/python/tests/test_routes.py
@@ -942,12 +942,8 @@ class TestLocationRoutes:
             delivery_type=DeliveryTypeEnum.FAMILY,
             in_roster=True,
         )
-        sooner_group = RouteGroup(
-            name="Sooner Group", drive_date=datetime(2098, 1, 1)
-        )
-        later_group = RouteGroup(
-            name="Later Group", drive_date=datetime(2099, 1, 1)
-        )
+        sooner_group = RouteGroup(name="Sooner Group", drive_date=datetime(2098, 1, 1))
+        later_group = RouteGroup(name="Later Group", drive_date=datetime(2099, 1, 1))
         test_session.add_all([loc, sooner_group, later_group])
         await test_session.commit()
         await test_session.refresh(loc)

--- a/backend/python/tests/test_routes.py
+++ b/backend/python/tests/test_routes.py
@@ -23,7 +23,9 @@ from app.models.location import Location
 from app.models.location_group import LocationGroup
 from app.models.route import Route
 from app.models.route_group import RouteGroup
+from app.models.route_snapshot import RouteSnapshot
 from app.models.route_stop import RouteStop
+from app.models.route_stop_snapshot import RouteStopSnapshot
 
 
 class TestDriverRoutes:
@@ -763,6 +765,231 @@ class TestLocationRoutes:
         listing = await async_client.get("/locations/")
         assert listing.json()["items"] == []
         assert listing.json()["total"] == 0
+
+    @pytest.mark.asyncio
+    async def test_get_locations_returns_aggregate_fields(
+        self,
+        async_client: AsyncClient,
+        sample_location_data: dict[str, Any],
+        test_location_group: Any,
+    ) -> None:
+        """GET /locations includes assigned_route, last_delivery_date, total_deliveries."""
+        create_resp = await async_client.post(
+            "/locations/",
+            json={
+                **sample_location_data,
+                "location_group_id": str(test_location_group.location_group_id),
+            },
+        )
+        assert create_resp.status_code == 201
+
+        response = await async_client.get("/locations/")
+        assert response.status_code == 200
+        loc = response.json()["items"][0]
+        assert loc["assigned_route"] is None
+        assert loc["last_delivery_date"] is None
+        assert loc["total_deliveries"] == 0
+
+    @pytest.mark.asyncio
+    async def test_get_location_by_id_returns_aggregate_fields(
+        self,
+        async_client: AsyncClient,
+        sample_location_data: dict[str, Any],
+        test_location_group: Any,
+    ) -> None:
+        """GET /locations/{id} includes assigned_route, last_delivery_date, total_deliveries."""
+        create_resp = await async_client.post(
+            "/locations/",
+            json={
+                **sample_location_data,
+                "location_group_id": str(test_location_group.location_group_id),
+            },
+        )
+        assert create_resp.status_code == 201
+        loc_id = create_resp.json()["location_id"]
+
+        response = await async_client.get(f"/locations/{loc_id}")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["assigned_route"] is None
+        assert data["last_delivery_date"] is None
+        assert data["total_deliveries"] == 0
+
+    @pytest.mark.asyncio
+    async def test_location_aggregates_with_completed_delivery(
+        self,
+        async_client: AsyncClient,
+        test_session: AsyncSession,
+        test_location_group: Any,
+    ) -> None:
+        """Completed delivery (RouteStopSnapshot exists) populates total_deliveries and last_delivery_date."""
+        loc = Location(
+            location_group_id=test_location_group.location_group_id,
+            name="Delivered Family",
+            contact_name="Delivered Family",
+            address="10 Delivered St",
+            phone_primary="5559999999",
+            delivery_type=DeliveryTypeEnum.FAMILY,
+            in_roster=True,
+        )
+        past_group = RouteGroup(
+            name="Past Route Group", drive_date=datetime(2024, 6, 1)
+        )
+        test_session.add_all([loc, past_group])
+        await test_session.commit()
+        await test_session.refresh(loc)
+        await test_session.refresh(past_group)
+
+        route = Route(
+            name="Past Route", length=1.0, route_group_id=past_group.route_group_id
+        )
+        test_session.add(route)
+        await test_session.commit()
+        await test_session.refresh(route)
+
+        stop = RouteStop(
+            route_id=route.route_id,
+            location_id=loc.location_id,
+            stop_number=1,
+        )
+        test_session.add(stop)
+        await test_session.commit()
+        await test_session.refresh(stop)
+
+        snapshot = RouteStopSnapshot(
+            route_stop_id=stop.route_stop_id,
+            address="10 Delivered St",
+            contact_name="Delivered Family",
+            phone_number="5559999999",
+            num_children=2,
+            latitude=0.0,
+            longitude=0.0,
+        )
+        test_session.add(snapshot)
+        await test_session.commit()
+
+        response = await async_client.get(f"/locations/{loc.location_id}")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total_deliveries"] == 1
+        assert data["last_delivery_date"] is not None
+        assert data["last_delivery_date"].startswith("2024-06-01")
+        assert data["assigned_route"] is None
+
+    @pytest.mark.asyncio
+    async def test_location_aggregates_with_assigned_route(
+        self,
+        async_client: AsyncClient,
+        test_session: AsyncSession,
+        test_location_group: Any,
+    ) -> None:
+        """Upcoming route (no snapshot) populates assigned_route but not delivery aggregates."""
+        loc = Location(
+            location_group_id=test_location_group.location_group_id,
+            name="Upcoming Family",
+            contact_name="Upcoming Family",
+            address="20 Upcoming St",
+            phone_primary="5558888888",
+            delivery_type=DeliveryTypeEnum.FAMILY,
+            in_roster=True,
+        )
+        future_group = RouteGroup(
+            name="Future Route Group", drive_date=datetime(2099, 7, 1)
+        )
+        test_session.add_all([loc, future_group])
+        await test_session.commit()
+        await test_session.refresh(loc)
+        await test_session.refresh(future_group)
+
+        route = Route(
+            name="Future Route Alpha",
+            length=1.0,
+            route_group_id=future_group.route_group_id,
+        )
+        test_session.add(route)
+        await test_session.commit()
+        await test_session.refresh(route)
+
+        test_session.add(
+            RouteStop(
+                route_id=route.route_id,
+                location_id=loc.location_id,
+                stop_number=1,
+            )
+        )
+        await test_session.commit()
+
+        response = await async_client.get(f"/locations/{loc.location_id}")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["assigned_route"] == "Future Route Alpha"
+        assert data["total_deliveries"] == 0
+        assert data["last_delivery_date"] is None
+
+    @pytest.mark.asyncio
+    async def test_location_assigned_route_picks_soonest(
+        self,
+        async_client: AsyncClient,
+        test_session: AsyncSession,
+        test_location_group: Any,
+    ) -> None:
+        """When a location is on multiple upcoming routes, assigned_route is the soonest."""
+        loc = Location(
+            location_group_id=test_location_group.location_group_id,
+            name="Multi Route Family",
+            contact_name="Multi Route Family",
+            address="30 Multi St",
+            phone_primary="5557777777",
+            delivery_type=DeliveryTypeEnum.FAMILY,
+            in_roster=True,
+        )
+        sooner_group = RouteGroup(
+            name="Sooner Group", drive_date=datetime(2098, 1, 1)
+        )
+        later_group = RouteGroup(
+            name="Later Group", drive_date=datetime(2099, 1, 1)
+        )
+        test_session.add_all([loc, sooner_group, later_group])
+        await test_session.commit()
+        await test_session.refresh(loc)
+        await test_session.refresh(sooner_group)
+        await test_session.refresh(later_group)
+
+        sooner_route = Route(
+            name="Sooner Route",
+            length=1.0,
+            route_group_id=sooner_group.route_group_id,
+        )
+        later_route = Route(
+            name="Later Route",
+            length=1.0,
+            route_group_id=later_group.route_group_id,
+        )
+        test_session.add_all([sooner_route, later_route])
+        await test_session.commit()
+        await test_session.refresh(sooner_route)
+        await test_session.refresh(later_route)
+
+        test_session.add_all(
+            [
+                RouteStop(
+                    route_id=sooner_route.route_id,
+                    location_id=loc.location_id,
+                    stop_number=1,
+                ),
+                RouteStop(
+                    route_id=later_route.route_id,
+                    location_id=loc.location_id,
+                    stop_number=1,
+                ),
+            ]
+        )
+        await test_session.commit()
+
+        response = await async_client.get(f"/locations/{loc.location_id}")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["assigned_route"] == "Sooner Route"
 
 
 class TestLocationGroupRoutes:

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -1499,6 +1499,17 @@
             "title": "Address",
             "type": "string"
           },
+          "assigned_route": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Assigned Route"
+          },
           "contact_name": {
             "title": "Contact Name",
             "type": "string"
@@ -1525,6 +1536,18 @@
             "default": true,
             "title": "In Roster",
             "type": "boolean"
+          },
+          "last_delivery_date": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Delivery Date"
           },
           "latitude": {
             "anyOf": [
@@ -1614,6 +1637,11 @@
               }
             ],
             "title": "Place Id"
+          },
+          "total_deliveries": {
+            "default": 0,
+            "title": "Total Deliveries",
+            "type": "integer"
           }
         },
         "required": [
@@ -1635,6 +1663,17 @@
           "address": {
             "title": "Address",
             "type": "string"
+          },
+          "assigned_route": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Assigned Route"
           },
           "contact_name": {
             "title": "Contact Name",
@@ -1662,6 +1701,18 @@
             "default": true,
             "title": "In Roster",
             "type": "boolean"
+          },
+          "last_delivery_date": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Delivery Date"
           },
           "latitude": {
             "anyOf": [
@@ -1755,6 +1806,11 @@
           "status": {
             "$ref": "#/components/schemas/LocationStatusEnum",
             "readOnly": true
+          },
+          "total_deliveries": {
+            "default": 0,
+            "title": "Total Deliveries",
+            "type": "integer"
           }
         },
         "required": [

--- a/frontend/src/api/generated/types.gen.ts
+++ b/frontend/src/api/generated/types.gen.ts
@@ -902,6 +902,10 @@ export type LocationReadInput = {
    */
   address: string;
   /**
+   * Assigned Route
+   */
+  assigned_route?: string | null;
+  /**
    * Contact Name
    */
   contact_name: string;
@@ -922,6 +926,10 @@ export type LocationReadInput = {
    * In Roster
    */
   in_roster?: boolean;
+  /**
+   * Last Delivery Date
+   */
+  last_delivery_date?: string | null;
   /**
    * Latitude
    */
@@ -970,6 +978,10 @@ export type LocationReadInput = {
    * Place Id
    */
   place_id?: string | null;
+  /**
+   * Total Deliveries
+   */
+  total_deliveries?: number;
 };
 
 /**
@@ -986,6 +998,10 @@ export type LocationReadOutput = {
    * Address
    */
   address: string;
+  /**
+   * Assigned Route
+   */
+  assigned_route?: string | null;
   /**
    * Contact Name
    */
@@ -1007,6 +1023,10 @@ export type LocationReadOutput = {
    * In Roster
    */
   in_roster?: boolean;
+  /**
+   * Last Delivery Date
+   */
+  last_delivery_date?: string | null;
   /**
    * Latitude
    */
@@ -1056,6 +1076,10 @@ export type LocationReadOutput = {
    */
   place_id?: string | null;
   readonly status: LocationStatusEnum;
+  /**
+   * Total Deliveries
+   */
+  total_deliveries?: number;
 };
 
 /**
@@ -2178,6 +2202,10 @@ export type LocationReadOutputWritable = {
    */
   address: string;
   /**
+   * Assigned Route
+   */
+  assigned_route?: string | null;
+  /**
    * Contact Name
    */
   contact_name: string;
@@ -2198,6 +2226,10 @@ export type LocationReadOutputWritable = {
    * In Roster
    */
   in_roster?: boolean;
+  /**
+   * Last Delivery Date
+   */
+  last_delivery_date?: string | null;
   /**
    * Latitude
    */
@@ -2246,6 +2278,10 @@ export type LocationReadOutputWritable = {
    * Place Id
    */
   place_id?: string | null;
+  /**
+   * Total Deliveries
+   */
+  total_deliveries?: number;
 };
 
 /**


### PR DESCRIPTION
## JIRA Ticket
[Ticket Name](https://f4kblueprint.atlassian.net/browse/F4KRP)

## Implementation Description
<!-- Quick summary of what you built and why. Include design justifications if needed -->
*
i added three read only fields to LocationRead: assigned_route, last_delivery_date, and total_deliveries. These are derived from route data at query time

## Steps to Test
<!-- What should the reviewer do to verify your changes? Include expected results -->
use postman to hit http://localhost:8080/locations to see the new endpoint
you will need an auth bearer token

## What Should Reviewers Focus On?
<!-- Call out substantial changes or anything you want a second opinion on -->
*
should double check the two new SQL query methods in location_service.py which are load_assigned_routes and load_delivery_aggregates and make sure the join logic and filtering is right

## Checklist
- [ ] PR name and commits are descriptive, imperative, and atomic (trivial commits squashed)
- [ ] I have requested a review from Claude, understood its suggestions, and implemented fixes where needed (or documented disagreements)
- [ ] I have requested a review from the PL and relevant devs with background on this PR