### PR TITLE
Seed: alternate A/B location groups by week instead of doubling up

### DIFF
--- a/backend/python/app/seed_database.py
+++ b/backend/python/app/seed_database.py
@@ -207,15 +207,19 @@ DEFAULT_CAP_MAX = 20
 # Default route start time (HH:MM:SS format)
 ROUTE_START_TIME = "08:00:00"
 
-# Location group schedule (weekday mapping)
+# Location group schedule: group name -> (weekday, alternating slot).
+# weekday is Monday=0 .. Sunday=6. Groups sharing a weekday are suffixed
+# "A"/"B" and deliver on *alternating* weeks, so any given date materializes
+# routes for at most one of them (slot None means "every occurrence of that
+# weekday", used for groups with no A/B partner).
 LOCATION_GROUP_SCHEDULE = {
-    "Schools": 4,
-    "Tuesday A": 1,
-    "Tuesday B": 1,
-    "Wednesday A": 2,
-    "Wednesday B": 2,
-    "Thursday A": 3,
-    "Thursday B": 3,
+    "Schools": (4, None),
+    "Tuesday A": (1, "A"),
+    "Tuesday B": (1, "B"),
+    "Wednesday A": (2, "A"),
+    "Wednesday B": (2, "B"),
+    "Thursday A": (3, "A"),
+    "Thursday B": (3, "B"),
 }
 
 # Cities that need specific group assignments (will be randomly assigned)
@@ -883,10 +887,14 @@ def main() -> None:
             current_date = start_date
             while current_date <= end_date:
                 weekday = current_date.weekday()
+                # Continuous week index (never resets across years), so
+                # consecutive occurrences of the same weekday always flip the
+                # slot -> A and B groups alternate week to week.
+                week_slot = "A" if (current_date.toordinal() // 7) % 2 == 0 else "B"
                 matching_groups = [
                     name
-                    for name, target_weekday in LOCATION_GROUP_SCHEDULE.items()
-                    if target_weekday == weekday
+                    for name, (target_weekday, slot) in LOCATION_GROUP_SCHEDULE.items()
+                    if target_weekday == weekday and (slot is None or slot == week_slot)
                 ]
 
                 for group_name in matching_groups:


### PR DESCRIPTION
## Problem

`Thursday A` and `Thursday B` (and the `Tuesday`/`Wednesday` A/B pairs) both mapped to the same weekday in `LOCATION_GROUP_SCHEDULE`, so the per-day route materialization loop created route groups for **both** partners on **every** occurrence of that weekday. To match F4K's real schedules, an A/B pair should share a weekday but deliver on **alternating** weeks.

## Fix

- `LOCATION_GROUP_SCHEDULE` now maps each group to a `(weekday, slot)` pair — `slot` is `"A"`/`"B"`, or `None` for groups with no partner (e.g. `Schools`).
- The loop computes a continuous week index, `current_date.toordinal() // 7`, which never resets across years, so consecutive occurrences of a given weekday always flip A↔B. Only the group whose slot matches the current week is materialized.

## Verification

Ran against the `food4kids-backend:latest` image + a throwaway Postgres:
- `ruff check .` + `ruff format --check .` — clean
- `mypy . --config-file mypy.ini` — Success, 114 files
- Seeded data confirmed to alternate (e.g. `Thursday A` and `Thursday B` on different weeks, biweekly cadence per group).

🤖 Generated with [Claude Code](https://claude.com/claude-code)