### PR TITLE
schema-changes

### DIFF
--- a/backend/python/app/dependencies/auth.py
+++ b/backend/python/app/dependencies/auth.py
@@ -11,6 +11,7 @@ from sqlmodel import select
 
 from app.config import settings
 from app.models import get_session
+from app.models.announcement import Announcement
 from app.models.route import Route
 from app.services.implementations.auth_service import AuthService
 from app.services.implementations.driver_service import DriverService
@@ -202,6 +203,44 @@ async def require_route_assigned_or_admin(
         )
     )
     if not is_assigned:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You are not authorized to access this resource.",
+        )
+    return True
+
+
+async def require_announcement_owner_or_admin(
+    request: Request,
+    access_token: str = Depends(get_access_token),
+    session: AsyncSession = Depends(get_session),
+) -> bool:
+    """Allow access if the caller is an admin or the announcement author."""
+    announcement_id = _path_uuid(request, "announcement_id")
+    decoded_token = _verified_token(access_token)
+
+    if decoded_token.get("role") == "admin":
+        return True
+
+    current_user_id = await user_service.get_user_id_by_auth_id(
+        session, decoded_token["uid"]
+    )
+    if current_user_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You are not authorized to access this resource.",
+        )
+
+    announcement = await session.scalar(
+        select(Announcement).where(Announcement.announcement_id == announcement_id)
+    )
+    if announcement is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Announcement with id {announcement_id} not found",
+        )
+
+    if announcement.user_id != current_user_id:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="You are not authorized to access this resource.",

