### PR TITLE
Lock down driver self updates

### DIFF
--- a/backend/python/app/dependencies/auth.py
+++ b/backend/python/app/dependencies/auth.py
@@ -137,9 +137,9 @@ async def require_self_driver_or_admin(
 ) -> bool:
     """
     Allow access if the caller is an admin, or is the driver identified by the
-    route's ``{driver_id}`` path parameter. Used for GET /drivers/{driver_id}.
-    Returns True for admins and False for self-driver access so shared endpoints
-    can apply role-specific field restrictions after authorization.
+    route's ``{driver_id}`` path parameter. Returns True for admins and False
+    for self-driver access so shared endpoints can apply role-specific field
+    restrictions after authorization.
 
     The token is verified once (with email_verified enforced for everyone,
     admins included). The driver_id is read from the path via ``_path_uuid``,

--- a/backend/python/app/dependencies/auth.py
+++ b/backend/python/app/dependencies/auth.py
@@ -138,6 +138,8 @@ async def require_self_driver_or_admin(
     """
     Allow access if the caller is an admin, or is the driver identified by the
     route's ``{driver_id}`` path parameter. Used for GET /drivers/{driver_id}.
+    Returns True for admins and False for self-driver access so shared endpoints
+    can apply role-specific field restrictions after authorization.
 
     The token is verified once (with email_verified enforced for everyone,
     admins included). The driver_id is read from the path via ``_path_uuid``,
@@ -158,7 +160,7 @@ async def require_self_driver_or_admin(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="You are not authorized to access this resource.",
         )
-    return True
+    return False
 
 
 async def require_route_assigned_or_admin(

--- a/backend/python/app/models/driver.py
+++ b/backend/python/app/models/driver.py
@@ -115,6 +115,8 @@ class DriverRead(DriverBase):
 
 
 class DriverUpdate(SQLModel):
+    first_name: str | None = Field(default=None, min_length=1, max_length=255)
+    last_name: str | None = Field(default=None, min_length=1, max_length=255)
     phone: str | None = Field(default=None, min_length=1, max_length=20)
     partner_driver_name: str | None = Field(default=None, max_length=255)
     availability: list[bool] | None = Field(default=None)

--- a/backend/python/app/routers/driver_routes.py
+++ b/backend/python/app/routers/driver_routes.py
@@ -244,11 +244,21 @@ async def update_driver(
     driver_id: UUID,
     driver: DriverUpdate,
     session: AsyncSession = Depends(get_session),
-    _auth: bool = Depends(require_self_driver_or_admin),
+    is_admin: bool = Depends(require_self_driver_or_admin),
 ) -> DriverRead:
     """
     Update an existing driver
     """
+    if not is_admin:
+        self_editable_fields = {"first_name", "last_name", "phone"}
+        requested_fields = set(driver.model_fields_set)
+        admin_only_fields = requested_fields - self_editable_fields
+        if admin_only_fields:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Only admins can update these driver fields.",
+            )
+
     updated_driver = await driver_service.update_driver_by_id(
         session, driver_id, driver
     )

--- a/backend/python/app/services/implementations/driver_service.py
+++ b/backend/python/app/services/implementations/driver_service.py
@@ -1,7 +1,8 @@
 import logging
-from typing import Any
+from typing import Any, ClassVar
 from uuid import UUID
 
+import firebase_admin.auth
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 from sqlmodel import select
@@ -14,6 +15,8 @@ from app.models.user import User
 
 class DriverService:
     """Service for managing drivers with Firebase authentication integration"""
+
+    USER_UPDATE_FIELDS: ClassVar[set[str]] = {"first_name", "last_name"}
 
     def __init__(self, logger: logging.Logger):
         self.logger = logger
@@ -148,19 +151,36 @@ class DriverService:
                 return None
 
             update_data = driver_data.model_dump(exclude_unset=True)
