### PR TITLE
F4KRP 208: Align location import validation with Current Validate Screen Requirements

### DIFF
--- a/backend/python/app/models/location.py
+++ b/backend/python/app/models/location.py
@@ -79,13 +79,16 @@ class Location(LocationBase, BaseModel, table=True):
 
 
 class AlertCode(str, Enum):
-    """Machine-readable reason code for an import alert."""
+    """Machine-readable blocking error code for an import row."""
 
-    MISSING_FIELDS = "MISSING_FIELDS"
-    INVALID_FORMAT = "INVALID_FORMAT"
-    LOCAL_DUPLICATE = "LOCAL_DUPLICATE"
+    MISSING_ADDRESS = "MISSING_ADDRESS"
+    INVALID_ADDRESS = "INVALID_ADDRESS"
+    MISSING_PHONE_NUMBER = "MISSING_PHONE_NUMBER"
+    INVALID_PHONE_NUMBER = "INVALID_PHONE_NUMBER"
+    MISSING_SCHOOL_OR_LAST_NAME = "MISSING_SCHOOL_OR_LAST_NAME"
+    INVALID_SCHOOL_OR_LAST_NAME = "INVALID_SCHOOL_OR_LAST_NAME"
     MISSING_DELIVERY_GROUP = "MISSING_DELIVERY_GROUP"
-    PARTIAL_DUPLICATE = "PARTIAL_DUPLICATE"
+    DUPLICATE_ENTRY = "DUPLICATE_ENTRY"
 
 
 class LocationImportEntry(SQLModel):
@@ -179,14 +182,17 @@ class ChangedEntry(SQLModel):
 class LocationImportResponse(SQLModel):
     """Combined validate + review-changes payload.
 
-    success=False when any row has alerts. net_new/stale/changed describe how the
-    import would affect the existing locations table; these are placeholders until
-    the matching logic is implemented.
+    success=False when any row has alerts. duplicate_groups lists row numbers
+    (1-based, matching LocationImportRow.row) for each within-file duplicate
+    cluster. net_new/stale/changed describe how the import would affect the
+    existing locations table; these are placeholders until the matching logic
+    is implemented.
     """
 
     success: bool
     total_rows: int
     rows: list[LocationImportRow]
+    duplicate_groups: list[list[int]] = []
     net_new: list[NetNewEntry] = []
     stale: list[StaleEntry] = []
     changed: list[ChangedEntry] = []

--- a/backend/python/app/services/implementations/location_import_validation.py
+++ b/backend/python/app/services/implementations/location_import_validation.py
@@ -44,13 +44,14 @@ def collect_field_alerts(
     *,
     geocode_ok: bool | None,
     phone_invalid: bool,
+    phone_secondary_invalid: bool = False,
 ) -> list[AlertCode]:
     """Collect per-field blocking alerts for one parsed import row."""
     alerts: list[AlertCode] = []
 
     if is_blank(entry.contact_name):
         alerts.append(AlertCode.MISSING_SCHOOL_OR_LAST_NAME)