--- a/backend/python/app/routers/announcement_routes.py
+++ b/backend/python/app/routers/announcement_routes.py
@@ -3,7 +3,10 @@ from uuid import UUID
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.dependencies.auth import require_driver_or_admin
+from app.dependencies.auth import (
+    require_announcement_owner_or_admin,
+    require_driver_or_admin,
+)
 from app.dependencies.services import get_announcement_service
 from app.models import get_session
 from app.models.announcement import (
@@ -74,7 +77,7 @@ async def update_announcement(
     announcement: AnnouncementUpdate,
     session: AsyncSession = Depends(get_session),
     announcement_service: AnnouncementService = Depends(get_announcement_service),
-    _auth: bool = Depends(require_driver_or_admin),
+    _auth: bool = Depends(require_announcement_owner_or_admin),
 ) -> AnnouncementRead:
     """Update an existing announcement"""
     updated_announcement = await announcement_service.update_announcement(
@@ -93,7 +96,7 @@ async def delete_announcement(
     announcement_id: UUID,
     session: AsyncSession = Depends(get_session),
     announcement_service: AnnouncementService = Depends(get_announcement_service),
-    _auth: bool = Depends(require_driver_or_admin),
+    _auth: bool = Depends(require_announcement_owner_or_admin),
 ) -> None:
     """Delete an announcement"""
     success = await announcement_service.delete_announcement(session, announcement_id)

--- a/backend/python/tests/conftest.py
+++ b/backend/python/tests/conftest.py
@@ -18,6 +18,7 @@ from app import create_app
 from app.dependencies.auth import (
     get_access_token,
     require_admin,
+    require_announcement_owner_or_admin,
     require_driver,
     require_driver_or_admin,
     require_route_assigned_or_admin,
@@ -120,6 +121,7 @@ def _apply_auth_overrides(app: Any) -> None:
     app.dependency_overrides[require_driver_or_admin] = lambda: True
     app.dependency_overrides[require_self_driver_or_admin] = lambda: True
     app.dependency_overrides[require_route_assigned_or_admin] = lambda: True
+    app.dependency_overrides[require_announcement_owner_or_admin] = lambda: True
     # GET /routes' sole auth dependency also resolves the driver_id filter;
     # bypass it to the "all routes" scope (driver_id=None), matching the admin
     # view, so router tests that hit GET /routes aren't gated by token checks.

--- a/backend/python/tests/test_auth_integration.py
+++ b/backend/python/tests/test_auth_integration.py
@@ -56,6 +56,7 @@ class Policy(str, Enum):
     DRIVER_OR_ADMIN = "driver_or_admin"
     SELF_DRIVER_OR_ADMIN = "self_driver_or_admin"
     ROUTE_ASSIGNED_OR_ADMIN = "route_assigned_or_admin"
+    ANNOUNCEMENT_OWNER_OR_ADMIN = "announcement_owner_or_admin"
     AUTHENTICATED = "authenticated"  # any signed-in user, no role/ownership check
 
     # Not behaviourally tested — classified only, for the completeness guard.
@@ -77,6 +78,7 @@ ALLOWED_ACTORS: dict[Policy, set[Actor]] = {
     Policy.DRIVER_OR_ADMIN: {Actor.ADMIN, Actor.SELF, Actor.OTHER},
     Policy.SELF_DRIVER_OR_ADMIN: {Actor.ADMIN, Actor.SELF},
     Policy.ROUTE_ASSIGNED_OR_ADMIN: {Actor.ADMIN, Actor.SELF},
+    Policy.ANNOUNCEMENT_OWNER_OR_ADMIN: {Actor.ADMIN, Actor.SELF},
     Policy.AUTHENTICATED: {Actor.ADMIN, Actor.SELF, Actor.OTHER},
 }
 
@@ -163,12 +165,12 @@ ROUTE_POLICIES: dict[tuple[str, str], Policy] = {
     ("DELETE", "/routes/{route_id}"): Policy.ADMIN_ONLY,
     ("GET", "/routes/{route_id}/google-maps-link"): Policy.ROUTE_ASSIGNED_OR_ADMIN,
     ("GET", "/routes/{route_id}/suggested-driver"): Policy.ADMIN_ONLY,
-    # --- announcements (any authenticated driver/admin) ---
+    # --- announcements ---
     ("GET", "/announcements/"): Policy.DRIVER_OR_ADMIN,
     ("POST", "/announcements/"): Policy.DRIVER_OR_ADMIN,
     ("GET", "/announcements/{announcement_id}"): Policy.DRIVER_OR_ADMIN,
-    ("PUT", "/announcements/{announcement_id}"): Policy.DRIVER_OR_ADMIN,
-    ("DELETE", "/announcements/{announcement_id}"): Policy.DRIVER_OR_ADMIN,
+    ("PUT", "/announcements/{announcement_id}"): Policy.ANNOUNCEMENT_OWNER_OR_ADMIN,
+    ("DELETE", "/announcements/{announcement_id}"): Policy.ANNOUNCEMENT_OWNER_OR_ADMIN,
     # --- upload (any driver/admin; feeds note + announcement attachments) ---
     ("POST", "/upload/"): Policy.DRIVER_OR_ADMIN,
     # --- system settings ---
@@ -250,11 +252,13 @@ class Seed(SimpleNamespace):
     other_driver_id: Any
     route_group_id: Any
     route_id: Any
+    announcement_id: Any
 
 
 @pytest_asyncio.fixture
 async def seed(test_session: AsyncSession) -> Seed:
     """Create the minimal records the auth dependencies look up by auth_id."""
+    from app.models.announcement import Announcement
     from app.models.driver import Driver
     from app.models.enum import DeliveryTypeEnum
     from app.models.location import Location
@@ -330,6 +334,14 @@ async def seed(test_session: AsyncSession) -> Seed:
     await test_session.commit()
     await test_session.refresh(route)
     await test_session.refresh(location)
+    announcement = Announcement(
+        subject="Seed Announcement",
+        message="Seed announcement body",
+        user_id=self_driver.user_id,
+    )
+    test_session.add(announcement)
+    await test_session.commit()
+    await test_session.refresh(announcement)
     test_session.add(
         RouteStop(
             route_id=route.route_id,
@@ -344,6 +356,7 @@ async def seed(test_session: AsyncSession) -> Seed:
         other_driver_id=other_driver.driver_id,
         route_group_id=route_group.route_group_id,
         route_id=route.route_id,
+        announcement_id=announcement.announcement_id,
     )
 
 
@@ -382,6 +395,7 @@ def _fill_path(path: str, seed: Seed) -> str:
     values = {
         "driver_id": str(seed.self_driver_id),
         "route_id": str(seed.route_id),
+        "announcement_id": str(seed.announcement_id),
         "year": "2025",
     }
     unrelated = str(uuid4())  # for params that ownership doesn't hinge on


### PR DESCRIPTION
This updates announcement edit/delete so only the original author or an admin can change them. It keeps the existing driver self-edit behaviour in place and updates the auth tests to cover the ownership rules.\n\nValidated with targeted backend tests in Docker: PYTHONPATH=/app pytest tests/test_auth_integration.py tests/test_routes.py -q