### PR TITLE
Add location group filter to locations

### DIFF
--- a/backend/python/app/routers/location_routes.py
+++ b/backend/python/app/routers/location_routes.py
@@ -39,6 +39,9 @@ async def get_locations(
     status_filter: list[LocationStatusEnum] | None = Query(
         None, alias="status", description="Filter by one or more location statuses"
     ),
+    location_group_id: list[UUID] | None = Query(
+        None, description="Filter by one or more location groups"
+    ),
     pagination: PaginationParams = Depends(get_pagination),
     session: AsyncSession = Depends(get_session),
     location_service: LocationService = Depends(get_location_service),
@@ -52,7 +55,7 @@ async def get_locations(
         # items with has_future_route populated (so the computed `status` is
         # correct). Re-validating each item here would reset has_future_route.
         return await location_service.get_locations(
-            session, pagination, delivery_type, status_filter
+            session, pagination, delivery_type, status_filter, location_group_id
         )
     except Exception as e:
         raise HTTPException(

--- a/backend/python/app/services/implementations/location_service.py
+++ b/backend/python/app/services/implementations/location_service.py
@@ -147,6 +147,7 @@ class LocationService:
         pagination: PaginationParams,
         delivery_type: list[DeliveryTypeEnum] | None = None,
         status_filter: list[LocationStatusEnum] | None = None,
+        location_group_id: list[UUID] | None = None,
     ) -> PaginatedResponse[LocationRead]:
         """Get paginated locations.
 
@@ -155,7 +156,7 @@ class LocationService:
         three-state status (Active / Unscheduled / Inactive) is computed
         from in_roster + whether the location appears in a present/future
         route. Callers can narrow via the optional ``status_filter`` and
-        ``delivery_type`` query params.
+        ``delivery_type`` and ``location_group_id`` query params.
         """
         try:
             statement = (
@@ -167,6 +168,11 @@ class LocationService:
             if delivery_type:
                 statement = statement.where(
                     Location.delivery_type.in_(delivery_type)  # type: ignore[attr-defined]
+                )
+
+            if location_group_id:
+                statement = statement.where(
+                    col(Location.location_group_id).in_(location_group_id)
                 )
 
             if status_filter:

--- a/backend/python/tests/test_routes.py
+++ b/backend/python/tests/test_routes.py
@@ -378,6 +378,107 @@ class TestLocationRoutes:
         assert school_id not in family_ids
 
     @pytest.mark.asyncio
+    async def test_get_locations_filters_by_location_group(
+        self,
+        async_client: AsyncClient,
+        test_session: AsyncSession,
+        test_location_group: Any,
+    ) -> None:
+        """GET /locations filters locations by a single location_group_id."""
+        other_group = LocationGroup(name="Other Delivery Group", color="#3357FF")
+        target_location = Location(
+            location_group_id=test_location_group.location_group_id,
+            name="Target Family",
+            contact_name="Target Family",
+            address="1 Target St",
+            phone_primary="5551111111",
+            delivery_type=DeliveryTypeEnum.FAMILY,
+            in_roster=True,
+        )
+        other_location = Location(
+            location_group_id=other_group.location_group_id,
+            name="Other Family",
+            contact_name="Other Family",
+            address="1 Other St",
+            phone_primary="5552222222",
+            delivery_type=DeliveryTypeEnum.FAMILY,
+            in_roster=True,
+        )
+        test_session.add(other_group)
+        test_session.add_all([target_location, other_location])
+        await test_session.commit()
+        await test_session.refresh(target_location)
+        await test_session.refresh(other_location)
+
+        response = await async_client.get(
+            "/locations/",
+            params={"location_group_id": str(test_location_group.location_group_id)},
+        )
+
+        assert response.status_code == 200
+        location_ids = {loc["location_id"] for loc in response.json()["items"]}
+        assert str(target_location.location_id) in location_ids
+        assert str(other_location.location_id) not in location_ids
+
+    @pytest.mark.asyncio
+    async def test_get_locations_filters_by_multiple_location_groups(
+        self,
+        async_client: AsyncClient,
+        test_session: AsyncSession,
+        test_location_group: Any,
+    ) -> None:
+        """GET /locations accepts repeated location_group_id query params."""
+        second_group = LocationGroup(name="Second Delivery Group", color="#33FF57")
+        third_group = LocationGroup(name="Third Delivery Group", color="#5733FF")
+        first_location = Location(
+            location_group_id=test_location_group.location_group_id,
+            name="First Group Family",
+            contact_name="First Group Family",
+            address="1 First St",
+            phone_primary="5551111111",
+            delivery_type=DeliveryTypeEnum.FAMILY,
+            in_roster=True,
+        )
+        second_location = Location(
+            location_group_id=second_group.location_group_id,
+            name="Second Group Family",
+            contact_name="Second Group Family",
+            address="1 Second St",
+            phone_primary="5552222222",
+            delivery_type=DeliveryTypeEnum.FAMILY,
+            in_roster=True,
+        )
+        third_location = Location(
+            location_group_id=third_group.location_group_id,
+            name="Third Group Family",
+            contact_name="Third Group Family",
+            address="1 Third St",
+            phone_primary="5553333333",
+            delivery_type=DeliveryTypeEnum.FAMILY,
+            in_roster=True,
+        )
+        test_session.add_all([second_group, third_group])
+        test_session.add_all([first_location, second_location, third_location])
+        await test_session.commit()
+        await test_session.refresh(first_location)
+        await test_session.refresh(second_location)
+        await test_session.refresh(third_location)
+
+        response = await async_client.get(
+            "/locations/",
+            params=[
+                ("location_group_id", str(test_location_group.location_group_id)),
+                ("location_group_id", str(second_group.location_group_id)),
+            ],
+        )
+
+        assert response.status_code == 200
+        location_ids = {loc["location_id"] for loc in response.json()["items"]}
+        assert str(first_location.location_id) in location_ids
+        assert str(second_location.location_id) in location_ids
+        assert str(third_location.location_id) not in location_ids
+
+    @pytest.mark.asyncio
     async def test_get_locations_filters_by_status(
         self,
         async_client: AsyncClient,
@@ -598,6 +699,136 @@ class TestLocationRoutes:
         assert str(active_school_location.location_id) in location_ids
         assert str(active_family_location.location_id) not in location_ids
         assert str(unscheduled_school_location.location_id) not in location_ids
+
+    @pytest.mark.asyncio
+    async def test_get_locations_filters_by_location_group_delivery_type_and_status(
+        self,
+        async_client: AsyncClient,
+        test_session: AsyncSession,
+        test_location_group: Any,
+    ) -> None:
+        """GET /locations composes location_group_id with existing filters."""
+        other_group = LocationGroup(name="Composed Other Group", color="#00AAFF")
+        matching_location = Location(
+            location_group_id=test_location_group.location_group_id,
+            name="Matching School",
+            contact_name="Matching School",
+            address="1 Matching St",
+            phone_primary="5551111111",
+            delivery_type=DeliveryTypeEnum.SCHOOL,
+            in_roster=True,
+        )
+        wrong_type_location = Location(
+            location_group_id=test_location_group.location_group_id,
+            name="Wrong Type Family",
+            contact_name="Wrong Type Family",
+            address="1 Wrong Type St",
+            phone_primary="5552222222",
+            delivery_type=DeliveryTypeEnum.FAMILY,
+            in_roster=True,
+        )
+        wrong_group_location = Location(
+            location_group_id=other_group.location_group_id,
+            name="Wrong Group School",
+            contact_name="Wrong Group School",
+            address="1 Wrong Group St",
+            phone_primary="5553333333",
+            delivery_type=DeliveryTypeEnum.SCHOOL,
+            in_roster=True,
+        )
+        inactive_location = Location(
+            location_group_id=test_location_group.location_group_id,
+            name="Inactive School",
+            contact_name="Inactive School",
+            address="1 Inactive St",
+            phone_primary="5554444444",
+            delivery_type=DeliveryTypeEnum.SCHOOL,
+            in_roster=False,
+        )
+        test_session.add(other_group)
+        test_session.add_all(
+            [
+                matching_location,
+                wrong_type_location,
+                wrong_group_location,
+                inactive_location,
+            ]
+        )
+        await test_session.commit()
+        await test_session.refresh(matching_location)
+        await test_session.refresh(wrong_type_location)
+        await test_session.refresh(wrong_group_location)
+        await test_session.refresh(inactive_location)
+
+        response = await async_client.get(
+            "/locations/",
+            params={
+                "location_group_id": str(test_location_group.location_group_id),
+                "delivery_type": "School",
+                "status": "Unscheduled",
+            },
+        )
+
+        assert response.status_code == 200
+        location_ids = {loc["location_id"] for loc in response.json()["items"]}
+        assert str(matching_location.location_id) in location_ids
+        assert str(wrong_type_location.location_id) not in location_ids
+        assert str(wrong_group_location.location_id) not in location_ids
+        assert str(inactive_location.location_id) not in location_ids
+
+    @pytest.mark.asyncio
+    async def test_get_locations_location_group_filter_preserves_pagination(
+        self,
+        async_client: AsyncClient,
+        test_session: AsyncSession,
+        test_location_group: Any,
+    ) -> None:
+        """GET /locations paginates after filtering by location_group_id."""
+        other_group = LocationGroup(name="Pagination Other Group", color="#AA00FF")
+        target_locations = [
+            Location(
+                location_group_id=test_location_group.location_group_id,
+                name=f"Paged Family {index}",
+                contact_name=f"Paged Family {index}",
+                address=f"{index} Paged St",
+                phone_primary=f"555111111{index}",
+                delivery_type=DeliveryTypeEnum.FAMILY,
+                in_roster=True,
+            )
+            for index in range(3)
+        ]
+        other_location = Location(
+            location_group_id=other_group.location_group_id,
+            name="Excluded Paged Family",
+            contact_name="Excluded Paged Family",
+            address="1 Excluded Paged St",
+            phone_primary="5552222222",
+            delivery_type=DeliveryTypeEnum.FAMILY,
+            in_roster=True,
+        )
+        test_session.add(other_group)
+        test_session.add_all([*target_locations, other_location])
+        await test_session.commit()
+
+        response = await async_client.get(
+            "/locations/",
+            params={
+                "location_group_id": str(test_location_group.location_group_id),
+                "page": 1,
+                "page_size": 2,
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data["items"]) == 2
+        assert data["total"] == 3
+        assert data["page"] == 1
+        assert data["page_size"] == 2
+        assert data["total_pages"] == 2
+        assert {
+            item["location_group_id"] for item in data["items"]
+        } == {str(test_location_group.location_group_id)}
 
     @pytest.mark.asyncio
     async def test_get_location_by_id(

--- a/backend/python/tests/test_routes.py
+++ b/backend/python/tests/test_routes.py
@@ -826,9 +826,9 @@ class TestLocationRoutes:
         assert data["page"] == 1
         assert data["page_size"] == 2
         assert data["total_pages"] == 2
-        assert {
-            item["location_group_id"] for item in data["items"]
-        } == {str(test_location_group.location_group_id)}
+        assert {item["location_group_id"] for item in data["items"]} == {
+            str(test_location_group.location_group_id)
+        }
 
     @pytest.mark.asyncio
     async def test_get_location_by_id(

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -5287,6 +5287,28 @@
             }
           },
           {
+            "description": "Filter by one or more location groups",
+            "in": "query",
+            "name": "location_group_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "items": {
+                    "format": "uuid",
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter by one or more location groups",
+              "title": "Location Group Id"
+            }
+          },
+          {
             "description": "Page number (1-indexed)",
             "in": "query",
             "name": "page",

--- a/frontend/src/api/generated/types.gen.ts
+++ b/frontend/src/api/generated/types.gen.ts
@@ -3282,6 +3282,12 @@ export type GetLocationsData = {
      */
     status?: Array<LocationStatusEnum> | null;
     /**
+     * Location Group Id
+     *
+     * Filter by one or more location groups
+     */
+    location_group_id?: Array<string> | null;
+    /**
      * Page
      *
      * Page number (1-indexed)


### PR DESCRIPTION
## What changed
This adds a new `location_group_id` filter to `GET /locations/`, so callers can fetch locations for one or more location groups from the normal paginated locations endpoint.

I also added tests for filtering by one group, multiple groups, using it with the existing delivery type and status filters, and making sure pagination still works.

## Tested
- `docker compose exec backend ruff check app tests`
- `docker compose exec backend mypy . --config-file mypy.ini`
- `docker compose exec backend python -m pytest tests/test_routes.py`
- `docker compose exec backend python -m pytest`