### PR TITLE
Upgrade PostgreSQL 12/15 → 17 across dev and CI

### DIFF
--- a/.github/workflows/boot-smoke.yml
+++ b/.github/workflows/boot-smoke.yml
@@ -25,7 +25,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:12-alpine
+        image: postgres:17-alpine
         env:
           POSTGRES_PASSWORD: password
           POSTGRES_USER: postgres

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -20,7 +20,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:15
+        image: postgres:17
         env:
           POSTGRES_PASSWORD: password
           POSTGRES_USER: postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
       - ./.env
   db:
     container_name: f4k_db
-    image: postgres:12-alpine
+    image: postgres:17-alpine
     ports:
       - 5432:5432
     volumes:


### PR DESCRIPTION
## What

Pins PostgreSQL **17** everywhere:

| File | Before | After |
|---|---|---|
| `docker-compose.yml` (local dev) | `postgres:12-alpine` | `postgres:17-alpine` |
| `.github/workflows/boot-smoke.yml` | `postgres:12-alpine` | `postgres:17-alpine` |
| `.github/workflows/pytest.yml` (CI tests) | `postgres:15` | `postgres:17` |

## Why

- Local dev + boot-smoke were on **Postgres 12**, inherited from the Blueprint starter template — never a deliberate choice. **Postgres 12 hit end-of-life in Nov 2024** (no more security patches).
- CI pytest was on **15**, so we were developing against 12 but testing against 15 — a silent version mismatch.
- This aligns all three on **17**, the current well-shaken-out stable.

## ⚠️ Local dev: wipe your DB volume

A Postgres data directory initialized by v12 is **not** readable by v17, so the `postgres_data` volume must be recreated. After pulling:

```bash
docker compose down -v   # drops the old postgres_data volume
docker compose up --build
```

`./db-init` will re-seed on the fresh volume. (CI is unaffected — it starts a clean container each run.)

## Out of scope

Production DB version is not configured in this repo. If prod is also on 12 (likely, same template heritage — Heroku Postgres), it should be upgraded separately as a coordinated migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)