### PR TITLE
Stamp updated_at on insert (industry-standard timestamps)

### DIFF
--- a/backend/python/app/models/base.py
+++ b/backend/python/app/models/base.py
@@ -12,6 +12,11 @@ _ONGOING_MODEL_VALIDATE: ContextVar[bool] = ContextVar("_ONGOING_MODEL_VALIDATE"
 T = TypeVar("T", bound="BaseModel")
 
 
+def _now_est_naive() -> datetime:
+    """Current time in F4K's timezone (America/New_York), stored tz-naive."""
+    return datetime.now(ZoneInfo("America/New_York")).replace(tzinfo=None)
+
+
 @contextmanager
 def set_ongoing_model_validate() -> Any:
     token = _ONGOING_MODEL_VALIDATE.set(True)
@@ -22,15 +27,13 @@ def set_ongoing_model_validate() -> Any:
 class BaseModel(sm.SQLModel):
     """Enhanced base model with common fields and functionality"""
 
-    # Common timestamp fields
-    created_at: datetime | None = Field(
-        default_factory=lambda: datetime.now(ZoneInfo("America/New_York")).replace(
-            tzinfo=None
-        ),
-    )
-    updated_at: datetime | None = Field(
-        default=None,
-    )
+    # Common timestamp fields.
+    # Industry-standard convention (Rails/Django/Laravel): both are stamped on
+    # insert (equal to within microseconds) and `updated_at` is bumped on every
+    # update. Models that genuinely need "null until first set" (e.g. Job, whose
+    # lifecycle tracks started/updated/finished) override `updated_at` explicitly.
+    created_at: datetime | None = Field(default_factory=_now_est_naive)
+    updated_at: datetime | None = Field(default_factory=_now_est_naive)
 
     def __init_subclass__(cls, **kwargs: Any) -> None:
         super().__init_subclass__(**kwargs)

--- a/backend/python/tests/test_models.py
+++ b/backend/python/tests/test_models.py
@@ -733,7 +733,8 @@ class TestEnumsAndSerialization:
         assert "last_name" in user_dict
         assert "full_name" in user_dict
         assert "created_at" in driver_dict
-        # updated_at should be None and might be excluded
+        # updated_at is stamped on insert (equal to created_at within microseconds)
+        assert driver_dict["updated_at"] is not None
         assert driver_dict["active"] is True  # Default value
         assert user_dict["role"] == "driver"
 


### PR DESCRIPTION
## Summary

`BaseModel.updated_at` defaulted to `NULL` and was only populated on update, so every freshly-created row had `updated_at = NULL`. This is the minority convention — Rails, Django, and Laravel all stamp `updated_at` on insert (equal to `created_at`) and bump it on every update.

This PR gives `updated_at` the same `default_factory` as `created_at`, so it is always populated.

## Why

Sorting by `updated_at` was unreliable: with `NULL` on insert, Postgres sorts those rows `NULLS FIRST` in a `DESC` order with **no tiebreaker among them**, so newly-created rows had no stable recency order. This surfaced in the announcement feed (#150), where a newly-created announcement would not reliably appear at the top and an edited post would sink below unedited ones. Making `updated_at` non-null at insert fixes that at the root, for every table.

## Scope / safety

- **`Job` is unaffected.** It deliberately overrides `updated_at` to `default=None` because its lifecycle (`started_at` / `updated_at` / `finished_at`) genuinely needs "null until set". That override still wins, so the column stays nullable to accommodate the opt-out (a DB-wide `NOT NULL` would break Job).
- **Frontend "Edited" badge unaffected.** It keys off an `updated_at - created_at > 1s` diff, and the insert-time delta between the two `default_factory` calls is microseconds (verified ~0.04 ms), so unedited rows read as unedited.
- `tests/test_seed_database.py` already asserted seeded rows have non-null `updated_at` (previously satisfied via the seed's `set_timestamps`); now it holds without that helper too.

## Testing

- `ruff check`, `ruff format --check`, `mypy app` — all clean
- `pytest tests/test_models.py tests/test_seed_database.py tests/test_routes.py` — 149 passed
- Verified live against a running stack: a freshly-created announcement now returns `updated_at` non-null, ~0.04 ms after `created_at`
- Added an explicit assertion in `test_models.py` that a fresh row's `updated_at` is non-null

🤖 Generated with [Claude Code](https://claude.com/claude-code)