### PR TITLE
Ensure the singleton settings row exists at startup

### DIFF
--- a/backend/python/app/__init__.py
+++ b/backend/python/app/__init__.py
@@ -8,7 +8,10 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.routing import APIRoute
 
 import app.models as models
-from app.dependencies.services import get_scheduler_service
+from app.dependencies.services import (
+    get_scheduler_service,
+    get_system_settings_service,
+)
 from app.services.jobs import init_jobs
 
 from .config import settings
@@ -130,6 +133,11 @@ async def lifespan(_app: FastAPI) -> AsyncGenerator[None, None]:
     if models.async_session_maker_instance is None:
         raise RuntimeError("Database not initialized. Call init_app() first.")
     async with models.async_session_maker_instance() as session:
+        # Guarantee the singleton settings row exists before anything reads it,
+        # so configurable settings (e.g. delivery_types) have a single source
+        # of truth and callers don't need a None-fallback.
+        await get_system_settings_service().ensure_settings(session)
+        await session.commit()
         await init_jobs(scheduler_service, session)
 
     yield

--- a/backend/python/app/services/implementations/system_settings_service.py
+++ b/backend/python/app/services/implementations/system_settings_service.py
@@ -17,6 +17,28 @@ class SystemSettingsService:
         result = await session.execute(select(SystemSettings))
         return result.scalars().first()
 
+    async def ensure_settings(self, session: AsyncSession) -> SystemSettings:
+        """Guarantee the singleton settings row exists, creating it with model
+        defaults if absent, and return it.
+
+        Called once at startup so the rest of the app can treat "the settings
+        row exists" as an invariant: config that lives on the row (e.g.
+        ``delivery_types``) has a single source of truth and readers don't need
+        a None-fallback. Idempotent — an existing row is left untouched.
+
+        The server runs as a single process (see ``server.py``) with migrations
+        applied before boot, so there's no insert race to guard against. Does
+        not commit — the caller owns the surrounding transaction.
+        """
+        settings = await self.get_settings(session)
+        if settings is not None:
+            return settings
+
+        settings = SystemSettings()
+        session.add(settings)
+        await session.flush()
+        return settings
+
     async def update_settings(
         self, session: AsyncSession, settings_data: SystemSettingsUpdate
     ) -> SystemSettings:

--- a/backend/python/tests/test_system_settings_service.py
+++ b/backend/python/tests/test_system_settings_service.py
@@ -1,0 +1,56 @@
+"""Tests for SystemSettingsService.ensure_settings — the startup invariant that
+guarantees the singleton settings row always exists.
+"""
+
+import logging
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import select
+
+from app.models.system_settings import SystemSettings
+from app.services.implementations.system_settings_service import SystemSettingsService
+
+
+def _service() -> SystemSettingsService:
+    return SystemSettingsService(logging.getLogger("test"))
+
+
+async def _count_settings(session: AsyncSession) -> int:
+    result = await session.execute(select(SystemSettings))
+    return len(result.scalars().all())
+
+
+@pytest.mark.asyncio
+async def test_ensure_settings_creates_row_when_absent(
+    test_session: AsyncSession,
+) -> None:
+    """With no settings row, ensure_settings creates one with model defaults."""
+    service = _service()
+    assert await service.get_settings(test_session) is None
+
+    created = await service.ensure_settings(test_session)
+
+    # Persisted with model defaults (boxes_per_car defaults to 10).
+    assert created.system_settings_id is not None
+    assert created.boxes_per_car == 10
+    assert await _count_settings(test_session) == 1
+
+
+@pytest.mark.asyncio
+async def test_ensure_settings_is_idempotent_and_preserves_existing(
+    test_session: AsyncSession,
+) -> None:
+    """A second call is a no-op — it returns the existing row untouched rather
+    than resetting it to defaults or inserting a duplicate."""
+    service = _service()
+
+    first = await service.ensure_settings(test_session)
+    first.boxes_per_car = 42
+    await test_session.flush()
+
+    second = await service.ensure_settings(test_session)
+
+    assert second.system_settings_id == first.system_settings_id
+    assert second.boxes_per_car == 42
+    assert await _count_settings(test_session) == 1


### PR DESCRIPTION
## Summary
Establishes **"the `SystemSettings` row always exists"** as an app invariant, seeded on startup. This gives configurable settings a single source of truth and lets readers stop carrying `None`-fallbacks.

- **`SystemSettingsService.ensure_settings()`** — idempotent: creates the row with model defaults if absent, leaves an existing row untouched. Does *not* commit (caller owns the transaction), matching the existing `set_import_column_map` pattern.
- **Lifespan wiring** — called in startup before `init_jobs`. The server runs as a single uvicorn process with `alembic upgrade head` before boot (see `server.py` / `Dockerfile`), so there's no multi-worker insert race to guard against.
- **Tests** — create-when-absent and idempotent-preserves-existing paths.

## Why
Follow-up to the delivery-types-config work (#181). Today `get_delivery_types` falls back to hardcoded defaults when the settings row is missing — a silent default that masks an unseeded DB. With this invariant in place, that fallback can be deleted and callers can trust the row exists. Verified in the boot logs that `ensure_settings` runs at startup.

## Testing
- `docker compose exec backend ruff check app tests scripts` ✅
- `docker compose exec backend ruff format --check app tests scripts` ✅
- `docker compose exec backend mypy . --config-file mypy.ini` ✅ (no issues, 112 files)
- `docker compose exec backend python -m pytest tests/test_system_settings_service.py` ✅ (2 passed)
- Existing settings/reroute tests re-run green (incl. a `TestClient` path that exercises the lifespan)

Note: OpenAPI contract is unchanged (no new endpoints/schema fields), so no client regeneration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)