-            user_update_fields = {"first_name", "last_name"}
             old_values = {
                 field: getattr(
-                    driver.user if field in user_update_fields else driver, field
+                    driver.user if field in self.USER_UPDATE_FIELDS else driver, field
                 )
                 for field in update_data
             }
 
             for field, value in update_data.items():
-                target = driver.user if field in user_update_fields else driver
+                target = driver.user if field in self.USER_UPDATE_FIELDS else driver
                 setattr(target, field, value)
 
             await session.commit()
+
+            if (
+                self.USER_UPDATE_FIELDS.intersection(update_data)
+                and driver.user.auth_id is not None
+            ):
+                firebase_admin.auth.update_user(
+                    driver.user.auth_id,
+                    display_name=driver.user.full_name,
+                )
+                firebase_admin.auth.set_custom_user_claims(
+                    driver.user.auth_id,
+                    {
+                        "role": driver.user.role,
+                        "given_name": driver.user.first_name,
+                        "family_name": driver.user.last_name,
+                    },
+                )
+
             await session.refresh(driver, attribute_names=["user"])
             return driver
 
@@ -168,7 +188,7 @@ class DriverService:
             # Rollback database changes
             assert driver is not None
             for field, value in old_values.items():
-                target = driver.user if field in {"first_name", "last_name"} else driver
+                target = driver.user if field in self.USER_UPDATE_FIELDS else driver
                 setattr(target, field, value)
             await session.commit()
             self.logger.error(f"Failed to update driver: {e!s}")

--- a/backend/python/app/services/implementations/driver_service.py
+++ b/backend/python/app/services/implementations/driver_service.py
@@ -148,10 +148,17 @@ class DriverService:
                 return None
 
             update_data = driver_data.model_dump(exclude_unset=True)
-            old_values = {field: getattr(driver, field) for field in update_data}
+            user_update_fields = {"first_name", "last_name"}
+            old_values = {
+                field: getattr(
+                    driver.user if field in user_update_fields else driver, field
+                )
+                for field in update_data
+            }
 
             for field, value in update_data.items():
-                setattr(driver, field, value)
+                target = driver.user if field in user_update_fields else driver
+                setattr(target, field, value)
 
             await session.commit()
             await session.refresh(driver, attribute_names=["user"])
@@ -161,7 +168,8 @@ class DriverService:
             # Rollback database changes
             assert driver is not None
             for field, value in old_values.items():
-                setattr(driver, field, value)
+                target = driver.user if field in {"first_name", "last_name"} else driver
+                setattr(target, field, value)
             await session.commit()
             self.logger.error(f"Failed to update driver: {e!s}")
             raise e

--- a/backend/python/tests/test_auth_middleware.py
+++ b/backend/python/tests/test_auth_middleware.py
@@ -287,9 +287,9 @@ def _make_driver_id_app() -> FastAPI:
 
     @app.get("/drivers/{driver_id}")
     async def get_driver(
-        driver_id: str, _auth: Any = Depends(require_self_driver_or_admin)
+        driver_id: str, is_admin: bool = Depends(require_self_driver_or_admin)
     ) -> dict:
-        return {"driver_id": driver_id}
+        return {"driver_id": driver_id, "is_admin": is_admin}
 
     return app
 
@@ -343,6 +343,7 @@ class TestRequireSelfDriverOrAdmin:
             resp = await _get_driver(app, driver_id, {"Authorization": "Bearer tok"})
 
         assert resp.status_code == 200
+        assert resp.json()["is_admin"] is True
 
     @pytest.mark.asyncio
     async def test_driver_can_access_own_id(self) -> None:
@@ -368,6 +369,7 @@ class TestRequireSelfDriverOrAdmin:
             resp = await _get_driver(app, driver_id, {"Authorization": "Bearer tok"})
 
         assert resp.status_code == 200
+        assert resp.json()["is_admin"] is False
 
     @pytest.mark.asyncio
     async def test_driver_cannot_access_other_driver(self) -> None:

--- a/backend/python/tests/test_routes.py
+++ b/backend/python/tests/test_routes.py
@@ -289,14 +289,18 @@ class TestDriverRoutes:
         self_client = await client_with_overrides(
             {require_self_driver_or_admin: lambda: False}
         )