-    elif present_str(entry.contact_name) and is_invalid_school_or_last_name(
+    elif entry.contact_name is not None and is_invalid_school_or_last_name(
         entry.contact_name
     ):
         alerts.append(AlertCode.INVALID_SCHOOL_OR_LAST_NAME)
@@ -63,6 +64,9 @@ def collect_field_alerts(
     if is_blank(entry.phone_primary):
         alerts.append(AlertCode.MISSING_PHONE_NUMBER)
     elif phone_invalid:
+        alerts.append(AlertCode.INVALID_PHONE_NUMBER)
+
+    if phone_secondary_invalid:
         alerts.append(AlertCode.INVALID_PHONE_NUMBER)
 
     if is_blank(entry.delivery_group):
@@ -80,7 +84,7 @@ def _name_match_key(name: str | None) -> str | None:
 def _address_match_key(address: str | None) -> str | None:
     if not present_str(address):
         return None
-    return address.strip()
+    return address.strip().casefold()
 
 
 def _phone_match_key(phone: str | None, normalized_phone: str | None) -> str | None:

--- a/backend/python/app/services/implementations/location_import_validation.py
+++ b/backend/python/app/services/implementations/location_import_validation.py
@@ -2,10 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, TypeGuard
-
-if TYPE_CHECKING:
-    from collections.abc import Sequence
+from typing import TypeGuard
 
 from app.models.location import AlertCode, LocationImportEntry
 from app.utilities.utils import validate_phone
@@ -87,9 +84,12 @@ def _address_match_key(address: str | None) -> str | None:
     return address.strip().casefold()
 
 
-def _phone_match_key(phone: str | None, normalized_phone: str | None) -> str | None:
-    if normalized_phone:
-        return normalized_phone
+def _phone_match_key(phone: str | None) -> str | None:
+    """Match key for phone_primary.
+
+    Callers should normalize phones onto the entry before duplicate detection
+    (see review_locations) so valid numbers compare as E.164.
+    """
     if not present_str(phone):
         return None
     return phone.strip()
@@ -98,11 +98,8 @@ def _phone_match_key(phone: str | None, normalized_phone: str | None) -> str | N
 def count_duplicate_field_matches(
     left: LocationImportEntry,
     right: LocationImportEntry,
-    *,
-    left_phone: str | None,
-    right_phone: str | None,
 ) -> int:
-    """Count how many of {name, address, phone} match between two rows, which is the 2-of-3 rule"""
+    """Count how many of {name, address, phone} match between two rows (2-of-3 rule)."""
     matches = 0
 
     left_name = _name_match_key(left.contact_name)
@@ -115,8 +112,8 @@ def count_duplicate_field_matches(
     if left_address and right_address and left_address == right_address:
         matches += 1
 
-    left_phone_key = _phone_match_key(left.phone_primary, left_phone)
-    right_phone_key = _phone_match_key(right.phone_primary, right_phone)
+    left_phone_key = _phone_match_key(left.phone_primary)
+    right_phone_key = _phone_match_key(right.phone_primary)
     if left_phone_key and right_phone_key and left_phone_key == right_phone_key:
         matches += 1
 
@@ -126,20 +123,9 @@ def count_duplicate_field_matches(
 def rows_are_duplicates(
     left: LocationImportEntry,
     right: LocationImportEntry,
-    *,
-    left_phone: str | None,
-    right_phone: str | None,
 ) -> bool:
     """True when at least two of {name, address, phone} match (2-of-3 rule)."""
-    return (
-        count_duplicate_field_matches(
-            left,
-            right,
-            left_phone=left_phone,
-            right_phone=right_phone,
-        )
-        >= 2
-    )
+    return count_duplicate_field_matches(left, right) >= 2
 
 
 class _UnionFind:
@@ -162,11 +148,11 @@ class _UnionFind:
 
 def find_duplicate_index_groups(
     entries: list[LocationImportEntry],
-    normalized_phones: Sequence[str | None],
 ) -> list[list[int]]:
     """Return duplicate clusters as lists of 0-based indices (size >= 2).
 
     Transitive duplicates are merged via union-find (A~B and B~C => one group).
+    Expects phone_primary to already be normalized when possible.
     """
     size = len(entries)
     if size < 2:
@@ -176,12 +162,7 @@ def find_duplicate_index_groups(
     union_find = _UnionFind(size)
     for left in range(size):
         for right in range(left + 1, size):
-            if rows_are_duplicates(
-                entries[left],
-                entries[right],
-                left_phone=normalized_phones[left],
-                right_phone=normalized_phones[right],
-            ):
+            if rows_are_duplicates(entries[left], entries[right]):
                 union_find.union(left, right)
 
     clusters: dict[int, list[int]] = {}

--- a/backend/python/app/services/implementations/location_import_validation.py
+++ b/backend/python/app/services/implementations/location_import_validation.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
-from typing import TypeGuard
+from typing import TYPE_CHECKING, TypeGuard
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 from app.models.location import AlertCode, LocationImportEntry
 from app.utilities.utils import validate_phone

--- a/backend/python/app/services/implementations/location_import_validation.py
+++ b/backend/python/app/services/implementations/location_import_validation.py
@@ -1,0 +1,186 @@
+"""Pure validation helpers for the location import review step."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import TypeGuard
+
+from app.models.location import AlertCode, LocationImportEntry
+from app.utilities.utils import validate_phone
+
+
+def is_blank(value: str | None) -> bool:
+    return value is None or not value.strip()
+
+
+def present_str(value: str | None) -> TypeGuard[str]:
+    """True when value is a non-empty string after stripping."""
+    return value is not None and bool(value.strip())
+
+
+def is_invalid_school_or_last_name(name: str) -> bool:
+    """True when the name is present but all digits (e.g. '33333333')."""
+    stripped = name.strip()
+    return bool(stripped) and stripped.isdigit()
+
+
+def try_normalize_phone(phone: str | None) -> tuple[str | None, bool]:
+    """Return (E.164 phone, is_invalid).
+
+    is_invalid is True only when a non-empty value fails validation.
+    """
+    if not present_str(phone):
+        return None, False
+    try:
+        return validate_phone(phone), False
+    except ValueError:
+        return None, True
+
+
+def collect_field_alerts(
+    entry: LocationImportEntry,
+    *,
+    geocode_ok: bool | None,
+    phone_invalid: bool,
+) -> list[AlertCode]:
+    """Collect per-field blocking alerts for one parsed import row."""
+    alerts: list[AlertCode] = []
+
+    if is_blank(entry.contact_name):
+        alerts.append(AlertCode.MISSING_SCHOOL_OR_LAST_NAME)
+    elif present_str(entry.contact_name) and is_invalid_school_or_last_name(
+        entry.contact_name
+    ):
+        alerts.append(AlertCode.INVALID_SCHOOL_OR_LAST_NAME)
+
+    if is_blank(entry.address):
+        alerts.append(AlertCode.MISSING_ADDRESS)
+    elif geocode_ok is False:
+        alerts.append(AlertCode.INVALID_ADDRESS)
+
+    if is_blank(entry.phone_primary):
+        alerts.append(AlertCode.MISSING_PHONE_NUMBER)
+    elif phone_invalid:
+        alerts.append(AlertCode.INVALID_PHONE_NUMBER)
+
+    if is_blank(entry.delivery_group):
+        alerts.append(AlertCode.MISSING_DELIVERY_GROUP)
+
+    return alerts
+
+
+def _name_match_key(name: str | None) -> str | None:
+    if not present_str(name):
+        return None
+    return name.strip().casefold()
+
+
+def _address_match_key(address: str | None) -> str | None:
+    if not present_str(address):
+        return None
+    return address.strip()
+
+
+def _phone_match_key(phone: str | None, normalized_phone: str | None) -> str | None:
+    if normalized_phone:
+        return normalized_phone
+    if not present_str(phone):
+        return None
+    return phone.strip()
+
+
+def count_duplicate_field_matches(
+    left: LocationImportEntry,
+    right: LocationImportEntry,
+    *,
+    left_phone: str | None,
+    right_phone: str | None,
+) -> int:
+    """Count how many of {name, address, phone} match between two rows, which is the 2-of-3 rule"""
+    matches = 0
+
+    left_name = _name_match_key(left.contact_name)
+    right_name = _name_match_key(right.contact_name)
+    if left_name and right_name and left_name == right_name:
+        matches += 1
+
+    left_address = _address_match_key(left.address)
+    right_address = _address_match_key(right.address)
+    if left_address and right_address and left_address == right_address:
+        matches += 1
+
+    left_phone_key = _phone_match_key(left.phone_primary, left_phone)
+    right_phone_key = _phone_match_key(right.phone_primary, right_phone)
+    if left_phone_key and right_phone_key and left_phone_key == right_phone_key:
+        matches += 1
+
+    return matches
+
+
+def rows_are_duplicates(
+    left: LocationImportEntry,
+    right: LocationImportEntry,
+    *,
+    left_phone: str | None,
+    right_phone: str | None,
+) -> bool:
+    """True when at least two of {name, address, phone} match (2-of-3 rule)."""
+    return (
+        count_duplicate_field_matches(
+            left,
+            right,
+            left_phone=left_phone,
+            right_phone=right_phone,
+        )
+        >= 2
+    )
+
+
+class _UnionFind:
+    # This is a union-find data structure. It is used to find groups of duplicate rows.
+    def __init__(self, size: int) -> None:
+        self._parent = list(range(size))
+
+    def find(self, node: int) -> int:
+        while self._parent[node] != node:
+            self._parent[node] = self._parent[self._parent[node]]
+            node = self._parent[node]
+        return node
+
+    def union(self, left: int, right: int) -> None:
+        root_left = self.find(left)
+        root_right = self.find(right)
+        if root_left != root_right:
+            self._parent[root_right] = root_left
+
+
+def find_duplicate_index_groups(
+    entries: list[LocationImportEntry],
+    normalized_phones: Sequence[str | None],
+) -> list[list[int]]:
+    """Return duplicate clusters as lists of 0-based indices (size >= 2).
+
+    Transitive duplicates are merged via union-find (A~B and B~C => one group).
+    """
+    size = len(entries)
+    if size < 2:
+        return []
+
+    # Create a union-find data structure to find the connected components
+    union_find = _UnionFind(size)
+    for left in range(size):
+        for right in range(left + 1, size):
+            if rows_are_duplicates(
+                entries[left],
+                entries[right],
+                left_phone=normalized_phones[left],
+                right_phone=normalized_phones[right],
+            ):
+                union_find.union(left, right)
+
+    clusters: dict[int, list[int]] = {}
+    for index in range(size):
+        root = union_find.find(index)
+        clusters.setdefault(root, []).append(index)
+
+    return [sorted(indices) for indices in clusters.values() if len(indices) >= 2]

--- a/backend/python/app/services/implementations/location_service.py
+++ b/backend/python/app/services/implementations/location_service.py
@@ -499,20 +499,33 @@ class LocationService:
                 row_num = int(index) + 1  # type: ignore[call-overload]
                 parsed_rows.append((row_num, self._parse_row(row, column_map)))
 
-            geocode_cache: dict[str, GeocodeResult | None] = {}
             unique_addresses = {
                 entry.address.strip()
                 for _, entry in parsed_rows
                 if present_str(entry.address)
             }
-            if unique_addresses:
+            known_valid_addresses = await self._existing_geocoded_addresses(
+                session, unique_addresses
+            )
+            addresses_to_geocode = unique_addresses - known_valid_addresses
+            geocode_ok_by_address: dict[str, bool] = dict.fromkeys(
+                known_valid_addresses, True
+            )
+            if addresses_to_geocode:
                 geocoded = await asyncio.gather(
                     *(
                         self._geocode_import_address(address)
-                        for address in unique_addresses
+                        for address in addresses_to_geocode
                     )
                 )
-                geocode_cache = dict(zip(unique_addresses, geocoded, strict=True))
+                geocode_ok_by_address.update(
+                    {
+                        address: result is not None
+                        for address, result in zip(
+                            addresses_to_geocode, geocoded, strict=True
+                        )
+                    }
+                )
 
             phone_invalid_flags: list[bool] = []
             phone_secondary_invalid_flags: list[bool] = []
@@ -542,8 +555,7 @@ class LocationService:
                 if is_blank(entry.address):
                     geocode_ok = None
                 elif entry.address is not None:
-                    geocode_result = geocode_cache.get(entry.address.strip())
-                    geocode_ok = geocode_result is not None
+                    geocode_ok = geocode_ok_by_address.get(entry.address.strip())
                 else:
                     geocode_ok = None
 
@@ -573,6 +585,27 @@ class LocationService:
         except Exception as e:
             self.logger.error(f"Failed to validate locations: {e!s}")
             raise e
+
+    async def _existing_geocoded_addresses(
+        self, session: AsyncSession, addresses: set[str]
+    ) -> set[str]:
+        """Return the subset of addresses that already exist on a geocoded Location.
+
+        Exact match on Location.address (import side is already stripped). Only
+        rows with latitude/longitude count as known-valid so we still geocode
+        addresses that were stored without coordinates.
+        """
+        if not addresses:
+            return set()
+
+        result = await session.execute(
+            select(Location.address).where(
+                col(Location.address).in_(addresses),
+                col(Location.latitude).is_not(None),
+                col(Location.longitude).is_not(None),
+            )
+        )
+        return {address for address in result.scalars().all() if address in addresses}
 
     async def _geocode_import_address(
         self, address: str | None

--- a/backend/python/app/services/implementations/location_service.py
+++ b/backend/python/app/services/implementations/location_service.py
@@ -4,7 +4,7 @@ import os
 from collections.abc import Iterable
 from datetime import datetime
 from io import BytesIO
-from typing import TYPE_CHECKING, Any, TypeGuard
+from typing import TYPE_CHECKING, Any
 from uuid import UUID
 from zoneinfo import ZoneInfo
 
@@ -31,7 +31,6 @@ from app.models.location import (
     LocationIngestResponse,
     LocationRead,
     LocationUpdate,
-    ValidatedLocationImportEntry,
 )
 from app.models.location_group import LocationGroup
 from app.models.note_chain import NoteChain
@@ -500,23 +499,38 @@ class LocationService:
                 row_num = int(index) + 1  # type: ignore[call-overload]
                 parsed_rows.append((row_num, self._parse_row(row, column_map)))
 
-            geocode_results = await asyncio.gather(
-                *(
-                    self._geocode_import_address(entry.address)
-                    for _, entry in parsed_rows
+            geocode_cache: dict[str, GeocodeResult | None] = {}
+            unique_addresses = {
+                entry.address.strip()
+                for _, entry in parsed_rows
+                if present_str(entry.address)
+            }
+            if unique_addresses:
+                geocoded = await asyncio.gather(
+                    *(
+                        self._geocode_import_address(address)
+                        for address in unique_addresses
+                    )
                 )
-            )
+                geocode_cache = dict(zip(unique_addresses, geocoded, strict=True))
 
             normalized_phones: list[str | None] = []
             phone_invalid_flags: list[bool] = []
+            phone_secondary_invalid_flags: list[bool] = []
             for _, entry in parsed_rows:
                 normalized_phone, phone_invalid = try_normalize_phone(
                     entry.phone_primary
                 )
                 if normalized_phone:
                     entry.phone_primary = normalized_phone
+                normalized_secondary, secondary_invalid = try_normalize_phone(
+                    entry.phone_secondary
+                )
+                if normalized_secondary:
+                    entry.phone_secondary = normalized_secondary
                 normalized_phones.append(normalized_phone)
                 phone_invalid_flags.append(phone_invalid)
+                phone_secondary_invalid_flags.append(secondary_invalid)
 
             entries = [entry for _, entry in parsed_rows]
             duplicate_index_groups = find_duplicate_index_groups(
@@ -531,13 +545,17 @@ class LocationService:
                 geocode_ok: bool | None
                 if is_blank(entry.address):
                     geocode_ok = None
+                elif entry.address is not None:
+                    geocode_result = geocode_cache.get(entry.address.strip())
+                    geocode_ok = geocode_result is not None
                 else:
-                    geocode_ok = geocode_results[index] is not None
+                    geocode_ok = None
 
                 alerts = collect_field_alerts(
                     entry,
                     geocode_ok=geocode_ok,
                     phone_invalid=phone_invalid_flags[index],
+                    phone_secondary_invalid=phone_secondary_invalid_flags[index],
                 )
                 if index in duplicate_indices:
                     alerts.append(AlertCode.DUPLICATE_ENTRY)
@@ -634,18 +652,6 @@ class LocationService:
             num_children=parse_int("num_children"),
             halal=parse_bool("halal"),
             dietary_restrictions=get_value("dietary_restrictions"),
-        )
-
-    @staticmethod
-    def _has_required_fields(
-        entry: LocationImportEntry,
-    ) -> TypeGuard[ValidatedLocationImportEntry]:
-        """Returns True (and narrows to ValidatedLocationImportEntry) when all required
-        fields are present; False when any are missing."""
-        return (
-            entry.contact_name is not None
-            and entry.address is not None
-            and entry.phone_primary is not None
         )
 
     async def _build_location(self, location_data: LocationCreate) -> Location:

--- a/backend/python/app/services/implementations/location_service.py
+++ b/backend/python/app/services/implementations/location_service.py
@@ -41,9 +41,15 @@ from app.models.route_snapshot import RouteSnapshot
 from app.models.route_stop import RouteStop
 from app.models.route_stop_snapshot import RouteStopSnapshot
 from app.schemas.pagination import PaginatedResponse, PaginationParams
-from app.utilities.google_maps_client import GoogleMapsClient
+from app.services.implementations.location_import_validation import (
+    collect_field_alerts,
+    find_duplicate_index_groups,
+    is_blank,
+    present_str,
+    try_normalize_phone,
+)
+from app.utilities.google_maps_client import GeocodeResult, GoogleMapsClient
 from app.utilities.pagination import paginate_query
-from app.utilities.utils import validate_phone
 
 if TYPE_CHECKING:
     from app.services.implementations.system_settings_service import (
@@ -488,78 +494,79 @@ class LocationService:
             )
             await session.commit()
             df = await self._read_upload_file(file)
-            rows: list[LocationImportRow] = []
-
-            # track local duplicates
-            full_dup_keys: dict[tuple[str, str, str], int] = {}
-            address_keys: dict[str, int] = {}
-            phone_keys: dict[str, int] = {}
+            parsed_rows: list[tuple[int, LocationImportEntry]] = []
 
             for index, row in df.iterrows():
                 row_num = int(index) + 1  # type: ignore[call-overload]
-                location = self._parse_row(row, column_map)
-                alerts: list[AlertCode] = []
+                parsed_rows.append((row_num, self._parse_row(row, column_map)))
 
-                # missing required fields
-                if not self._has_required_fields(location):
-                    alerts.append(AlertCode.MISSING_FIELDS)
-                    rows.append(
-                        LocationImportRow(row=row_num, location=location, alerts=alerts)
-                    )
-                    continue
-
-                # invalid phone number format
-                try:
-                    location.phone_primary = validate_phone(location.phone_primary)
-                    if location.phone_secondary:
-                        location.phone_secondary = validate_phone(
-                            location.phone_secondary
-                        )
-                except ValueError:
-                    alerts.append(AlertCode.INVALID_FORMAT)
-                    rows.append(
-                        LocationImportRow(row=row_num, location=location, alerts=alerts)
-                    )
-                    continue
-
-                # missing delivery group
-                if not location.delivery_group:
-                    alerts.append(AlertCode.MISSING_DELIVERY_GROUP)
-
-                # full duplicate (same contact name, address, and phone)
-                full_key = (
-                    location.contact_name,
-                    location.address,
-                    location.phone_primary,
+            geocode_results = await asyncio.gather(
+                *(
+                    self._geocode_import_address(entry.address)
+                    for _, entry in parsed_rows
                 )
-                if full_key in full_dup_keys:
-                    alerts.append(AlertCode.LOCAL_DUPLICATE)
-                else:
-                    full_dup_keys[full_key] = row_num
+            )
 
-                    # partial duplicate — same address or same phone
-                    if (
-                        location.address in address_keys
-                        or location.phone_primary in phone_keys
-                    ):
-                        alerts.append(AlertCode.PARTIAL_DUPLICATE)
-                    if location.address not in address_keys:
-                        address_keys[location.address] = row_num
-                    if location.phone_primary not in phone_keys:
-                        phone_keys[location.phone_primary] = row_num
+            normalized_phones: list[str | None] = []
+            phone_invalid_flags: list[bool] = []
+            for _, entry in parsed_rows:
+                normalized_phone, phone_invalid = try_normalize_phone(
+                    entry.phone_primary
+                )
+                if normalized_phone:
+                    entry.phone_primary = normalized_phone
+                normalized_phones.append(normalized_phone)
+                phone_invalid_flags.append(phone_invalid)
+
+            entries = [entry for _, entry in parsed_rows]
+            duplicate_index_groups = find_duplicate_index_groups(
+                entries, normalized_phones
+            )
+            duplicate_indices = {
+                index for group in duplicate_index_groups for index in group
+            }
+
+            rows: list[LocationImportRow] = []
+            for index, (row_num, entry) in enumerate(parsed_rows):
+                geocode_ok: bool | None
+                if is_blank(entry.address):
+                    geocode_ok = None
+                else:
+                    geocode_ok = geocode_results[index] is not None
+
+                alerts = collect_field_alerts(
+                    entry,
+                    geocode_ok=geocode_ok,
+                    phone_invalid=phone_invalid_flags[index],
+                )
+                if index in duplicate_indices:
+                    alerts.append(AlertCode.DUPLICATE_ENTRY)
 
                 rows.append(
-                    LocationImportRow(row=row_num, location=location, alerts=alerts)
+                    LocationImportRow(row=row_num, location=entry, alerts=alerts)
                 )
+
+            duplicate_groups = [
+                [parsed_rows[i][0] for i in group] for group in duplicate_index_groups
+            ]
 
             return LocationImportResponse(
                 success=not any(r.alerts for r in rows),
                 total_rows=len(rows),
                 rows=rows,
+                duplicate_groups=duplicate_groups,
             )
         except Exception as e:
             self.logger.error(f"Failed to validate locations: {e!s}")
             raise e
+
+    async def _geocode_import_address(
+        self, address: str | None
+    ) -> GeocodeResult | None:
+        """Geocode a non-blank import address; skip geocoding when address is missing."""
+        if not present_str(address):
+            return None
+        return await self.google_maps_service.geocode_address(address)
 
     async def _read_upload_file(self, file: UploadFile) -> pd.DataFrame:
         """Validate file type and read into a DataFrame."""

--- a/backend/python/app/services/implementations/location_service.py
+++ b/backend/python/app/services/implementations/location_service.py
@@ -514,7 +514,6 @@ class LocationService:
                 )
                 geocode_cache = dict(zip(unique_addresses, geocoded, strict=True))
 
-            normalized_phones: list[str | None] = []
             phone_invalid_flags: list[bool] = []
             phone_secondary_invalid_flags: list[bool] = []
             for _, entry in parsed_rows:
@@ -528,14 +527,11 @@ class LocationService:
                 )
                 if normalized_secondary:
                     entry.phone_secondary = normalized_secondary
-                normalized_phones.append(normalized_phone)
                 phone_invalid_flags.append(phone_invalid)
                 phone_secondary_invalid_flags.append(secondary_invalid)
 
             entries = [entry for _, entry in parsed_rows]
-            duplicate_index_groups = find_duplicate_index_groups(
-                entries, normalized_phones
-            )
+            duplicate_index_groups = find_duplicate_index_groups(entries)
             duplicate_indices = {
                 index for group in duplicate_index_groups for index in group
             }

--- a/backend/python/app/utilities/google_maps_client.py
+++ b/backend/python/app/utilities/google_maps_client.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import re
 from dataclasses import dataclass
@@ -25,6 +26,9 @@ class GoogleMapsClient:
 
     async def geocode_address(self, address: str) -> GeocodeResult | None:
         """Geocode a single address string using Google Maps Geocoding API"""
+        return await asyncio.to_thread(self._geocode_address_sync, address)
+
+    def _geocode_address_sync(self, address: str) -> GeocodeResult | None:
         cleaned_address = self._clean_address(address)
         geocode_result = self.client.geocode(cleaned_address, region=self.region_bias)
 

--- a/backend/python/tests/test_location_import_validation.py
+++ b/backend/python/tests/test_location_import_validation.py
@@ -8,7 +8,6 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from app.models.enum import DeliveryTypeEnum
 from app.models.location import AlertCode, Location, LocationImportEntry
 from app.services.implementations.location_import_validation import (
     collect_field_alerts,
@@ -275,7 +274,7 @@ class TestExistingGeocodedAddresses:
                 location_group_id=test_location_group.location_group_id,
                 name="Known",
                 contact_name="Known",
-                delivery_type=DeliveryTypeEnum.FAMILY,
+                delivery_type="Family",
                 address=known,
                 phone_primary="+15195551234",
                 longitude=-80.5,
@@ -287,7 +286,7 @@ class TestExistingGeocodedAddresses:
                 location_group_id=test_location_group.location_group_id,
                 name="Bare",
                 contact_name="Bare",
-                delivery_type=DeliveryTypeEnum.FAMILY,
+                delivery_type="Family",
                 address=ungeocoded,
                 phone_primary="+15195551235",
                 longitude=None,

--- a/backend/python/tests/test_location_import_validation.py
+++ b/backend/python/tests/test_location_import_validation.py
@@ -2,7 +2,14 @@
 
 from __future__ import annotations
 
-from app.models.location import AlertCode, LocationImportEntry
+import logging
+from typing import TYPE_CHECKING, Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.models.enum import DeliveryTypeEnum
+from app.models.location import AlertCode, Location, LocationImportEntry
 from app.services.implementations.location_import_validation import (
     collect_field_alerts,
     count_duplicate_field_matches,
@@ -10,6 +17,10 @@ from app.services.implementations.location_import_validation import (
     is_invalid_school_or_last_name,
     rows_are_duplicates,
 )
+from app.services.implementations.location_service import LocationService
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
 
 
 def _entry(
@@ -248,3 +259,58 @@ class TestDuplicateDetection:
         ]
         groups = find_duplicate_index_groups(entries)
         assert groups == [[0, 1]]
+
+
+class TestExistingGeocodedAddresses:
+    @pytest.mark.asyncio
+    async def test_returns_exact_matches_with_coordinates(
+        self, test_session: AsyncSession, test_location_group: Any
+    ) -> None:
+        known = "123 Main St, City, State 12345"
+        unknown = "999 New Ave"
+        ungeocoded = "No Coords Rd"
+
+        test_session.add(
+            Location(
+                location_group_id=test_location_group.location_group_id,
+                name="Known",
+                contact_name="Known",
+                delivery_type=DeliveryTypeEnum.FAMILY,
+                address=known,
+                phone_primary="+15195551234",
+                longitude=-80.5,
+                latitude=43.4,
+            )
+        )
+        test_session.add(
+            Location(
+                location_group_id=test_location_group.location_group_id,
+                name="Bare",
+                contact_name="Bare",
+                delivery_type=DeliveryTypeEnum.FAMILY,
+                address=ungeocoded,
+                phone_primary="+15195551235",
+                longitude=None,
+                latitude=None,
+            )
+        )
+        await test_session.flush()
+
+        service = LocationService(
+            logging.getLogger("test"),
+            MagicMock(),
+            MagicMock(),
+        )
+        result = await service._existing_geocoded_addresses(
+            test_session, {known, unknown, ungeocoded}
+        )
+        assert result == {known}
+
+    @pytest.mark.asyncio
+    async def test_empty_input_returns_empty(self, test_session: AsyncSession) -> None:
+        service = LocationService(
+            logging.getLogger("test"),
+            MagicMock(),
+            MagicMock(),
+        )
+        assert await service._existing_geocoded_addresses(test_session, set()) == set()

--- a/backend/python/tests/test_location_import_validation.py
+++ b/backend/python/tests/test_location_import_validation.py
@@ -81,6 +81,21 @@ class TestFieldValidation:
         )
         assert AlertCode.INVALID_PHONE_NUMBER in alerts
 
+    def test_invalid_phone_secondary(self) -> None:
+        alerts = collect_field_alerts(
+            LocationImportEntry(
+                contact_name="Smith",
+                address="123 Main St",
+                delivery_group="Tuesday A",
+                phone_primary="+15195551234",
+                phone_secondary="not-a-phone",
+            ),
+            geocode_ok=True,
+            phone_invalid=False,
+            phone_secondary_invalid=True,
+        )
+        assert AlertCode.INVALID_PHONE_NUMBER in alerts
+
     def test_multiple_errors_on_one_row(self) -> None:
         alerts = collect_field_alerts(
             _entry(contact_name="33333333", delivery_group=None),
@@ -213,6 +228,13 @@ class TestDuplicateDetection:
     def test_name_match_is_case_insensitive(self) -> None:
         left = _entry(contact_name="Smith")
         right = _entry(contact_name="smith")
+        assert rows_are_duplicates(
+            left, right, left_phone="+15195551234", right_phone="+15195551234"
+        )
+
+    def test_address_match_is_case_insensitive(self) -> None:
+        left = _entry(address="123 Main St")
+        right = _entry(address="123 main st")
         assert rows_are_duplicates(
             left, right, left_phone="+15195551234", right_phone="+15195551234"
         )

--- a/backend/python/tests/test_location_import_validation.py
+++ b/backend/python/tests/test_location_import_validation.py
@@ -118,9 +118,7 @@ class TestDuplicateDetection:
             address="105 Albert St",
             phone_primary="+15192842498",
         )
-        assert rows_are_duplicates(
-            left, right, left_phone="+15192842498", right_phone="+15192842498"
-        )
+        assert rows_are_duplicates(left, right)
 
     def test_name_and_phone_two_of_three(self) -> None:
         left = _entry(
@@ -133,9 +131,7 @@ class TestDuplicateDetection:
             address="20 Second Ave",
             phone_primary="+14272842498",
         )
-        assert rows_are_duplicates(
-            left, right, left_phone="+14272842498", right_phone="+14272842498"
-        )
+        assert rows_are_duplicates(left, right)
 
     def test_address_and_phone_two_of_three(self) -> None:
         left = _entry(
@@ -148,9 +144,7 @@ class TestDuplicateDetection:
             address="80 Mooregate Cres",
             phone_primary="+15193034390",
         )
-        assert rows_are_duplicates(
-            left, right, left_phone="+15193034390", right_phone="+15193034390"
-        )
+        assert rows_are_duplicates(left, right)
 
     def test_name_and_address_two_of_three(self) -> None:
         left = _entry(
@@ -163,9 +157,7 @@ class TestDuplicateDetection:
             address="527 Parkside Dr",
             phone_primary="+15192222222",
         )
-        assert rows_are_duplicates(
-            left, right, left_phone="+15191111111", right_phone="+15192222222"
-        )
+        assert rows_are_duplicates(left, right)
 
     def test_one_of_three_address_only_not_duplicate(self) -> None:
         left = _entry(
@@ -178,15 +170,8 @@ class TestDuplicateDetection:
             address="100 Shared Building",
             phone_primary="+15192222222",
         )
-        assert (
-            count_duplicate_field_matches(
-                left, right, left_phone="+15191111111", right_phone="+15192222222"
-            )
-            == 1
-        )
-        assert not rows_are_duplicates(
-            left, right, left_phone="+15191111111", right_phone="+15192222222"
-        )
+        assert count_duplicate_field_matches(left, right) == 1
+        assert not rows_are_duplicates(left, right)
 
     def test_one_of_three_phone_only_not_duplicate(self) -> None:
         left = _entry(
@@ -199,9 +184,7 @@ class TestDuplicateDetection:
             address="2 B St",
             phone_primary="+15193034390",
         )
-        assert not rows_are_duplicates(
-            left, right, left_phone="+15193034390", right_phone="+15193034390"
-        )
+        assert not rows_are_duplicates(left, right)
 
     def test_one_of_three_name_only_not_duplicate(self) -> None:
         left = _entry(
@@ -214,30 +197,28 @@ class TestDuplicateDetection:
             address="2 B St",
             phone_primary="+15192222222",
         )
-        assert not rows_are_duplicates(
-            left, right, left_phone="+15191111111", right_phone="+15192222222"
-        )
+        assert not rows_are_duplicates(left, right)
 
     def test_different_address_formatting_not_duplicate(self) -> None:
-        left = _entry(address="123 Main St")
-        right = _entry(address="123 Main Street")
-        assert not rows_are_duplicates(
-            left, right, left_phone="+15195551274", right_phone="+15195551234"
+        left = _entry(
+            address="123 Main St",
+            phone_primary="+15195551274",
         )
+        right = _entry(
+            address="123 Main Street",
+            phone_primary="+15195551234",
+        )
+        assert not rows_are_duplicates(left, right)
 
     def test_name_match_is_case_insensitive(self) -> None:
         left = _entry(contact_name="Smith")
         right = _entry(contact_name="smith")
-        assert rows_are_duplicates(
-            left, right, left_phone="+15195551234", right_phone="+15195551234"
-        )
+        assert rows_are_duplicates(left, right)
 
     def test_address_match_is_case_insensitive(self) -> None:
         left = _entry(address="123 Main St")
         right = _entry(address="123 main st")
-        assert rows_are_duplicates(
-            left, right, left_phone="+15195551234", right_phone="+15195551234"
-        )
+        assert rows_are_duplicates(left, right)
 
     def test_transitive_duplicate_cluster(self) -> None:
         entries = [
@@ -257,8 +238,7 @@ class TestDuplicateDetection:
                 phone_primary="+15191111111",
             ),
         ]
-        phones = ["+15191111111", "+15191111111", "+15191111111"]
-        groups = find_duplicate_index_groups(entries, phones)
+        groups = find_duplicate_index_groups(entries)
         assert groups == [[0, 1, 2]]
 
     def test_all_members_in_duplicate_group(self) -> None:
@@ -266,5 +246,5 @@ class TestDuplicateDetection:
             _entry(contact_name="A", address="1 St", phone_primary="+15191111111"),
             _entry(contact_name="A", address="2 St", phone_primary="+15191111111"),
         ]
-        groups = find_duplicate_index_groups(entries, ["+15191111111", "+15191111111"])
+        groups = find_duplicate_index_groups(entries)
         assert groups == [[0, 1]]

--- a/backend/python/tests/test_location_import_validation.py
+++ b/backend/python/tests/test_location_import_validation.py
@@ -1,0 +1,248 @@
+"""Tests for location import validation."""
+
+from __future__ import annotations
+
+from app.models.location import AlertCode, LocationImportEntry
+from app.services.implementations.location_import_validation import (
+    collect_field_alerts,
+    count_duplicate_field_matches,
+    find_duplicate_index_groups,
+    is_invalid_school_or_last_name,
+    rows_are_duplicates,
+)
+
+
+def _entry(
+    *,
+    contact_name: str | None = "Smith",
+    address: str | None = "123 Main St",
+    phone_primary: str | None = "+15195551234",
+    delivery_group: str | None = "Tuesday A",
+) -> LocationImportEntry:
+    return LocationImportEntry(
+        contact_name=contact_name,
+        address=address,
+        delivery_group=delivery_group,
+        phone_primary=phone_primary,
+    )
+
+
+class TestFieldValidation:
+    def test_missing_each_required_field(self) -> None:
+        assert collect_field_alerts(
+            _entry(contact_name=None),
+            geocode_ok=True,
+            phone_invalid=False,
+        ) == [AlertCode.MISSING_SCHOOL_OR_LAST_NAME]
+
+        assert collect_field_alerts(
+            _entry(address=None),
+            geocode_ok=None,
+            phone_invalid=False,
+        ) == [AlertCode.MISSING_ADDRESS]
+
+        assert collect_field_alerts(
+            _entry(phone_primary=None),
+            geocode_ok=True,
+            phone_invalid=False,
+        ) == [AlertCode.MISSING_PHONE_NUMBER]
+
+        assert collect_field_alerts(
+            _entry(delivery_group=None),
+            geocode_ok=True,
+            phone_invalid=False,
+        ) == [AlertCode.MISSING_DELIVERY_GROUP]
+
+    def test_invalid_school_or_last_name_all_digits(self) -> None:
+        assert is_invalid_school_or_last_name("33333333") is True
+        assert is_invalid_school_or_last_name("Smith") is False
+        assert is_invalid_school_or_last_name("Smith2") is False
+
+        alerts = collect_field_alerts(
+            _entry(contact_name="33333333"),
+            geocode_ok=True,
+            phone_invalid=False,
+        )
+        assert AlertCode.INVALID_SCHOOL_OR_LAST_NAME in alerts
+
+    def test_invalid_address_when_geocode_fails(self) -> None:
+        alerts = collect_field_alerts(
+            _entry(address="95 Roger"),
+            geocode_ok=False,
+            phone_invalid=False,
+        )
+        assert alerts == [AlertCode.INVALID_ADDRESS]
+
+    def test_invalid_phone_number(self) -> None:
+        alerts = collect_field_alerts(
+            _entry(),
+            geocode_ok=True,
+            phone_invalid=True,
+        )
+        assert AlertCode.INVALID_PHONE_NUMBER in alerts
+
+    def test_multiple_errors_on_one_row(self) -> None:
+        alerts = collect_field_alerts(
+            _entry(contact_name="33333333", delivery_group=None),
+            geocode_ok=True,
+            phone_invalid=False,
+        )
+        assert AlertCode.INVALID_SCHOOL_OR_LAST_NAME in alerts
+        assert AlertCode.MISSING_DELIVERY_GROUP in alerts
+
+
+class TestDuplicateDetection:
+    def test_three_of_three_is_duplicate(self) -> None:
+        left = _entry(
+            contact_name="Chan",
+            address="105 Albert St",
+            phone_primary="+15192842498",
+        )
+        right = _entry(
+            contact_name="Chan",
+            address="105 Albert St",
+            phone_primary="+15192842498",
+        )
+        assert rows_are_duplicates(
+            left, right, left_phone="+15192842498", right_phone="+15192842498"
+        )
+
+    def test_name_and_phone_two_of_three(self) -> None:
+        left = _entry(
+            contact_name="Bale",
+            address="10 First Ave",
+            phone_primary="+14272842498",
+        )
+        right = _entry(
+            contact_name="Bale",
+            address="20 Second Ave",
+            phone_primary="+14272842498",
+        )
+        assert rows_are_duplicates(
+            left, right, left_phone="+14272842498", right_phone="+14272842498"
+        )
+
+    def test_address_and_phone_two_of_three(self) -> None:
+        left = _entry(
+            contact_name="Wang",
+            address="80 Mooregate Cres",
+            phone_primary="+15193034390",
+        )
+        right = _entry(
+            contact_name="Loren",
+            address="80 Mooregate Cres",
+            phone_primary="+15193034390",
+        )
+        assert rows_are_duplicates(
+            left, right, left_phone="+15193034390", right_phone="+15193034390"
+        )
+
+    def test_name_and_address_two_of_three(self) -> None:
+        left = _entry(
+            contact_name="Weber",
+            address="527 Parkside Dr",
+            phone_primary="+15191111111",
+        )
+        right = _entry(
+            contact_name="Weber",
+            address="527 Parkside Dr",
+            phone_primary="+15192222222",
+        )
+        assert rows_are_duplicates(
+            left, right, left_phone="+15191111111", right_phone="+15192222222"
+        )
+
+    def test_one_of_three_address_only_not_duplicate(self) -> None:
+        left = _entry(
+            contact_name="Family A",
+            address="100 Shared Building",
+            phone_primary="+15191111111",
+        )
+        right = _entry(
+            contact_name="Family B",
+            address="100 Shared Building",
+            phone_primary="+15192222222",
+        )
+        assert (
+            count_duplicate_field_matches(
+                left, right, left_phone="+15191111111", right_phone="+15192222222"
+            )
+            == 1
+        )
+        assert not rows_are_duplicates(
+            left, right, left_phone="+15191111111", right_phone="+15192222222"
+        )
+
+    def test_one_of_three_phone_only_not_duplicate(self) -> None:
+        left = _entry(
+            contact_name="Family A",
+            address="1 A St",
+            phone_primary="+15193034390",
+        )
+        right = _entry(
+            contact_name="Family B",
+            address="2 B St",
+            phone_primary="+15193034390",
+        )
+        assert not rows_are_duplicates(
+            left, right, left_phone="+15193034390", right_phone="+15193034390"
+        )
+
+    def test_one_of_three_name_only_not_duplicate(self) -> None:
+        left = _entry(
+            contact_name="Smith",
+            address="1 A St",
+            phone_primary="+15191111111",
+        )
+        right = _entry(
+            contact_name="Smith",
+            address="2 B St",
+            phone_primary="+15192222222",
+        )
+        assert not rows_are_duplicates(
+            left, right, left_phone="+15191111111", right_phone="+15192222222"
+        )
+
+    def test_different_address_formatting_not_duplicate(self) -> None:
+        left = _entry(address="123 Main St")
+        right = _entry(address="123 Main Street")
+        assert not rows_are_duplicates(
+            left, right, left_phone="+15195551274", right_phone="+15195551234"
+        )
+
+    def test_name_match_is_case_insensitive(self) -> None:
+        left = _entry(contact_name="Smith")
+        right = _entry(contact_name="smith")
+        assert rows_are_duplicates(
+            left, right, left_phone="+15195551234", right_phone="+15195551234"
+        )
+
+    def test_transitive_duplicate_cluster(self) -> None:
+        entries = [
+            _entry(
+                contact_name="Alpha",
+                address="1 A St",
+                phone_primary="+15191111111",
+            ),
+            _entry(
+                contact_name="Alpha",
+                address="2 B St",
+                phone_primary="+15191111111",
+            ),
+            _entry(
+                contact_name="Gamma",
+                address="2 B St",
+                phone_primary="+15191111111",
+            ),
+        ]
+        phones = ["+15191111111", "+15191111111", "+15191111111"]
+        groups = find_duplicate_index_groups(entries, phones)
+        assert groups == [[0, 1, 2]]
+
+    def test_all_members_in_duplicate_group(self) -> None:
+        entries = [
+            _entry(contact_name="A", address="1 St", phone_primary="+15191111111"),
+            _entry(contact_name="A", address="2 St", phone_primary="+15191111111"),
+        ]
+        groups = find_duplicate_index_groups(entries, ["+15191111111", "+15191111111"])
+        assert groups == [[0, 1]]

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -2,13 +2,16 @@
   "components": {
     "schemas": {
       "AlertCode": {
-        "description": "Machine-readable reason code for an import alert.",
+        "description": "Machine-readable blocking error code for an import row.",
         "enum": [
-          "MISSING_FIELDS",
-          "INVALID_FORMAT",
-          "LOCAL_DUPLICATE",
+          "MISSING_ADDRESS",
+          "INVALID_ADDRESS",
+          "MISSING_PHONE_NUMBER",
+          "INVALID_PHONE_NUMBER",
+          "MISSING_SCHOOL_OR_LAST_NAME",
+          "INVALID_SCHOOL_OR_LAST_NAME",
           "MISSING_DELIVERY_GROUP",
-          "PARTIAL_DUPLICATE"
+          "DUPLICATE_ENTRY"
         ],
         "title": "AlertCode",
         "type": "string"
@@ -1380,7 +1383,7 @@
         "type": "object"
       },
       "LocationImportResponse": {
-        "description": "Combined validate + review-changes payload.\n\nsuccess=False when any row has alerts. net_new/stale/changed describe how the\nimport would affect the existing locations table; these are placeholders until\nthe matching logic is implemented.",
+        "description": "Combined validate + review-changes payload.\n\nsuccess=False when any row has alerts. duplicate_groups lists row numbers\n(1-based, matching LocationImportRow.row) for each within-file duplicate\ncluster. net_new/stale/changed describe how the import would affect the\nexisting locations table; these are placeholders until the matching logic\nis implemented.",
         "properties": {
           "changed": {
             "default": [],
@@ -1388,6 +1391,17 @@
               "$ref": "#/components/schemas/ChangedEntry"
             },
             "title": "Changed",
+            "type": "array"
+          },
+          "duplicate_groups": {
+            "default": [],
+            "items": {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            },
+            "title": "Duplicate Groups",
             "type": "array"
           },
           "net_new": {

--- a/frontend/src/api/generated/types.gen.ts
+++ b/frontend/src/api/generated/types.gen.ts
@@ -7,14 +7,17 @@ export type ClientOptions = {
 /**
  * AlertCode
  *
- * Machine-readable reason code for an import alert.
+ * Machine-readable blocking error code for an import row.
  */
 export type AlertCode =
-  | 'MISSING_FIELDS'
-  | 'INVALID_FORMAT'
-  | 'LOCAL_DUPLICATE'
+  | 'MISSING_ADDRESS'
+  | 'INVALID_ADDRESS'
+  | 'MISSING_PHONE_NUMBER'
+  | 'INVALID_PHONE_NUMBER'
+  | 'MISSING_SCHOOL_OR_LAST_NAME'
+  | 'INVALID_SCHOOL_OR_LAST_NAME'
   | 'MISSING_DELIVERY_GROUP'
-  | 'PARTIAL_DUPLICATE';
+  | 'DUPLICATE_ENTRY';
 
 /**
  * AnnouncementCreate
@@ -826,15 +829,21 @@ export type LocationImportEntry = {
  *
  * Combined validate + review-changes payload.
  *
- * success=False when any row has alerts. net_new/stale/changed describe how the
- * import would affect the existing locations table; these are placeholders until
- * the matching logic is implemented.
+ * success=False when any row has alerts. duplicate_groups lists row numbers
+ * (1-based, matching LocationImportRow.row) for each within-file duplicate
+ * cluster. net_new/stale/changed describe how the import would affect the
+ * existing locations table; these are placeholders until the matching logic
+ * is implemented.
  */
 export type LocationImportResponse = {
   /**
    * Changed
    */
   changed?: Array<ChangedEntry>;
+  /**
+   * Duplicate Groups
+   */
+  duplicate_groups?: Array<Array<number>>;
   /**
    * Net New
    */

--- a/frontend/src/common/components/DataTable.tsx
+++ b/frontend/src/common/components/DataTable.tsx
@@ -32,11 +32,12 @@ export interface DataTableProps<T> {
 
 interface AlertCellProps {
   type: 'error' | 'warning';
-  label: string;
+  label: string | readonly string[];
 }
 
 function AlertCell({ type, label }: AlertCellProps) {
   const isError = type === 'error';
+  const labels = typeof label === 'string' ? [label] : [...label];
   return (
     <span
       className={cn(
@@ -49,7 +50,14 @@ function AlertCell({ type, label }: AlertCellProps) {
       ) : (
         <AlertTriangle className="h-4 w-4 shrink-0" />
       )}
-      <span className="text-p2 font-medium">{label}</span>
+      <span className="text-p2 flex flex-col font-medium">
+        {labels.map((text, index) => (
+          <span key={`${text}-${index}`}>
+            {text}
+            {index < labels.length - 1 ? ',' : ''}
+          </span>
+        ))}
+      </span>
     </span>
   );
 }

--- a/frontend/src/pages/admin/routes/generation/ValidateStep.tsx
+++ b/frontend/src/pages/admin/routes/generation/ValidateStep.tsx
@@ -26,32 +26,45 @@ const WARNING_CELL_CLASS = 'border-b-2 border-dark-yellow bg-light-yellow';
 // ---------------------------------------------------------------------------
 
 function getAlertDisplay(
-  code: AlertCode,
-  location: LocationImportRow['location']
+  code: AlertCode
 ): { type: 'error' | 'warning'; label: string } {
   switch (code) {
-    case 'MISSING_FIELDS': {
-      const missing: string[] = [];
-      if (!location.contact_name) missing.push('Name');
-      if (!location.address) missing.push('Address');
-      if (!location.phone_primary) missing.push('Phone');
-      const label =
-        missing.length === 1 ? `Missing ${missing[0]}` : 'Missing Fields';
-      return { type: 'error', label };
-    }
-    case 'INVALID_FORMAT':
-      return { type: 'error', label: 'Invalid Format' };
-    case 'LOCAL_DUPLICATE':
-      return { type: 'warning', label: 'Duplicate Entry' };
-    case 'PARTIAL_DUPLICATE':
-      return { type: 'warning', label: 'Partial Duplicate Entry' };
+    case 'MISSING_SCHOOL_OR_LAST_NAME':
+      return { type: 'error', label: 'Missing School / Last Name' };
+    case 'INVALID_SCHOOL_OR_LAST_NAME':
+      return { type: 'error', label: 'Invalid School / Last Name' };
+    case 'MISSING_ADDRESS':
+      return { type: 'error', label: 'Missing Address' };
+    case 'INVALID_ADDRESS':
+      return { type: 'error', label: 'Invalid Address' };
+    case 'MISSING_PHONE_NUMBER':
+      return { type: 'error', label: 'Missing Phone Number' };
+    case 'INVALID_PHONE_NUMBER':
+      return { type: 'error', label: 'Invalid Phone Number' };
     case 'MISSING_DELIVERY_GROUP':
       return { type: 'error', label: 'Missing Delivery Group' };
+    case 'DUPLICATE_ENTRY':
+      return { type: 'warning', label: 'Duplicate Entry' };
+    default: {
+      const _exhaustive: never = code;
+      return { type: 'error', label: _exhaustive };
+    }
   }
 }
 
 const isDuplicateRow = (row: LocationImportRow) =>
-  row.alerts.some((a) => a === 'LOCAL_DUPLICATE' || a === 'PARTIAL_DUPLICATE');
+  row.alerts.includes('DUPLICATE_ENTRY');
+
+const hasContactNameAlert = (alerts: AlertCode[]) =>
+  alerts.includes('MISSING_SCHOOL_OR_LAST_NAME') ||
+  alerts.includes('INVALID_SCHOOL_OR_LAST_NAME');
+
+const hasAddressAlert = (alerts: AlertCode[]) =>
+  alerts.includes('MISSING_ADDRESS') || alerts.includes('INVALID_ADDRESS');
+
+const hasPhoneAlert = (alerts: AlertCode[]) =>
+  alerts.includes('MISSING_PHONE_NUMBER') ||
+  alerts.includes('INVALID_PHONE_NUMBER');
 
 // Returns the cell highlight class for non-alert data columns
 function getCellClass(
@@ -95,7 +108,7 @@ export function ValidateStep() {
       render: (row) => {
         const first = row.alerts[0];
         if (!first) return null;
-        const { type, label } = getAlertDisplay(first, row.location);
+        const { type, label } = getAlertDisplay(first);
         return <AlertCell type={type} label={label} />;
       },
     },
@@ -110,20 +123,13 @@ export function ValidateStep() {
       header: 'School / Last Name',
       render: (row) => row.location.contact_name ?? '',
       getCellClassName: (row) =>
-        getCellClass(
-          row,
-          row.alerts.includes('MISSING_FIELDS') && !row.location.contact_name
-        ),
+        getCellClass(row, hasContactNameAlert(row.alerts)),
     },
     {
       key: 'address',
       header: 'Address',
       render: (row) => row.location.address ?? '',
-      getCellClassName: (row) =>
-        getCellClass(
-          row,
-          row.alerts.includes('MISSING_FIELDS') && !row.location.address
-        ),
+      getCellClassName: (row) => getCellClass(row, hasAddressAlert(row.alerts)),
     },
     {
       key: 'delivery_group',
@@ -140,13 +146,7 @@ export function ValidateStep() {
       key: 'phone_primary',
       header: 'Primary Phone',
       render: (row) => row.location.phone_primary ?? '',
-      getCellClassName: (row) =>
-        getCellClass(
-          row,
-          row.alerts.some((a: AlertCode) =>
-            ['MISSING_FIELDS', 'INVALID_FORMAT'].includes(a)
-          )
-        ),
+      getCellClassName: (row) => getCellClass(row, hasPhoneAlert(row.alerts)),
     },
   ];
 

--- a/frontend/src/pages/admin/routes/generation/ValidateStep.tsx
+++ b/frontend/src/pages/admin/routes/generation/ValidateStep.tsx
@@ -17,9 +17,8 @@ import { AlertCell, Banner, Button, DataTable } from '@/common/components';
 import { EmptyState } from '../components';
 import type { GenerationOutletContext } from './AdminRoutesGenerationLayout';
 
-// Styling for error and warning cells
+// Styling for error cells — all alerts are blocking and use the same red error.
 const ERROR_CELL_CLASS = 'border-b-2 border-red bg-light-red';
-const WARNING_CELL_CLASS = 'border-b-2 border-dark-yellow bg-light-yellow';
 
 // ---------------------------------------------------------------------------
 // Alert display helpers
@@ -45,7 +44,7 @@ function getAlertDisplay(code: AlertCode): {
     case 'MISSING_DELIVERY_GROUP':
       return { type: 'error', label: 'Missing Delivery Group' };
     case 'DUPLICATE_ENTRY':
-      return { type: 'warning', label: 'Duplicate Entry' };
+      return { type: 'error', label: 'Duplicate Entry' };
     default: {
       const _exhaustive: never = code;
       return { type: 'error', label: _exhaustive };
@@ -72,8 +71,7 @@ function getCellClass(
   row: LocationImportRow,
   hasFieldError: boolean
 ): string | undefined {
-  if (hasFieldError) return ERROR_CELL_CLASS;
-  if (isDuplicateRow(row)) return WARNING_CELL_CLASS;
+  if (hasFieldError || isDuplicateRow(row)) return ERROR_CELL_CLASS;
   return undefined;
 }
 
@@ -107,10 +105,13 @@ export function ValidateStep() {
       key: 'alerts',
       header: 'Alert',
       render: (row) => {
-        const first = row.alerts[0];
-        if (!first) return null;
-        const { type, label } = getAlertDisplay(first);
-        return <AlertCell type={type} label={label} />;
+        if (row.alerts.length === 0) return null;
+        return (
+          <AlertCell
+            type="error"
+            label={row.alerts.map((code) => getAlertDisplay(code).label)}
+          />
+        );
       },
     },
     {

--- a/frontend/src/pages/admin/routes/generation/ValidateStep.tsx
+++ b/frontend/src/pages/admin/routes/generation/ValidateStep.tsx
@@ -25,9 +25,10 @@ const WARNING_CELL_CLASS = 'border-b-2 border-dark-yellow bg-light-yellow';
 // Alert display helpers
 // ---------------------------------------------------------------------------
 
-function getAlertDisplay(
-  code: AlertCode
-): { type: 'error' | 'warning'; label: string } {
+function getAlertDisplay(code: AlertCode): {
+  type: 'error' | 'warning';
+  label: string;
+} {
   switch (code) {
     case 'MISSING_SCHOOL_OR_LAST_NAME':
       return { type: 'error', label: 'Missing School / Last Name' };


### PR DESCRIPTION
## JIRA Ticket
[F4KRP 208](https://f4kblueprint.atlassian.net/browse/F4KRP-208)

## Implementation Description

- Updates POST /locations/review to align with the Figma Validate screen and import PRD. Validation logic lives in `location_import_validation.py`; `LocationService.review_locations()` orchestrates parsing, geocoding, and response assembly.

- Per-field blocking errors -> Replaced lumped `MISSING_FIELDS` / `INVALID_FORMAT` with specific codes. `collect_field_alerts()` evaluates each field independently, so one row can report multiple errors (e.g. `INVALID_SCHOOL_OR_LAST_NAME` + `MISSING_DELIVERY_GROUP`).

- Small update to frontend to use new AlertCodes

New validations:
- Invalid address -> `review_locations()` geocodes via `_geocode_import_address()`; `collect_field_alerts()` emits `INVALID_ADDRESS` when `geocode_ok` is False.
     - Invalid name -> `is_invalid_school_or_last_name()` flags all-digit names (e.g. 33333333).
     - Invalid phone -> `try_normalize_phone()` normalizes valid numbers to E.164; invalid non-empty values get `INVALID_PHONE_NUMBER`.
- Duplicate detection (2-of-3 rule) -> Two rows are linked if `rows_are_duplicates()` returns true, which delegates to `count_duplicate_field_matches()` and requires ≥ 2 matches across {name, address, phone}. Matching uses `_name_match_key()` (case-insensitive), `_address_match_key() `(exact stripped string; 123 Main St ≠ 123 Main Street), and `_phone_match_key()`. Removed the old address-or-phone-only check that over-flagged shared buildings.

- **Transitive grouping (using union-find to group duplicates)**

Pairs alone aren't enough; duplicates can chain transitively:

| Row | Name | Address | Phone | Linked to |
|---|---|---|---|---|
| A | Alpha | 1 A St | 519-111-1111 | B (name + phone) |
| B | Alpha | 2 B St | 519-111-1111 | A (name + phone), C (address + phone) |
| C | Gamma | 2 B St | 519-111-1111 | B (address + phone) |

A and C share only phone (1-of-3) -> `rows_are_duplicates(A, C)` is `false`, but all three belong in one group because B connects them.

**How `find_duplicate_index_groups()` handles this**

1. Compare every row pair; if `rows_are_duplicates()` → `_UnionFind.union(i, j)`
2. Collect connected components (size ≥ 2) as 0-based index groups
3. `review_locations()` maps indices → 1-based row numbers in `duplicate_groups`
4. Every row in a cluster gets `DUPLICATE_ENTRY` appended to its alerts

## Steps to Test
<!-- What should the reviewer do to verify your changes? Include expected results -->
1. Unit tests added for location validation logic

## What Should Reviewers Focus On?
<!-- Call out substantial changes or anything you want a second opinion on -->
* Invalid name ->` is_invalid_school_or_last_name()` flags all-digit names (e.g. 33333333).
    * Is there any other criteria for an invalid school or last name?
* Does the grouping make sense? Should `A` and `C` be grouped together on the UI even though they are not duplicates?

## Checklist
- [x] PR name and commits are descriptive, imperative, and atomic (trivial commits squashed)
- [x] I have requested a review from Claude, understood its suggestions, and implemented fixes where needed (or documented disagreements)
- [x] I have requested a review from the PL and relevant devs with background on this PR

**Frontend only — delete if not applicable:** -> frontend changes are small
- [x] Follows Tailwind/shadcn best practices per README; no hardcoded color or spacing values
- [x] Implementation matches Zeplin designs and screenshots are attached above
- [x] Screens render correctly on mobile and desktop; no console warnings or errors