### PR TITLE
Make Google Maps link respect the route snapshot for frozen routes

### DIFF
--- a/backend/python/app/services/implementations/route_service.py
+++ b/backend/python/app/services/implementations/route_service.py
@@ -23,7 +23,10 @@ from app.models.system_settings import SystemSettings
 from app.models.user import User
 from app.schemas.pagination import PaginatedResponse, PaginationParams
 from app.utilities.boxes import box_count_expr, resolve_children_per_box
-from app.utilities.google_maps_link import build_google_maps_directions_url
+from app.utilities.google_maps_link import (
+    MapWaypoint,
+    build_google_maps_directions_url,
+)
 from app.utilities.pagination import paginate_query
 from app.utilities.routes_utils import fetch_route_polyline
 
@@ -339,10 +342,15 @@ class RouteService:
             HTTPException 404: If the route or system settings are not found.
             HTTPException 422: If a stop is missing both address and coordinates.
         """
-        # 1. Fetch route stops with their locations, ordered by stop_number
+        # 1. Fetch route stops with their live location and (if frozen) snapshot,
+        #    ordered by stop_number.
         statement = (
-            select(RouteStop, Location)
+            select(RouteStop, Location, RouteStopSnapshot)
             .join(Location, RouteStop.location_id == Location.location_id)  # type: ignore[arg-type]
+            .outerjoin(
+                RouteStopSnapshot,
+                RouteStopSnapshot.route_stop_id == RouteStop.route_stop_id,  # type: ignore[arg-type]
+            )
             .where(RouteStop.route_id == route_id)
             .order_by(RouteStop.stop_number)  # type: ignore[arg-type]
         )
@@ -358,33 +366,56 @@ class RouteService:
                 detail=f"Route {route_id} has no stops.",
             )
 
-        # 2. Fetch warehouse coordinates from SystemSettings
-        settings_result = await session.execute(select(SystemSettings).limit(1))
-        system_settings = settings_result.scalars().first()
-
-        if not system_settings:
-            raise HTTPException(
-                status_code=404,
-                detail="System settings not found.",
+        # 2. Resolve the origin. A frozen route carries its own start
+        #    coordinates; an unfrozen one uses the live warehouse.
+        route_snapshot = (
+            await session.execute(
+                select(RouteSnapshot).where(RouteSnapshot.route_id == route_id)
             )
-        if (
-            system_settings.warehouse_latitude is None
-            or system_settings.warehouse_longitude is None
-        ):
-            raise HTTPException(
-                status_code=422,
-                detail="Warehouse coordinates are not configured in system settings.",
-            )
+        ).scalar_one_or_none()
 
-        # 3. Extract the ordered list of Location objects
-        locations: list[Location] = [location for _, location in rows]
+        if route_snapshot is not None:
+            origin_lat = route_snapshot.start_latitude
+            origin_lon = route_snapshot.start_longitude
+        else:
+            settings_result = await session.execute(select(SystemSettings).limit(1))
+            system_settings = settings_result.scalars().first()
+
+            if not system_settings:
+                raise HTTPException(
+                    status_code=404,
+                    detail="System settings not found.",
+                )
+            if (
+                system_settings.warehouse_latitude is None
+                or system_settings.warehouse_longitude is None
+            ):
+                raise HTTPException(
+                    status_code=422,
+                    detail=(
+                        "Warehouse coordinates are not configured in system settings."
+                    ),
+                )
+            origin_lat = system_settings.warehouse_latitude
+            origin_lon = system_settings.warehouse_longitude
+
+        # 3. Resolve each stop, preferring the frozen snapshot over the live
+        #    location (present = use snapshot).
+        waypoints = [
+            MapWaypoint(
+                address=snapshot.address if snapshot else location.address,
+                latitude=snapshot.latitude if snapshot else location.latitude,
+                longitude=snapshot.longitude if snapshot else location.longitude,
+            )
+            for _, location, snapshot in rows
+        ]
 
         # 4. Generate the URL
         try:
             url = build_google_maps_directions_url(
-                locations=locations,
-                warehouse_lat=system_settings.warehouse_latitude,
-                warehouse_lon=system_settings.warehouse_longitude,
+                stops=waypoints,
+                warehouse_lat=origin_lat,
+                warehouse_lon=origin_lon,
             )
         except ValueError as e:
             raise HTTPException(status_code=422, detail=str(e)) from e

--- a/backend/python/app/utilities/google_maps_link.py
+++ b/backend/python/app/utilities/google_maps_link.py
@@ -1,12 +1,23 @@
-from typing import TYPE_CHECKING
+from dataclasses import dataclass
 from urllib.parse import quote
 
-if TYPE_CHECKING:
-    from app.models.location import Location
+
+@dataclass
+class MapWaypoint:
+    """A single resolved stop for a directions URL.
+
+    Decoupled from the ``Location`` model so callers can pass whatever the
+    route actually delivered to — e.g. a frozen snapshot's address/coords for
+    a past route, or the live location's for an upcoming one.
+    """
+
+    address: str | None
+    latitude: float | None
+    longitude: float | None
 
 
 def build_google_maps_directions_url(
-    locations: list["Location"],
+    stops: list[MapWaypoint],
     warehouse_lat: float,
     warehouse_lon: float,
 ) -> str:
@@ -23,7 +34,7 @@ def build_google_maps_directions_url(
     characters.  Both limits are enforced here.
 
     Args:
-        locations: Ordered list of Location objects (route stops).
+        stops: Ordered list of resolved waypoints (route stops).
         warehouse_lat: Latitude of the warehouse (route origin).
         warehouse_lon: Longitude of the warehouse (route origin).
 
@@ -31,16 +42,16 @@ def build_google_maps_directions_url(
         A fully-formed Google Maps directions URL string.
 
     Raises:
-        ValueError: If a location has neither an address nor coordinates,
+        ValueError: If a stop has neither an address nor coordinates,
             if there are more than 50 stops, or if the resulting URL
             exceeds 2 000 characters.
     """
     _MAX_WAYPOINTS = 50
     _MAX_URL_LENGTH = 2000
 