-        response = await self_client.put(
-            f"/drivers/{test_driver.driver_id}",
-            json={
-                "first_name": "Updated",
-                "last_name": "Driver",
-                "phone": "+14165550123",
-            },
-        )
+        with (
+            patch("firebase_admin.auth.update_user") as mock_update_user,
+            patch("firebase_admin.auth.set_custom_user_claims") as mock_claims,
+        ):
+            response = await self_client.put(
+                f"/drivers/{test_driver.driver_id}",
+                json={
+                    "first_name": "Updated",
+                    "last_name": "Driver",
+                    "phone": "+14165550123",
+                },
+            )
 
         assert response.status_code == 200
         data = response.json()
@@ -310,6 +314,18 @@ class TestDriverRoutes:
         assert user.first_name == "Updated"
         assert user.last_name == "Driver"
         assert test_driver.phone == "+14165550123"
+        mock_update_user.assert_called_once_with(
+            user.auth_id,
+            display_name="Updated Driver",
+        )
+        mock_claims.assert_called_once_with(
+            user.auth_id,
+            {
+                "role": user.role,
+                "given_name": "Updated",
+                "family_name": "Driver",
+            },
+        )
 
     @pytest.mark.asyncio
     async def test_self_driver_cannot_update_admin_only_fields(
@@ -351,15 +367,19 @@ class TestDriverRoutes:
         """Admin update keeps the full DriverUpdate surface, including User names."""
         from app.models.user import User
 
-        response = await async_client.put(
-            f"/drivers/{test_driver.driver_id}",
-            json={
-                "first_name": "Admin",
-                "last_name": "Updated",
-                "address": "456 Admin Address St",
-                "active": False,
-            },
-        )
+        with (
+            patch("firebase_admin.auth.update_user") as mock_update_user,
+            patch("firebase_admin.auth.set_custom_user_claims") as mock_claims,
+        ):
+            response = await async_client.put(
+                f"/drivers/{test_driver.driver_id}",
+                json={
+                    "first_name": "Admin",
+                    "last_name": "Updated",
+                    "address": "456 Admin Address St",
+                    "active": False,
+                },
+            )
 
         assert response.status_code == 200
         data = response.json()
@@ -375,6 +395,18 @@ class TestDriverRoutes:
         assert user.last_name == "Updated"
         assert test_driver.address == "456 Admin Address St"
         assert test_driver.active is False
+        mock_update_user.assert_called_once_with(
+            user.auth_id,
+            display_name="Admin Updated",
+        )
+        mock_claims.assert_called_once_with(
+            user.auth_id,
+            {
+                "role": user.role,
+                "given_name": "Admin",
+                "family_name": "Updated",
+            },
+        )
 
     @pytest.mark.asyncio
     async def test_update_driver_not_found(self, async_client: AsyncClient) -> None:

--- a/backend/python/tests/test_routes.py
+++ b/backend/python/tests/test_routes.py
@@ -19,6 +19,7 @@ import pytest
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.dependencies.auth import require_self_driver_or_admin
 from app.dependencies.services import get_google_maps_client
 from app.models.location import Location
 from app.models.location_group import LocationGroup
@@ -274,6 +275,106 @@ class TestDriverRoutes:
         assert response.status_code == 200
         data = response.json()
         assert data["partner_driver_name"] is None
+
+    @pytest.mark.asyncio
+    async def test_self_driver_updates_own_name_and_phone(
+        self,
+        client_with_overrides: Any,
+        test_driver: Any,
+        test_session: AsyncSession,
+    ) -> None:
+        """Self-driver update can edit only User name fields and Driver phone."""
+        from app.models.user import User
+
+        self_client = await client_with_overrides(
+            {require_self_driver_or_admin: lambda: False}
+        )
+        response = await self_client.put(
+            f"/drivers/{test_driver.driver_id}",
+            json={
+                "first_name": "Updated",
+                "last_name": "Driver",
+                "phone": "+14165550123",
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["first_name"] == "Updated"
+        assert data["last_name"] == "Driver"
+        assert data["phone"] == "+14165550123"
+
+        await test_session.refresh(test_driver)
+        user = await test_session.get(User, test_driver.user_id)
+        assert user is not None
+        assert user.first_name == "Updated"
+        assert user.last_name == "Driver"
+        assert test_driver.phone == "+14165550123"
+
+    @pytest.mark.asyncio
+    async def test_self_driver_cannot_update_admin_only_fields(
+        self,
+        client_with_overrides: Any,
+        test_driver: Any,
+        test_session: AsyncSession,
+    ) -> None:
+        """Self-driver update rejects admin-only fields and does not persist them."""
+        original_phone = test_driver.phone
+        original_address = test_driver.address
+        original_active = test_driver.active
+        self_client = await client_with_overrides(
+            {require_self_driver_or_admin: lambda: False}
+        )
+
+        response = await self_client.put(
+            f"/drivers/{test_driver.driver_id}",
+            json={
+                "phone": "+14165550123",
+                "address": "123 Admin Only St",
+                "active": False,
+            },
+        )
+
+        assert response.status_code == 403
+        await test_session.refresh(test_driver)
+        assert test_driver.phone == original_phone
+        assert test_driver.address == original_address
+        assert test_driver.active is original_active
+
+    @pytest.mark.asyncio
+    async def test_admin_updates_driver_name_and_admin_only_fields(
+        self,
+        async_client: AsyncClient,
+        test_driver: Any,
+        test_session: AsyncSession,
+    ) -> None:
+        """Admin update keeps the full DriverUpdate surface, including User names."""
+        from app.models.user import User
+
+        response = await async_client.put(
+            f"/drivers/{test_driver.driver_id}",
+            json={
+                "first_name": "Admin",
+                "last_name": "Updated",
+                "address": "456 Admin Address St",
+                "active": False,
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["first_name"] == "Admin"
+        assert data["last_name"] == "Updated"
+        assert data["address"] == "456 Admin Address St"
+        assert data["active"] is False
+
+        await test_session.refresh(test_driver)
+        user = await test_session.get(User, test_driver.user_id)
+        assert user is not None
+        assert user.first_name == "Admin"
+        assert user.last_name == "Updated"
+        assert test_driver.address == "456 Admin Address St"
+        assert test_driver.active is False
 
     @pytest.mark.asyncio
     async def test_update_driver_not_found(self, async_client: AsyncClient) -> None:

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -925,6 +925,32 @@
             ],
             "title": "Car Make Model"
           },
+          "first_name": {
+            "anyOf": [
+              {
+                "maxLength": 255,
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "First Name"
+          },
+          "last_name": {
+            "anyOf": [
+              {
+                "maxLength": 255,
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Name"
+          },
           "license_plate": {
             "anyOf": [
               {

--- a/frontend/src/api/generated/types.gen.ts
+++ b/frontend/src/api/generated/types.gen.ts
@@ -572,6 +572,14 @@ export type DriverUpdate = {
    */
   car_make_model?: string | null;
   /**
+   * First Name
+   */
+  first_name?: string | null;
+  /**
+   * Last Name
+   */
+  last_name?: string | null;
+  /**
    * License Plate
    */
   license_plate?: string | null;


### PR DESCRIPTION
## Summary
- Let drivers update their own first name, last name, and phone through the existing driver update endpoint
- Block self-driver updates to admin-only fields like address, availability, vehicle details, and active
- Keep admin updates unrestricted and update generated API types

## Tests
- docker compose exec backend ruff format app tests scripts
- docker compose exec backend ruff check app tests scripts
- docker compose exec backend mypy . --config-file mypy.ini
- docker compose exec backend python -m pytest tests/test_routes.py tests/test_auth_middleware.py::TestRequireSelfDriverOrAdmin tests/test_models.py -q
- corepack pnpm@9.15.9 lint
- corepack pnpm@9.15.9 build