### PR TITLE
Make updated_at accurate: bump on every update

### DIFF
--- a/backend/python/app/models/base.py
+++ b/backend/python/app/models/base.py
@@ -32,8 +32,15 @@ class BaseModel(sm.SQLModel):
     # insert (equal to within microseconds) and `updated_at` is bumped on every
     # update. Models that genuinely need "null until first set" (e.g. Job, whose
     # lifecycle tracks started/updated/finished) override `updated_at` explicitly.
+    #
+    # `updated_at` is bumped by a column-level SQLAlchemy `onupdate`, which fires
+    # for BOTH ORM flushes and Core `update()` statements — so bulk updates stay
+    # accurate too — unless the statement sets `updated_at` itself.
     created_at: datetime | None = Field(default_factory=_now_est_naive)
-    updated_at: datetime | None = Field(default_factory=_now_est_naive)
+    updated_at: datetime | None = Field(
+        default_factory=_now_est_naive,
+        sa_column_kwargs={"onupdate": _now_est_naive},
+    )
 
     def __init_subclass__(cls, **kwargs: Any) -> None:
         super().__init_subclass__(**kwargs)

--- a/backend/python/tests/test_base_timestamps.py
+++ b/backend/python/tests/test_base_timestamps.py
@@ -1,0 +1,122 @@
+"""Tests for the BaseModel timestamp convention: ``created_at``/``updated_at``
+are stamped on insert, and ``updated_at`` is bumped on every update — via a
+column-level ``onupdate`` that fires for both ORM flushes and Core ``update()``
+statements. ``Job`` overrides ``updated_at`` and is exempt.
+"""
+
+from datetime import datetime
+
+import pytest
+from sqlalchemy import update
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import col
+
+from app.models.job import Job
+from app.models.system_settings import SystemSettings
+
+# A fixed past instant used to backdate rows deterministically, so "did
+# updated_at move to ~now?" doesn't hinge on sub-microsecond timing.
+_PAST = datetime(2000, 1, 1, 12, 0, 0)
+
+
+async def _make_settings(session: AsyncSession) -> SystemSettings:
+    settings = SystemSettings()
+    session.add(settings)
+    await session.commit()
+    return settings
+
+
+async def _backdate(session: AsyncSession, settings: SystemSettings) -> None:
+    """Set both timestamps to _PAST via an explicit Core update (which, by
+    setting updated_at itself, deliberately bypasses onupdate)."""
+    await session.execute(
+        update(SystemSettings)
+        .where(col(SystemSettings.system_settings_id) == settings.system_settings_id)
+        .values(created_at=_PAST, updated_at=_PAST)
+    )
+    await session.commit()
+    await session.refresh(settings)
+    assert settings.created_at == _PAST
+    assert settings.updated_at == _PAST
+
+
+@pytest.mark.asyncio
+async def test_timestamps_stamped_and_equal_on_insert(
+    test_session: AsyncSession,
+) -> None:
+    """Both timestamps are set on insert and equal to within a microsecond."""
+    settings = await _make_settings(test_session)
+
+    assert settings.created_at is not None
+    assert settings.updated_at is not None
+    assert abs((settings.updated_at - settings.created_at).total_seconds()) < 0.001
+
+
+@pytest.mark.asyncio
+async def test_updated_at_bumps_on_orm_update(test_session: AsyncSession) -> None:
+    """An ORM attribute change bumps updated_at and leaves created_at alone."""
+    settings = await _make_settings(test_session)
+    await _backdate(test_session, settings)
+
+    settings.default_cap = 5
+    await test_session.commit()
+    await test_session.refresh(settings)
+
+    assert settings.created_at == _PAST  # insert stamp is immutable
+    assert settings.updated_at is not None and settings.updated_at > _PAST
+
+
+@pytest.mark.asyncio
+async def test_updated_at_bumps_on_core_bulk_update(
+    test_session: AsyncSession,
+) -> None:
+    """A Core update() that doesn't set updated_at still bumps it (onupdate)."""
+    settings = await _make_settings(test_session)
+    await _backdate(test_session, settings)
+
+    await test_session.execute(
+        update(SystemSettings)
+        .where(col(SystemSettings.system_settings_id) == settings.system_settings_id)
+        .values(default_cap=7)
+    )
+    await test_session.commit()
+    await test_session.refresh(settings)
+
+    assert settings.updated_at is not None and settings.updated_at > _PAST
+
+
+@pytest.mark.asyncio
+async def test_explicit_updated_at_wins_over_onupdate(
+    test_session: AsyncSession,
+) -> None:
+    """When a statement sets updated_at itself, onupdate does not override it."""
+    settings = await _make_settings(test_session)
+    await _backdate(test_session, settings)
+    explicit = datetime(2010, 6, 15, 8, 30, 0)
+
+    await test_session.execute(
+        update(SystemSettings)
+        .where(col(SystemSettings.system_settings_id) == settings.system_settings_id)
+        .values(default_cap=9, updated_at=explicit)
+    )
+    await test_session.commit()
+    await test_session.refresh(settings)
+
+    assert settings.updated_at == explicit
+
+
+@pytest.mark.asyncio
+async def test_job_updated_at_is_not_auto_bumped(test_session: AsyncSession) -> None:
+    """Job overrides updated_at (null until first set), so it is exempt from the
+    auto-bump — its lifecycle sets the timestamp explicitly."""
+    job = Job()
+    test_session.add(job)
+    await test_session.commit()
+    await test_session.refresh(job)
+    assert job.updated_at is None
+
+    job.started_at = datetime(2021, 3, 3, 3, 3, 3)
+    await test_session.commit()
+    await test_session.refresh(job)
+
+    assert job.updated_at is None


### PR DESCRIPTION
Follow-up to #192. During that work we found that `BaseModel`'s `updated_at` was **inert on updates** — the comment claimed "bumped on every update" (Rails/Django convention), but nothing enforced it. `updated_at` was stamped only at insert (via `default_factory`), and a handful of services bumped it by hand where they remembered. Nothing consumed it yet, but an accurate `updated_at` is worth having before something starts to.

## What
Add a column-level SQLAlchemy `onupdate` to `updated_at` in `app/models/base.py`:

```python
updated_at: datetime | None = Field(
    default_factory=_now_est_naive,
    sa_column_kwargs={"onupdate": _now_est_naive},
)
```

`onupdate` is the comprehensive choice — it fires for **both** ORM flushes (`setattr` + commit) **and** Core `update()` statements, so bulk updates stay accurate too. (A `before_flush` listener would only catch the ORM path and miss Core updates like the delivery-type rename and note-chain FK-nulling.) When a statement sets `updated_at` itself, the explicit value wins and `onupdate` is skipped — so existing manual assignments (`job_service`, `driver_history_service`, note read-receipts) keep working unchanged.

## Scope / safety
- **`Job` is exempt** — it overrides `updated_at` as its own `default=None` field ("null until first set" for its started/updated/finished lifecycle), so it doesn't inherit the `onupdate`. Locked in by a test.
- Audited every existing `updated_at` assertion in the suite — all are insert-time or read-model constructions, none break.
- This also makes the #192 delivery-type rename's bulk `update(Location)` bump `updated_at` for free, with no change to that code.

## Tests
New `tests/test_base_timestamps.py` covers: insert stamps both equal; ORM update bumps `updated_at` and leaves `created_at`; Core `update()` bumps it; an explicit `updated_at` in the statement wins over `onupdate`; and `Job` is not auto-bumped. Full suite green (376 passed) plus ruff + `ruff format --check` + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)