-    if len(locations) > _MAX_WAYPOINTS:
+    if len(stops) > _MAX_WAYPOINTS:
         raise ValueError(
-            f"Route has {len(locations)} stops, but Google Maps directions "
+            f"Route has {len(stops)} stops, but Google Maps directions "
             f"URLs support a maximum of {_MAX_WAYPOINTS} waypoints."
         )
 
@@ -49,11 +60,11 @@ def build_google_maps_directions_url(
     # Origin is always the warehouse coordinates
     segments: list[str] = [f"{warehouse_lat},{warehouse_lon}"]
 
-    for i, location in enumerate(locations):
-        if location.address:
-            segments.append(quote(location.address, safe=""))
-        elif location.latitude is not None and location.longitude is not None:
-            segments.append(f"{location.latitude},{location.longitude}")
+    for i, stop in enumerate(stops):
+        if stop.address:
+            segments.append(quote(stop.address, safe=""))
+        elif stop.latitude is not None and stop.longitude is not None:
+            segments.append(f"{stop.latitude},{stop.longitude}")
         else:
             raise ValueError(f"Stop {i + 1} has neither an address nor coordinates.")
 

--- a/backend/python/tests/test_google_maps_link.py
+++ b/backend/python/tests/test_google_maps_link.py
@@ -1,0 +1,79 @@
+from urllib.parse import quote
+
+import pytest
+
+from app.utilities.google_maps_link import (
+    MapWaypoint,
+    build_google_maps_directions_url,
+)
+
+
+def _stop(
+    address: str | None = None,
+    latitude: float | None = None,
+    longitude: float | None = None,
+) -> MapWaypoint:
+    return MapWaypoint(address=address, latitude=latitude, longitude=longitude)
+
+
+class TestBuildGoogleMapsDirectionsUrl:
+    def test_origin_is_warehouse_coords(self) -> None:
+        url = build_google_maps_directions_url(
+            [_stop(address="1 Main St")], warehouse_lat=43.65, warehouse_lon=-79.38
+        )
+        assert url.startswith("https://www.google.com/maps/dir/43.65,-79.38/")
+
+    def test_address_is_url_encoded(self) -> None:
+        url = build_google_maps_directions_url(
+            [_stop(address="10 Main St, Apt #2")], 43.0, -79.0
+        )
+        assert quote("10 Main St, Apt #2", safe="") in url
+        assert " " not in url
+
+    def test_falls_back_to_coords_when_no_address(self) -> None:
+        url = build_google_maps_directions_url(
+            [_stop(latitude=44.5, longitude=-79.5)], 43.0, -79.0
+        )
+        assert url.endswith("/44.5,-79.5")
+
+    def test_prefers_address_over_coords(self) -> None:
+        url = build_google_maps_directions_url(
+            [_stop(address="7 Elm St", latitude=44.5, longitude=-79.5)], 43.0, -79.0
+        )
+        assert quote("7 Elm St", safe="") in url
+        assert "44.5,-79.5" not in url.split("/dir/")[1]
+
+    def test_preserves_stop_order(self) -> None:
+        url = build_google_maps_directions_url(
+            [_stop(address="first"), _stop(address="second"), _stop(address="third")],
+            43.0,
+            -79.0,
+        )
+        assert url == ("https://www.google.com/maps/dir/43.0,-79.0/first/second/third")
+
+    def test_stop_with_neither_address_nor_coords_raises(self) -> None:
+        with pytest.raises(ValueError, match="Stop 2 has neither"):
+            build_google_maps_directions_url(
+                [_stop(address="ok"), _stop()], 43.0, -79.0
+            )
+
+    def test_missing_only_one_coord_is_not_valid_coords(self) -> None:
+        # latitude present but longitude None -> can't form "lat,lon".
+        with pytest.raises(ValueError, match="Stop 1 has neither"):
+            build_google_maps_directions_url([_stop(latitude=44.0)], 43.0, -79.0)
+
+    def test_exactly_50_stops_ok(self) -> None:
+        stops = [_stop(latitude=1.0, longitude=2.0) for _ in range(50)]
+        url = build_google_maps_directions_url(stops, 43.0, -79.0)
+        assert url.count("/1.0,2.0") == 50
+
+    def test_more_than_50_stops_raises(self) -> None:
+        stops = [_stop(latitude=1.0, longitude=2.0) for _ in range(51)]
+        with pytest.raises(ValueError, match="maximum of 50 waypoints"):
+            build_google_maps_directions_url(stops, 43.0, -79.0)
+
+    def test_url_length_limit_raises(self) -> None:
+        # A single very long address blows past the 2000-char browser limit.
+        stops = [_stop(address="A" * 2100)]
+        with pytest.raises(ValueError, match="exceeds the browser limit"):
+            build_google_maps_directions_url(stops, 43.0, -79.0)

--- a/backend/python/tests/test_routes.py
+++ b/backend/python/tests/test_routes.py
@@ -1919,6 +1919,205 @@ class TestRouteRoutes:
         assert response.status_code == 422
 
     @pytest.mark.asyncio
+    async def test_google_maps_link_unfrozen_uses_live_data(
+        self,
+        async_client: AsyncClient,
+        test_session: AsyncSession,
+        test_route: Any,
+        test_location_group: Any,
+    ) -> None:
+        """For an upcoming (unfrozen) route the link is built from the live
+        Location rows and the live warehouse in SystemSettings."""
+        from urllib.parse import quote
+
+        from sqlmodel import select
+
+        from app.models.system_settings import SystemSettings
+
+        # A settings row already exists (autouse fixture); configure its
+        # warehouse coordinates rather than inserting a second row.
+        settings = (
+            (await test_session.execute(select(SystemSettings).limit(1)))
+            .scalars()
+            .one()
+        )
+        settings.warehouse_location = "Depot"
+        settings.warehouse_latitude = 43.65
+        settings.warehouse_longitude = -79.38
+        test_session.add(settings)
+        loc = Location(
+            location_group_id=test_location_group.location_group_id,
+            name="Live Fam",
+            contact_name="Live Fam",
+            address="10 Live Ave",
+            phone_primary="5550001111",
+            delivery_type="Family",
+            latitude=44.0,
+            longitude=-79.0,
+        )
+        test_session.add(loc)
+        await test_session.commit()
+        await test_session.refresh(loc)
+        test_session.add(
+            RouteStop(
+                route_id=test_route.route_id,
+                location_id=loc.location_id,
+                stop_number=1,
+            )
+        )
+        await test_session.commit()
+
+        response = await async_client.get(
+            f"/routes/{test_route.route_id}/google-maps-link"
+        )
+        assert response.status_code == 200
+        url = response.json()
+        # Origin is the live warehouse; stop is the live address.
+        assert "/dir/43.65,-79.38/" in url
+        assert quote("10 Live Ave", safe="") in url
+
+    @pytest.mark.asyncio
+    async def test_google_maps_link_frozen_uses_snapshot(
+        self,
+        async_client: AsyncClient,
+        test_session: AsyncSession,
+        test_route: Any,
+        test_location_group: Any,
+    ) -> None:
+        """For a frozen route (RouteSnapshot present) the link reflects the
+        snapshotted address/coords and the frozen warehouse origin — even after
+        the live Location and warehouse have since been mutated."""
+        from urllib.parse import quote
+
+        from sqlmodel import select
+
+        from app.models.route_snapshot import RouteSnapshot
+        from app.models.system_settings import SystemSettings
+
+        # Live warehouse and location as they are TODAY (post-delivery drift).
+        settings = (
+            (await test_session.execute(select(SystemSettings).limit(1)))
+            .scalars()
+            .one()
+        )
+        settings.warehouse_location = "New Depot"
+        settings.warehouse_latitude = 1.0
+        settings.warehouse_longitude = 1.0
+        test_session.add(settings)
+        loc = Location(
+            location_group_id=test_location_group.location_group_id,
+            name="Moved Fam",
+            contact_name="Moved Fam",
+            address="999 New Address",
+            phone_primary="5550002222",
+            delivery_type="Family",
+            latitude=2.0,
+            longitude=2.0,
+        )
+        test_session.add(loc)
+        await test_session.commit()
+        await test_session.refresh(loc)
+
+        stop = RouteStop(
+            route_id=test_route.route_id,
+            location_id=loc.location_id,
+            stop_number=1,
+        )
+        test_session.add(stop)
+        await test_session.commit()
+        await test_session.refresh(stop)
+
+        # Freeze: warehouse origin and the delivered address/coords as they
+        # were at drive time.
+        test_session.add_all(
+            [
+                RouteSnapshot(
+                    route_id=test_route.route_id,
+                    start_address="Old Depot",
+                    start_latitude=43.65,
+                    start_longitude=-79.38,
+                ),
+                RouteStopSnapshot(
+                    route_stop_id=stop.route_stop_id,
+                    address="123 Old Address",
+                    contact_name="Old Fam",
+                    phone_number="5550002222",
+                    num_children=3,
+                    notes="",
+                    latitude=44.0,
+                    longitude=-79.0,
+                ),
+            ]
+        )
+        await test_session.commit()
+
+        response = await async_client.get(
+            f"/routes/{test_route.route_id}/google-maps-link"
+        )
+        assert response.status_code == 200
+        url = response.json()
+        # Origin is the frozen warehouse, not the live (1.0, 1.0).
+        assert "/dir/43.65,-79.38/" in url
+        assert "/dir/1.0,1.0/" not in url
+        # Stop reflects the snapshotted address, not the live one.
+        assert quote("123 Old Address", safe="") in url
+        assert quote("999 New Address", safe="") not in url
+
+    @pytest.mark.asyncio
+    async def test_google_maps_link_frozen_stop_without_snapshot_falls_back(
+        self,
+        async_client: AsyncClient,
+        test_session: AsyncSession,
+        test_route: Any,
+        test_location_group: Any,
+    ) -> None:
+        """A frozen route whose stop lacks a per-stop snapshot (e.g. the freeze
+        job skipped it for missing coords) falls back to the live Location for
+        that stop, while still using the RouteSnapshot origin."""
+        from urllib.parse import quote
+
+        from app.models.route_snapshot import RouteSnapshot
+
+        loc = Location(
+            location_group_id=test_location_group.location_group_id,
+            name="Unsnapped Fam",
+            contact_name="Unsnapped Fam",
+            address="55 Fallback Rd",
+            phone_primary="5550003333",
+            delivery_type="Family",
+            latitude=45.0,
+            longitude=-80.0,
+        )
+        test_session.add(loc)
+        await test_session.commit()
+        await test_session.refresh(loc)
+
+        test_session.add_all(
+            [
+                RouteStop(
+                    route_id=test_route.route_id,
+                    location_id=loc.location_id,
+                    stop_number=1,
+                ),
+                RouteSnapshot(
+                    route_id=test_route.route_id,
+                    start_address="Depot",
+                    start_latitude=43.65,
+                    start_longitude=-79.38,
+                ),
+            ]
+        )
+        await test_session.commit()
+
+        response = await async_client.get(
+            f"/routes/{test_route.route_id}/google-maps-link"
+        )
+        assert response.status_code == 200
+        url = response.json()
+        assert "/dir/43.65,-79.38/" in url
+        assert quote("55 Fallback Rd", safe="") in url
+
+    @pytest.mark.asyncio
     async def test_suggested_driver_by_past_deliveries(
         self,
         async_client: AsyncClient,


### PR DESCRIPTION
## Problem

`RouteService.get_google_maps_link` built its directions URL purely from the **live** `Location` rows and the **live** `SystemSettings` warehouse. Because locations mutate in place (a move updates the `Location` row), a Google Maps link generated for a **frozen / past route** reflected today's addresses and today's warehouse — not what was actually delivered to on the drive day. This silently drifted and was the odd one out: the rest of `route_service` already reads frozen routes via a COALESCE-over-snapshot pattern (e.g. `num_children` for box totals).

## Fix

`get_google_maps_link` now:
- **Per stop**, prefers the `RouteStopSnapshot` (frozen `address` / `latitude` / `longitude`) when present, falling back to the live `Location` — matching the `RouteStopSnapshot` docstring ("present = use snapshot").
- **Origin**: uses the `RouteSnapshot`'s frozen `start_latitude` / `start_longitude` when the route is frozen; otherwise the live warehouse from `SystemSettings` (which is only required for unfrozen routes now).

`build_google_maps_directions_url` is decoupled from the `Location` model via a small `MapWaypoint` dataclass, so the live-vs-snapshot resolution happens explicitly at the call site rather than by duck-typing on `Location`.

## Tests

- **`tests/test_google_maps_link.py`** (new): unit tests for the builder — origin formatting, URL-encoding, coord fallback, address-over-coords preference, stop ordering, the missing-data error, and the 50-waypoint / 2000-char limits.
- **`tests/test_routes.py`**: integration tests through the endpoint —
  - unfrozen route uses live data;
  - **frozen route's link is stable against live `Location` + warehouse mutation** (reflects the snapshot, not current values);
  - frozen route with a stop that has no per-stop snapshot falls back to the live `Location` while still using the `RouteSnapshot` origin.

All 15 pass locally; `ruff check`, `ruff format --check`, and `mypy` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)