### PR TITLE
Build data import changes review page

### DIFF
--- a/backend/python/app/models/location.py
+++ b/backend/python/app/models/location.py
@@ -195,8 +195,6 @@ class ChangedEntry(SQLModel):
     phone_primary: str | ChangedFieldStr
     phone_secondary: str | None | ChangedFieldOptStr = None
     num_children: int | None | ChangedFieldOptInt = None
-    halal: bool | None = None
-    dietary_restrictions: str | None = None
 
 
 class LocationImportResponse(SQLModel):

--- a/backend/python/app/models/location.py
+++ b/backend/python/app/models/location.py
@@ -149,6 +149,8 @@ class NetNewEntry(SQLModel):
     phone_primary: str
     phone_secondary: str | None = None
     num_children: int | None = None
+    halal: bool | None = None
+    dietary_restrictions: str | None = None
 
 
 class StaleEntry(SQLModel):
@@ -193,6 +195,8 @@ class ChangedEntry(SQLModel):
     phone_primary: str | ChangedFieldStr
     phone_secondary: str | None | ChangedFieldOptStr = None
     num_children: int | None | ChangedFieldOptInt = None
+    halal: bool | None = None
+    dietary_restrictions: str | None = None
 
 
 class LocationImportResponse(SQLModel):

--- a/backend/python/app/services/implementations/location_service.py
+++ b/backend/python/app/services/implementations/location_service.py
@@ -867,12 +867,6 @@ class LocationService:
             )
             if num_children_changed
             else location.num_children,
-            halal=entry.halal if entry.halal is not None else location.halal,
-            dietary_restrictions=(
-                entry.dietary_restrictions
-                if entry.dietary_restrictions is not None
-                else location.dietary_restrictions
-            ),
         )
 
     async def _read_upload_file(self, file: UploadFile) -> pd.DataFrame:

--- a/backend/python/app/services/implementations/location_service.py
+++ b/backend/python/app/services/implementations/location_service.py
@@ -789,6 +789,8 @@ class LocationService:
             phone_primary=entry.phone_primary,
             phone_secondary=entry.phone_secondary,
             num_children=entry.num_children,
+            halal=entry.halal,
+            dietary_restrictions=entry.dietary_restrictions,
         )
 
     @staticmethod
@@ -865,6 +867,12 @@ class LocationService:
             )
             if num_children_changed
             else location.num_children,
+            halal=entry.halal if entry.halal is not None else location.halal,
+            dietary_restrictions=(
+                entry.dietary_restrictions
+                if entry.dietary_restrictions is not None
+                else location.dietary_restrictions
+            ),
         )
 
     async def _read_upload_file(self, file: UploadFile) -> pd.DataFrame:

--- a/backend/python/tests/test_routes.py
+++ b/backend/python/tests/test_routes.py
@@ -1680,6 +1680,8 @@ class TestLocationImportRoutes:
                     address="Formatted Old Address",
                     phone_primary="+14164164169",
                     num_children=2,
+                    halal=True,
+                    dietary_restrictions="Vegetarian",
                     delivery_type="Family",
                 ),
                 Location(
@@ -1755,6 +1757,11 @@ class TestLocationImportRoutes:
             "new_value": "Formatted New Address",
             "old_value": "Formatted Old Address",
         }
+        assert changed_by_name["Address Change Family"]["halal"] is True
+        assert (
+            changed_by_name["Address Change Family"]["dietary_restrictions"]
+            == "Vegetarian"
+        )
         assert changed_by_name["Phone Change Family"]["phone_primary"] == {
             "new_value": "+15195550123",
             "old_value": "+14164164170",

--- a/backend/python/tests/test_routes.py
+++ b/backend/python/tests/test_routes.py
@@ -1508,6 +1508,17 @@ class TestLocationImportRoutes:
     """Test suite for location import validation, review, and ingest."""
 
     @pytest.mark.asyncio
+    async def test_review_locations_rejects_unknown_delivery_type(
+        self, async_client: AsyncClient
+    ) -> None:
+        request = import_review_request([], delivery_type="Unknown")
+
+        response = await async_client.post("/locations/review", **request)
+
+        assert response.status_code == 400
+        assert "Unknown delivery_type" in response.json()["detail"]
+
+    @pytest.mark.asyncio
     async def test_review_locations_emits_specific_blocking_alerts(
         self, client_with_overrides: Any
     ) -> None:

--- a/backend/python/tests/test_routes.py
+++ b/backend/python/tests/test_routes.py
@@ -1680,8 +1680,6 @@ class TestLocationImportRoutes:
                     address="Formatted Old Address",
                     phone_primary="+14164164169",
                     num_children=2,
-                    halal=True,
-                    dietary_restrictions="Vegetarian",
                     delivery_type="Family",
                 ),
                 Location(
@@ -1757,11 +1755,6 @@ class TestLocationImportRoutes:
             "new_value": "Formatted New Address",
             "old_value": "Formatted Old Address",
         }
-        assert changed_by_name["Address Change Family"]["halal"] is True
-        assert (
-            changed_by_name["Address Change Family"]["dietary_restrictions"]
-            == "Vegetarian"
-        )
         assert changed_by_name["Phone Change Family"]["phone_primary"] == {
             "new_value": "+15195550123",
             "old_value": "+14164164170",

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -2057,17 +2057,6 @@
             "title": "Contact Name",
             "type": "string"
           },
-          "dietary_restrictions": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Dietary Restrictions"
-          },
           "delivery_group": {
             "anyOf": [
               {
@@ -2078,6 +2067,17 @@
               }
             ],
             "title": "Delivery Group"
+          },
+          "dietary_restrictions": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Dietary Restrictions"
           },
           "halal": {
             "anyOf": [

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -326,17 +326,6 @@
             "title": "Contact Name",
             "type": "string"
           },
-          "dietary_restrictions": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Dietary Restrictions"
-          },
           "delivery_group": {
             "anyOf": [
               {
@@ -355,17 +344,6 @@
             "format": "uuid",
             "title": "Location Id",
             "type": "string"
-          },
-          "halal": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Halal"
           },
           "num_children": {
             "anyOf": [

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -326,6 +326,17 @@
             "title": "Contact Name",
             "type": "string"
           },
+          "dietary_restrictions": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Dietary Restrictions"
+          },
           "delivery_group": {
             "anyOf": [
               {
@@ -344,6 +355,17 @@
             "format": "uuid",
             "title": "Location Id",
             "type": "string"
+          },
+          "halal": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Halal"
           },
           "num_children": {
             "anyOf": [
@@ -2057,6 +2079,17 @@
             "title": "Contact Name",
             "type": "string"
           },
+          "dietary_restrictions": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Dietary Restrictions"
+          },
           "delivery_group": {
             "anyOf": [
               {
@@ -2067,6 +2100,17 @@
               }
             ],
             "title": "Delivery Group"
+          },
+          "halal": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Halal"
           },
           "num_children": {
             "anyOf": [

--- a/frontend/src/api/generated/types.gen.ts
+++ b/frontend/src/api/generated/types.gen.ts
@@ -225,10 +225,6 @@ export type ChangedEntry = {
    */
   contact_name: string;
   /**
-   * Dietary Restrictions
-   */
-  dietary_restrictions?: string | null;
-  /**
    * Delivery Group
    */
   delivery_group?: string | ChangedFieldOptStr | null;
@@ -236,10 +232,6 @@ export type ChangedEntry = {
    * Location Id
    */
   location_id: string;
-  /**
-   * Halal
-   */
-  halal?: boolean | null;
   /**
    * Num Children
    */

--- a/frontend/src/api/generated/types.gen.ts
+++ b/frontend/src/api/generated/types.gen.ts
@@ -225,6 +225,10 @@ export type ChangedEntry = {
    */
   contact_name: string;
   /**
+   * Dietary Restrictions
+   */
+  dietary_restrictions?: string | null;
+  /**
    * Delivery Group
    */
   delivery_group?: string | ChangedFieldOptStr | null;
@@ -232,6 +236,10 @@ export type ChangedEntry = {
    * Location Id
    */
   location_id: string;
+  /**
+   * Halal
+   */
+  halal?: boolean | null;
   /**
    * Num Children
    */
@@ -1213,9 +1221,17 @@ export type NetNewEntry = {
    */
   contact_name: string;
   /**
+   * Dietary Restrictions
+   */
+  dietary_restrictions?: string | null;
+  /**
    * Delivery Group
    */
   delivery_group?: string | null;
+  /**
+   * Halal
+   */
+  halal?: boolean | null;
   /**
    * Num Children
    */

--- a/frontend/src/api/generated/types.gen.ts
+++ b/frontend/src/api/generated/types.gen.ts
@@ -1213,13 +1213,13 @@ export type NetNewEntry = {
    */
   contact_name: string;
   /**
-   * Dietary Restrictions
-   */
-  dietary_restrictions?: string | null;
-  /**
    * Delivery Group
    */
   delivery_group?: string | null;
+  /**
+   * Dietary Restrictions
+   */
+  dietary_restrictions?: string | null;
   /**
    * Halal
    */

--- a/frontend/src/common/components/FileInput.tsx
+++ b/frontend/src/common/components/FileInput.tsx
@@ -9,6 +9,7 @@ interface FileInputProps {
   selectedFile?: File | null;
   onClearFile?: () => void;
   accept?: string;
+  acceptedFileTypesLabel?: string;
   disabled?: boolean;
   className?: string;
 }
@@ -18,6 +19,7 @@ function FileInput({
   selectedFile,
   onClearFile,
   accept = '.xlsx',
+  acceptedFileTypesLabel = 'Excel files (.xlsx) only',
   disabled,
   className,
 }: FileInputProps) {
@@ -70,7 +72,7 @@ function FileInput({
         </p>
         <p className="text-p1 text-grey-500">
           <span className="text-red">* </span>
-          Excel files (.xlsx) only
+          {acceptedFileTypesLabel}
         </p>
       </div>
       {selectedFile && (

--- a/frontend/src/pages/admin/routes/generation/ImportStep.tsx
+++ b/frontend/src/pages/admin/routes/generation/ImportStep.tsx
@@ -27,7 +27,7 @@ import {
 
 import type { GenerationOutletContext } from './AdminRoutesGenerationLayout';
 
-const ACCEPTED_EXTENSIONS = new Set(['.xlsx']);
+const ACCEPTED_EXTENSIONS = new Set(['.xlsx', '.csv']);
 
 interface SystemField {
   key: string;
@@ -94,7 +94,7 @@ export function ImportStep() {
     const ext = '.' + selected.name.split('.').pop()?.toLowerCase();
     if (!ACCEPTED_EXTENSIONS.has(ext)) {
       setFormatError(
-        'Unsupported format — please upload an Excel (.xlsx) file'
+        'Unsupported format — please upload an Excel (.xlsx) or CSV file'
       );
       return;
     }
@@ -200,8 +200,8 @@ export function ImportStep() {
         <CardHeader>
           <CardTitle>Import Data</CardTitle>
           <CardDescription>
-            Select a delivery type, then upload an Excel file (.xlsx) with
-            delivery information
+            Select a delivery type, then upload an Excel (.xlsx) or CSV file
+            with delivery information
           </CardDescription>
         </CardHeader>
         <CardContent className="flex flex-col gap-4 pt-4">

--- a/frontend/src/pages/admin/routes/generation/ImportStep.tsx
+++ b/frontend/src/pages/admin/routes/generation/ImportStep.tsx
@@ -235,6 +235,8 @@ export function ImportStep() {
               onFileSelect={handleFileSelect}
               selectedFile={file}
               onClearFile={handleClearFile}
+              accept=".xlsx,.csv"
+              acceptedFileTypesLabel="Excel (.xlsx) or CSV files"
             />
           )}
         </CardContent>

--- a/frontend/src/pages/admin/routes/generation/ReviewStep.tsx
+++ b/frontend/src/pages/admin/routes/generation/ReviewStep.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { type ReactNode, useState } from 'react';
 import {
   Link,
   Navigate,
@@ -42,6 +42,7 @@ import type { GenerationOutletContext } from './AdminRoutesGenerationLayout';
  * generic mirrors their shape for the isChanged guard and ChangedCell below.
  */
 type ChangedField<T> = { new_value: T; old_value: T };
+type ChangedRow = ChangedEntry & { _index: number };
 
 function isChanged<T>(v: T | ChangedField<T>): v is ChangedField<T> {
   return (
@@ -50,6 +51,14 @@ function isChanged<T>(v: T | ChangedField<T>): v is ChangedField<T> {
     'new_value' in (v as object) &&
     'old_value' in (v as object)
   );
+}
+
+function newValue<T>(value: T | ChangedField<T>): T {
+  return isChanged(value) ? value.new_value : value;
+}
+
+function oldValue<T>(value: T | ChangedField<T>): T {
+  return isChanged(value) ? value.old_value : value;
 }
 
 function ChangedCell({
@@ -75,6 +84,31 @@ function ChangedCell({
         {value.old_value ?? '—'}
       </span>
     </div>
+  );
+}
+
+function DecisionButton({
+  active,
+  variant,
+  label,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  variant: 'primary' | 'secondary';
+  label: string;
+  onClick: () => void;
+  children: ReactNode;
+}) {
+  return (
+    <Button
+      variant={variant}
+      aria-label={label}
+      onClick={onClick}
+      className={active ? 'opacity-100' : 'opacity-45'}
+    >
+      {children}
+    </Button>
   );
 }
 
@@ -146,6 +180,30 @@ function toIngestNetNew(entry: NetNewEntry): ValidatedLocationImportEntry {
   };
 }
 
+function changedEntryToNetNew(
+  entry: ChangedEntry
+): ValidatedLocationImportEntry {
+  return {
+    contact_name: entry.contact_name,
+    address: newValue(entry.address),
+    delivery_group: newValue(entry.delivery_group) ?? '',
+    phone_primary: newValue(entry.phone_primary),
+    phone_secondary: newValue(entry.phone_secondary),
+    num_children: newValue(entry.num_children),
+  };
+}
+
+function changedEntryToStale(entry: ChangedEntry): StaleEntry {
+  return {
+    location_id: entry.location_id,
+    contact_name: entry.contact_name,
+    address: oldValue(entry.address),
+    delivery_group: oldValue(entry.delivery_group),
+    phone_primary: oldValue(entry.phone_primary),
+    phone_secondary: oldValue(entry.phone_secondary),
+  };
+}
+
 export function ReviewStep() {
   const navigate = useNavigate();
   const { file, reviewResult, selectedDeliveryType } =
@@ -153,7 +211,13 @@ export function ReviewStep() {
   const { mutateAsync: ingestLocations, isPending: isIngesting } =
     useIngestLocations();
 
-  const [accepted, setAccepted] = useState<Set<number>>(new Set());
+  const [excludedNetNewRows, setExcludedNetNewRows] = useState<Set<number>>(
+    new Set()
+  );
+  const [keptStaleIds, setKeptStaleIds] = useState<Set<string>>(new Set());
+  const [separateChangedRows, setSeparateChangedRows] = useState<Set<number>>(
+    new Set()
+  );
   const [confirmOpen, setConfirmOpen] = useState(false);
   const [ingestError, setIngestError] = useState<string | null>(null);
 
@@ -166,26 +230,56 @@ export function ReviewStep() {
   const staleRows = data.stale ?? [];
   const changedEntries = data.changed ?? [];
 
-  const toggleAccepted = (index: number) => {
-    setAccepted((prev) => {
+  const setNetNewIncluded = (row: number, included: boolean) => {
+    setExcludedNetNewRows((prev) => {
       const next = new Set(prev);
-      if (next.has(index)) {
-        next.delete(index);
-      } else {
-        next.add(index);
-      }
+      if (included) next.delete(row);
+      else next.add(row);
+      return next;
+    });
+  };
+
+  const setStaleIncluded = (locationId: string, included: boolean) => {
+    setKeptStaleIds((prev) => {
+      const next = new Set(prev);
+      if (included) next.delete(locationId);
+      else next.add(locationId);
+      return next;
+    });
+  };
+
+  const setChangedSeparate = (index: number, separate: boolean) => {
+    setSeparateChangedRows((prev) => {
+      const next = new Set(prev);
+      if (separate) next.add(index);
+      else next.delete(index);
       return next;
     });
   };
 
   const handleConfirm = async () => {
     setIngestError(null);
+    const approvedChanged = changedEntries.filter(
+      (_, index) => !separateChangedRows.has(index)
+    );
+    const separateChanged = changedEntries.filter((_, index) =>
+      separateChangedRows.has(index)
+    );
+
     try {
       await ingestLocations({
         delivery_type: selectedDeliveryType,
-        net_new: netNewRows.map(toIngestNetNew),
-        stale: staleRows,
-        changed: changedEntries,
+        net_new: [
+          ...netNewRows
+            .filter((entry) => !excludedNetNewRows.has(entry.row))
+            .map(toIngestNetNew),
+          ...separateChanged.map(changedEntryToNetNew),
+        ],
+        stale: [
+          ...staleRows.filter((entry) => !keptStaleIds.has(entry.location_id)),
+          ...separateChanged.map(changedEntryToStale),
+        ],
+        changed: approvedChanged,
       });
       setConfirmOpen(false);
       navigate('/admin/routes/generation/configure');
@@ -194,7 +288,69 @@ export function ReviewStep() {
     }
   };
 
-  const changedColumns: Column<ChangedEntry & { _index: number }>[] = [
+  const netNewReviewColumns: Column<NetNewEntry>[] = [
+    ...netNewColumns,
+    {
+      key: 'decision',
+      header: 'Decision',
+      render: (r) => {
+        const included = !excludedNetNewRows.has(r.row);
+        return (
+          <div className="flex items-center gap-2">
+            <DecisionButton
+              active={included}
+              variant="primary"
+              label="Add this row"
+              onClick={() => setNetNewIncluded(r.row, true)}
+            >
+              Add
+            </DecisionButton>
+            <DecisionButton
+              active={!included}
+              variant="secondary"
+              label="Skip this row"
+              onClick={() => setNetNewIncluded(r.row, false)}
+            >
+              Skip
+            </DecisionButton>
+          </div>
+        );
+      },
+    },
+  ];
+
+  const staleReviewColumns: Column<StaleEntry>[] = [
+    ...staleColumns,
+    {
+      key: 'decision',
+      header: 'Decision',
+      render: (r) => {
+        const included = !keptStaleIds.has(r.location_id);
+        return (
+          <div className="flex items-center gap-2">
+            <DecisionButton
+              active={included}
+              variant="primary"
+              label="Deactivate this location"
+              onClick={() => setStaleIncluded(r.location_id, true)}
+            >
+              Deactivate
+            </DecisionButton>
+            <DecisionButton
+              active={!included}
+              variant="secondary"
+              label="Keep this location active"
+              onClick={() => setStaleIncluded(r.location_id, false)}
+            >
+              Keep
+            </DecisionButton>
+          </div>
+        );
+      },
+    },
+  ];
+
+  const changedColumns: Column<ChangedRow>[] = [
     {
       key: 'contact_name',
       header: 'School / Last Name',
@@ -227,27 +383,28 @@ export function ReviewStep() {
     },
     {
       key: 'actions',
-      header: 'Actions',
+      header: 'Decision',
       render: (r) => {
-        const isAccepted = accepted.has(r._index);
+        const isSeparate = separateChangedRows.has(r._index);
         return (
           <div className="flex items-center gap-2">
             <Button
               variant="primary"
-              shape="circular"
-              aria-label="Accept new value"
-              onClick={() => !isAccepted && toggleAccepted(r._index)}
-              className={isAccepted ? 'opacity-100' : 'opacity-40'}
+              aria-label="Apply this change"
+              onClick={() => setChangedSeparate(r._index, false)}
+              className={!isSeparate ? 'opacity-100' : 'opacity-45'}
             >
               <CheckIcon className="size-4" />
+              Apply
             </Button>
             <Button
               variant="secondary"
-              shape="circular"
-              aria-label="Keep old value"
-              onClick={() => isAccepted && toggleAccepted(r._index)}
+              aria-label="Treat as separate rows"
+              onClick={() => setChangedSeparate(r._index, true)}
+              className={isSeparate ? 'opacity-100' : 'opacity-45'}
             >
               <XIcon className="size-4" />
+              Separate
             </Button>
           </div>
         );
@@ -259,6 +416,10 @@ export function ReviewStep() {
     ...entry,
     _index: i,
   }));
+  const appliedNetNewCount = netNewRows.length - excludedNetNewRows.size;
+  const appliedStaleCount = staleRows.length - keptStaleIds.size;
+  const appliedChangedCount = changedEntries.length - separateChangedRows.size;
+  const separateChangedCount = separateChangedRows.size;
 
   return (
     <>
@@ -273,11 +434,11 @@ export function ReviewStep() {
         <div>
           <h2 className="text-grey-500">New in Spreadsheet</h2>
           <p className="text-p1 text-grey-400">
-            New entries to be added to the system.
+            New rows can be added to the system or skipped for now.
           </p>
         </div>
         <DataTable
-          columns={netNewColumns}
+          columns={netNewReviewColumns}
           rows={netNewRows}
           getRowKey={(r) => r.row}
           emptyState={
@@ -294,11 +455,11 @@ export function ReviewStep() {
         <div>
           <h2 className="text-grey-500">Removed in Spreadsheet</h2>
           <p className="text-p1 text-grey-400">
-            Entries to be archived in the system.
+            Removed locations can be marked inactive or kept as-is.
           </p>
         </div>
         <DataTable
-          columns={staleColumns}
+          columns={staleReviewColumns}
           rows={staleRows}
           getRowKey={(r) => r.location_id}
           emptyState={
@@ -316,7 +477,8 @@ export function ReviewStep() {
           <div>
             <h2 className="text-grey-500">Data that has Changed</h2>
             <p className="text-p1 text-grey-400">
-              Entries that have data that was changed from previous upload.
+              Apply a matched change, or treat the spreadsheet row as a separate
+              location.
             </p>
           </div>
           <div className="flex items-center gap-2">
@@ -353,8 +515,17 @@ export function ReviewStep() {
           <ModalHeader>
             <ModalTitle>Confirm Changes</ModalTitle>
             <ModalDescription>
-              Some data has been updated, added, or removed. Are you sure you
-              want to apply these changes?
+              This will add {appliedNetNewCount + separateChangedCount} new{' '}
+              {appliedNetNewCount + separateChangedCount === 1
+                ? 'location'
+                : 'locations'}
+              , mark {appliedStaleCount + separateChangedCount}{' '}
+              {appliedStaleCount + separateChangedCount === 1
+                ? 'location'
+                : 'locations'}{' '}
+              inactive, and apply {appliedChangedCount}{' '}
+              {appliedChangedCount === 1 ? 'matched change' : 'matched changes'}
+              .
             </ModalDescription>
           </ModalHeader>
           <ModalFooter>

--- a/frontend/src/pages/admin/routes/generation/ReviewStep.tsx
+++ b/frontend/src/pages/admin/routes/generation/ReviewStep.tsx
@@ -13,7 +13,6 @@ import type {
   StaleEntry,
   ValidatedLocationImportEntry,
 } from '@/api/generated/types.gen';
-import CheckIcon from '@/assets/icons/check.svg?react';
 import type { Column } from '@/common/components';
 import {
   Banner,
@@ -25,30 +24,19 @@ import {
   ModalFooter,
   ModalHeader,
   ModalTitle,
-  Tag,
 } from '@/common/components';
 
 import { EmptyState } from '../components';
 import type { GenerationOutletContext } from './AdminRoutesGenerationLayout';
 
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-/**
- * A field that either holds a plain value or a before/after change pair.
- * The generated client emits concrete variants (ChangedFieldStr, etc.); this
- * generic mirrors their shape for the isChanged guard and ChangedCell below.
- */
 type ChangedField<T> = { new_value: T; old_value: T };
-type ChangedRow = ChangedEntry & { _index: number };
 
-function isChanged<T>(v: T | ChangedField<T>): v is ChangedField<T> {
+function isChanged<T>(value: T | ChangedField<T>): value is ChangedField<T> {
   return (
-    typeof v === 'object' &&
-    v !== null &&
-    'new_value' in (v as object) &&
-    'old_value' in (v as object)
+    typeof value === 'object' &&
+    value !== null &&
+    'new_value' in (value as object) &&
+    'old_value' in (value as object)
   );
 }
 
@@ -66,74 +54,20 @@ function ChangedCell({
   if (!isChanged(value)) {
     return <span>{value ?? '—'}</span>;
   }
+
   return (
-    <div className="flex flex-col gap-1">
-      <span className="bg-success-fill text-success-stroke inline-block rounded px-2 py-0.5 text-xs font-medium">
-        {value.new_value ?? '—'}
-      </span>
-      <span className="bg-light-red text-red border-red inline-block rounded-t border-b-2 px-2 py-0.5 text-xs font-medium">
+    <div className="-mx-4 -my-2.5 flex flex-col">
+      <span className="bg-grey-150 flex min-h-10 items-center gap-2 px-4 py-2.5">
+        <span className="text-grey-400 text-base">−</span>
         {value.old_value ?? '—'}
+      </span>
+      <span className="flex min-h-10 items-center gap-2 border-b-2 border-blue-100 bg-blue-50 px-4 py-2.5">
+        <span className="text-grey-400 text-base">+</span>
+        {value.new_value ?? '—'}
       </span>
     </div>
   );
 }
-
-// ---------------------------------------------------------------------------
-// Column definitions
-// ---------------------------------------------------------------------------
-
-const netNewColumns: Column<NetNewEntry>[] = [
-  { key: 'row', header: 'Row', render: (r) => String(r.row) },
-  {
-    key: 'contact_name',
-    header: 'School / Last Name',
-    render: (r) => r.contact_name,
-  },
-  { key: 'address', header: 'Address', render: (r) => r.address },
-  {
-    key: 'delivery_group',
-    header: 'Delivery Group',
-    render: (r) => r.delivery_group ?? '—',
-  },
-  {
-    key: 'phone_primary',
-    header: 'Primary Phone',
-    render: (r) => r.phone_primary,
-  },
-  {
-    key: 'phone_secondary',
-    header: 'Secondary Phone',
-    render: (r) => r.phone_secondary ?? '—',
-  },
-];
-
-const staleColumns: Column<StaleEntry>[] = [
-  {
-    key: 'contact_name',
-    header: 'School / Last Name',
-    render: (r) => r.contact_name,
-  },
-  { key: 'address', header: 'Address', render: (r) => r.address },
-  {
-    key: 'delivery_group',
-    header: 'Delivery Group',
-    render: (r) => r.delivery_group ?? '—',
-  },
-  {
-    key: 'phone_primary',
-    header: 'Primary Phone',
-    render: (r) => r.phone_primary,
-  },
-  {
-    key: 'phone_secondary',
-    header: 'Secondary Phone',
-    render: (r) => r.phone_secondary ?? '—',
-  },
-];
-
-// ---------------------------------------------------------------------------
-// ReviewStep
-// ---------------------------------------------------------------------------
 
 function toIngestNetNew(entry: NetNewEntry): ValidatedLocationImportEntry {
   return {
@@ -148,6 +82,28 @@ function toIngestNetNew(entry: NetNewEntry): ValidatedLocationImportEntry {
   };
 }
 
+function ReviewStatus({
+  reviewed,
+  total,
+}: {
+  reviewed: number;
+  total: number;
+}) {
+  const complete = reviewed === total && total > 0;
+
+  return (
+    <span
+      className={
+        complete
+          ? 'bg-success-fill text-success-stroke rounded-full px-3 py-1 text-sm'
+          : 'bg-grey-300 rounded-full px-3 py-1 text-sm'
+      }
+    >
+      {reviewed} / {total} Reviewed
+    </span>
+  );
+}
+
 export function ReviewStep() {
   const navigate = useNavigate();
   const { file, reviewResult, selectedDeliveryType } =
@@ -155,7 +111,10 @@ export function ReviewStep() {
   const { mutateAsync: ingestLocations, isPending: isIngesting } =
     useIngestLocations();
 
-  const [confirmedChanges, setConfirmedChanges] = useState<Set<number>>(
+  const [reviewedChanged, setReviewedChanged] = useState<Set<number>>(
+    new Set()
+  );
+  const [reviewedRemoved, setReviewedRemoved] = useState<Set<string>>(
     new Set()
   );
   const [confirmOpen, setConfirmOpen] = useState(false);
@@ -165,14 +124,13 @@ export function ReviewStep() {
     return <Navigate to="/admin/routes/generation/import" replace />;
   }
 
-  const data = reviewResult;
-  const netNewRows = data.net_new ?? [];
-  const staleRows = data.stale ?? [];
-  const changedEntries = data.changed ?? [];
+  const netNewRows = reviewResult.net_new ?? [];
+  const staleRows = reviewResult.stale ?? [];
+  const changedEntries = reviewResult.changed ?? [];
 
-  const toggleConfirmed = (index: number) => {
-    setConfirmedChanges((prev) => {
-      const next = new Set(prev);
+  const toggleChanged = (index: number) => {
+    setReviewedChanged((previous) => {
+      const next = new Set(previous);
       if (next.has(index)) {
         next.delete(index);
       } else {
@@ -182,15 +140,32 @@ export function ReviewStep() {
     });
   };
 
+  const toggleRemoved = (locationId: string) => {
+    setReviewedRemoved((previous) => {
+      const next = new Set(previous);
+      if (next.has(locationId)) {
+        next.delete(locationId);
+      } else {
+        next.add(locationId);
+      }
+      return next;
+    });
+  };
+
+  const allReviewed =
+    reviewedChanged.size === changedEntries.length &&
+    reviewedRemoved.size === staleRows.length;
+
   const handleConfirm = async () => {
     setIngestError(null);
-
     try {
       await ingestLocations({
         delivery_type: selectedDeliveryType,
         net_new: netNewRows.map(toIngestNetNew),
         stale: staleRows,
-        changed: changedEntries,
+        changed: changedEntries.filter((_, index) =>
+          reviewedChanged.has(index)
+        ),
       });
       setConfirmOpen(false);
       navigate('/admin/routes/generation/configure');
@@ -199,66 +174,91 @@ export function ReviewStep() {
     }
   };
 
-  const changedColumns: Column<ChangedRow>[] = [
+  const changedColumns: Column<ChangedEntry & { _index: number }>[] = [
+    {
+      key: 'reviewed',
+      header: '',
+      headerClassName: 'w-8 px-2',
+      render: (row) => (
+        <input
+          type="checkbox"
+          checked={reviewedChanged.has(row._index)}
+          onChange={() => toggleChanged(row._index)}
+          aria-label={`Review changes for ${row.contact_name}`}
+          className="border-grey-300 size-4 cursor-pointer rounded accent-blue-300"
+        />
+      ),
+    },
     {
       key: 'contact_name',
       header: 'School / Last Name',
-      render: (r) => r.contact_name,
+      render: (row) => row.contact_name,
     },
     {
       key: 'address',
       header: 'Address',
-      render: (r) => <ChangedCell value={r.address} />,
+      render: (row) => <ChangedCell value={row.address} />,
     },
     {
       key: 'delivery_group',
       header: 'Delivery Group',
-      render: (r) => <ChangedCell value={r.delivery_group} />,
+      render: (row) => <ChangedCell value={row.delivery_group} />,
     },
     {
       key: 'phone_primary',
-      header: 'Primary Phone',
-      render: (r) => <ChangedCell value={r.phone_primary} />,
-    },
-    {
-      key: 'phone_secondary',
-      header: 'Secondary Phone',
-      render: (r) => <ChangedCell value={r.phone_secondary} />,
+      header: 'Phone Number',
+      render: (row) => <ChangedCell value={row.phone_primary} />,
     },
     {
       key: 'num_children',
       header: 'Number of Children',
-      render: (r) => <ChangedCell value={r.num_children} />,
-    },
-    {
-      key: 'actions',
-      header: 'Confirmed',
-      render: (r) => {
-        const isConfirmed = confirmedChanges.has(r._index);
-        return (
-          <Button
-            variant="primary"
-            shape="circular"
-            aria-label={
-              isConfirmed ? 'Unconfirm this change' : 'Confirm this change'
-            }
-            title={isConfirmed ? 'Unconfirm change' : 'Confirm change'}
-            aria-pressed={isConfirmed}
-            onClick={() => toggleConfirmed(r._index)}
-            className={isConfirmed ? 'opacity-100' : 'opacity-40'}
-          >
-            <CheckIcon className="size-4" />
-          </Button>
-        );
-      },
+      render: (row) => <ChangedCell value={row.num_children} />,
     },
   ];
 
-  const changedRows = changedEntries.map((entry, i) => ({
+  const staleColumns: Column<StaleEntry>[] = [
+    {
+      key: 'reviewed',
+      header: '',
+      headerClassName: 'w-8 px-2',
+      render: (row) => (
+        <input
+          type="checkbox"
+          checked={reviewedRemoved.has(row.location_id)}
+          onChange={() => toggleRemoved(row.location_id)}
+          aria-label={`Review removal of ${row.contact_name}`}
+          className="border-grey-300 size-4 cursor-pointer rounded accent-blue-300"
+        />
+      ),
+    },
+    {
+      key: 'contact_name',
+      header: 'School / Last Name',
+      render: (row) => row.contact_name,
+    },
+    { key: 'address', header: 'Address', render: (row) => row.address },
+    {
+      key: 'delivery_group',
+      header: 'Delivery Group',
+      render: (row) => row.delivery_group ?? '—',
+    },
+    {
+      key: 'phone_primary',
+      header: 'Phone Number',
+      render: (row) => row.phone_primary,
+    },
+    {
+      key: 'num_children',
+      header: 'Number of Children',
+      render: () => '—',
+    },
+  ];
+
+  const changedRows = changedEntries.map((entry, index) => ({
     ...entry,
-    _index: i,
+    _index: index,
   }));
-  const allChangesConfirmed = confirmedChanges.size === changedEntries.length;
+  const compactEmptyState = '[&_td>div]:gap-1 [&_td>div]:py-8 [&_td_img]:h-28';
 
   return (
     <>
@@ -268,104 +268,92 @@ export function ReviewStep() {
         </Banner>
       )}
 
-      {/* New in Spreadsheet */}
       <section className="flex flex-col gap-3">
-        <div>
-          <h2 className="text-grey-500">New in Spreadsheet</h2>
-          <p className="text-p1 text-grey-400">
-            New entries to be added to the system.
-          </p>
-        </div>
-        <DataTable
-          columns={netNewColumns}
-          rows={netNewRows}
-          getRowKey={(r) => r.row}
-          emptyState={
-            <EmptyState
-              title="No new entries found in the spreadsheet"
-              description="It's feeling quite empty here"
-            />
-          }
-        />
-      </section>
-
-      {/* Removed in Spreadsheet */}
-      <section className="flex flex-col gap-3">
-        <div>
-          <h2 className="text-grey-500">Removed in Spreadsheet</h2>
-          <p className="text-p1 text-grey-400">
-            Entries to be marked inactive in the system.
-          </p>
-        </div>
-        <DataTable
-          columns={staleColumns}
-          rows={staleRows}
-          getRowKey={(r) => r.location_id}
-          emptyState={
-            <EmptyState
-              title="No removed entries found in the spreadsheet"
-              description="It's feeling quite empty here"
-            />
-          }
-        />
-      </section>
-
-      {/* Data that has Changed */}
-      <section className="flex flex-col gap-3">
-        <div className="flex items-start justify-between">
+        <div className="flex items-end justify-between">
           <div>
-            <h2 className="text-grey-500">Data that has Changed</h2>
-            <p className="text-p1 text-grey-400">
-              Review and confirm each change before continuing.
+            <div className="flex items-center gap-3">
+              <h2 className="text-grey-500">Changed Data</h2>
+              <ReviewStatus
+                reviewed={reviewedChanged.size}
+                total={changedEntries.length}
+              />
+            </div>
+            <p className="text-p1 text-grey-500">
+              Check off entries that have changed since the previous upload to
+              confirm you have reviewed them
             </p>
           </div>
           <div className="flex items-center gap-2">
-            <Tag variant="success">New</Tag>
-            <Tag variant="error">Old</Tag>
+            <span className="border-grey-300 rounded-full border bg-white px-4 py-1 text-sm">
+              Old
+            </span>
+            <span className="rounded-full border border-blue-100 bg-blue-50 px-4 py-1 text-sm">
+              New
+            </span>
           </div>
         </div>
         <DataTable
           columns={changedColumns}
           rows={changedRows}
-          getRowKey={(r) => r._index}
+          getRowKey={(row) => row._index}
+          className={compactEmptyState}
           emptyState={
             <EmptyState
-              title="No new entries found in the spreadsheet"
-              description="It's feeling quite empty here"
+              title="No entries found"
+              description="No action required at this time"
             />
           }
         />
       </section>
 
-      {/* Actions */}
+      <section className="flex flex-col gap-3">
+        <div>
+          <div className="flex items-center gap-3">
+            <h2 className="text-grey-500">Removed</h2>
+            <ReviewStatus
+              reviewed={reviewedRemoved.size}
+              total={staleRows.length}
+            />
+          </div>
+          <p className="text-p1 text-grey-500">
+            Check off entries that were removed since the previous upload to
+            confirm you have reviewed them
+          </p>
+        </div>
+        <DataTable
+          columns={staleColumns}
+          rows={staleRows}
+          getRowKey={(row) => row.location_id}
+          className={compactEmptyState}
+          emptyState={
+            <EmptyState
+              title="No entries found"
+              description="No action required at this time"
+            />
+          }
+        />
+      </section>
+
       <div className="flex items-center justify-between">
         <Button variant="tertiary" asChild>
-          <Link to="/admin/routes/generation/validate">Back to Validation</Link>
+          <Link to="/admin/routes/generation/validate">Back to validate</Link>
         </Button>
         <Button
           variant="primary"
-          disabled={!allChangesConfirmed}
+          disabled={!allReviewed}
           onClick={() => setConfirmOpen(true)}
         >
-          Continue to Configure Routes
+          Continue to edit route groups
         </Button>
       </div>
 
-      {/* Confirmation Changes Modal */}
       <Modal open={confirmOpen} onOpenChange={setConfirmOpen}>
         <ModalContent>
           <ModalHeader>
             <ModalTitle>Confirm Changes</ModalTitle>
             <ModalDescription>
-              This will add {netNewRows.length} new{' '}
-              {netNewRows.length === 1 ? 'location' : 'locations'}, mark{' '}
-              {staleRows.length}{' '}
-              {staleRows.length === 1 ? 'location' : 'locations'} inactive, and
-              apply {changedEntries.length}{' '}
-              {changedEntries.length === 1
-                ? 'matched change'
-                : 'matched changes'}
-              .
+              Some data has been updated, added, or removed. Are you sure you
+              want to apply these changes?
             </ModalDescription>
           </ModalHeader>
           <ModalFooter>
@@ -377,7 +365,7 @@ export function ReviewStep() {
               disabled={isIngesting}
               onClick={handleConfirm}
             >
-              {isIngesting ? 'Applying…' : 'Apply Changes'}
+              {isIngesting ? 'Applying…' : 'Apply changes'}
             </Button>
           </ModalFooter>
         </ModalContent>

--- a/frontend/src/pages/admin/routes/generation/ReviewStep.tsx
+++ b/frontend/src/pages/admin/routes/generation/ReviewStep.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, useState } from 'react';
+import { useState } from 'react';
 import {
   Link,
   Navigate,
@@ -87,31 +87,6 @@ function ChangedCell({
   );
 }
 
-function DecisionButton({
-  active,
-  variant,
-  label,
-  onClick,
-  children,
-}: {
-  active: boolean;
-  variant: 'primary' | 'secondary';
-  label: string;
-  onClick: () => void;
-  children: ReactNode;
-}) {
-  return (
-    <Button
-      variant={variant}
-      aria-label={label}
-      onClick={onClick}
-      className={active ? 'opacity-100' : 'opacity-45'}
-    >
-      {children}
-    </Button>
-  );
-}
-
 // ---------------------------------------------------------------------------
 // Column definitions
 // ---------------------------------------------------------------------------
@@ -177,6 +152,8 @@ function toIngestNetNew(entry: NetNewEntry): ValidatedLocationImportEntry {
     phone_primary: entry.phone_primary,
     phone_secondary: entry.phone_secondary,
     num_children: entry.num_children,
+    halal: entry.halal,
+    dietary_restrictions: entry.dietary_restrictions,
   };
 }
 
@@ -190,6 +167,8 @@ function changedEntryToNetNew(
     phone_primary: newValue(entry.phone_primary),
     phone_secondary: newValue(entry.phone_secondary),
     num_children: newValue(entry.num_children),
+    halal: entry.halal,
+    dietary_restrictions: entry.dietary_restrictions,
   };
 }
 
@@ -211,13 +190,9 @@ export function ReviewStep() {
   const { mutateAsync: ingestLocations, isPending: isIngesting } =
     useIngestLocations();
 
-  const [excludedNetNewRows, setExcludedNetNewRows] = useState<Set<number>>(
-    new Set()
-  );
-  const [keptStaleIds, setKeptStaleIds] = useState<Set<string>>(new Set());
-  const [separateChangedRows, setSeparateChangedRows] = useState<Set<number>>(
-    new Set()
-  );
+  const [changedDecisions, setChangedDecisions] = useState<
+    Map<number, 'apply' | 'separate'>
+  >(new Map());
   const [confirmOpen, setConfirmOpen] = useState(false);
   const [ingestError, setIngestError] = useState<string | null>(null);
 
@@ -230,29 +205,13 @@ export function ReviewStep() {
   const staleRows = data.stale ?? [];
   const changedEntries = data.changed ?? [];
 
-  const setNetNewIncluded = (row: number, included: boolean) => {
-    setExcludedNetNewRows((prev) => {
-      const next = new Set(prev);
-      if (included) next.delete(row);
-      else next.add(row);
-      return next;
-    });
-  };
-
-  const setStaleIncluded = (locationId: string, included: boolean) => {
-    setKeptStaleIds((prev) => {
-      const next = new Set(prev);
-      if (included) next.delete(locationId);
-      else next.add(locationId);
-      return next;
-    });
-  };
-
-  const setChangedSeparate = (index: number, separate: boolean) => {
-    setSeparateChangedRows((prev) => {
-      const next = new Set(prev);
-      if (separate) next.add(index);
-      else next.delete(index);
+  const setChangedDecision = (
+    index: number,
+    decision: 'apply' | 'separate'
+  ) => {
+    setChangedDecisions((prev) => {
+      const next = new Map(prev);
+      next.set(index, decision);
       return next;
     });
   };
@@ -260,25 +219,20 @@ export function ReviewStep() {
   const handleConfirm = async () => {
     setIngestError(null);
     const approvedChanged = changedEntries.filter(
-      (_, index) => !separateChangedRows.has(index)
+      (_, index) => changedDecisions.get(index) === 'apply'
     );
-    const separateChanged = changedEntries.filter((_, index) =>
-      separateChangedRows.has(index)
+    const separateChanged = changedEntries.filter(
+      (_, index) => changedDecisions.get(index) === 'separate'
     );
 
     try {
       await ingestLocations({
         delivery_type: selectedDeliveryType,
         net_new: [
-          ...netNewRows
-            .filter((entry) => !excludedNetNewRows.has(entry.row))
-            .map(toIngestNetNew),
+          ...netNewRows.map(toIngestNetNew),
           ...separateChanged.map(changedEntryToNetNew),
         ],
-        stale: [
-          ...staleRows.filter((entry) => !keptStaleIds.has(entry.location_id)),
-          ...separateChanged.map(changedEntryToStale),
-        ],
+        stale: [...staleRows, ...separateChanged.map(changedEntryToStale)],
         changed: approvedChanged,
       });
       setConfirmOpen(false);
@@ -287,68 +241,6 @@ export function ReviewStep() {
       setIngestError('Could not apply the import changes — please try again.');
     }
   };
-
-  const netNewReviewColumns: Column<NetNewEntry>[] = [
-    ...netNewColumns,
-    {
-      key: 'decision',
-      header: 'Decision',
-      render: (r) => {
-        const included = !excludedNetNewRows.has(r.row);
-        return (
-          <div className="flex items-center gap-2">
-            <DecisionButton
-              active={included}
-              variant="primary"
-              label="Add this row"
-              onClick={() => setNetNewIncluded(r.row, true)}
-            >
-              Add
-            </DecisionButton>
-            <DecisionButton
-              active={!included}
-              variant="secondary"
-              label="Skip this row"
-              onClick={() => setNetNewIncluded(r.row, false)}
-            >
-              Skip
-            </DecisionButton>
-          </div>
-        );
-      },
-    },
-  ];
-
-  const staleReviewColumns: Column<StaleEntry>[] = [
-    ...staleColumns,
-    {
-      key: 'decision',
-      header: 'Decision',
-      render: (r) => {
-        const included = !keptStaleIds.has(r.location_id);
-        return (
-          <div className="flex items-center gap-2">
-            <DecisionButton
-              active={included}
-              variant="primary"
-              label="Deactivate this location"
-              onClick={() => setStaleIncluded(r.location_id, true)}
-            >
-              Deactivate
-            </DecisionButton>
-            <DecisionButton
-              active={!included}
-              variant="secondary"
-              label="Keep this location active"
-              onClick={() => setStaleIncluded(r.location_id, false)}
-            >
-              Keep
-            </DecisionButton>
-          </div>
-        );
-      },
-    },
-  ];
 
   const changedColumns: Column<ChangedRow>[] = [
     {
@@ -385,26 +277,30 @@ export function ReviewStep() {
       key: 'actions',
       header: 'Decision',
       render: (r) => {
-        const isSeparate = separateChangedRows.has(r._index);
+        const decision = changedDecisions.get(r._index);
         return (
           <div className="flex items-center gap-2">
             <Button
               variant="primary"
+              shape="circular"
               aria-label="Apply this change"
-              onClick={() => setChangedSeparate(r._index, false)}
-              className={!isSeparate ? 'opacity-100' : 'opacity-45'}
+              title="Apply change"
+              aria-pressed={decision === 'apply'}
+              onClick={() => setChangedDecision(r._index, 'apply')}
+              className={decision === 'apply' ? 'opacity-100' : 'opacity-40'}
             >
               <CheckIcon className="size-4" />
-              Apply
             </Button>
             <Button
               variant="secondary"
+              shape="circular"
               aria-label="Treat as separate rows"
-              onClick={() => setChangedSeparate(r._index, true)}
-              className={isSeparate ? 'opacity-100' : 'opacity-45'}
+              title="Treat as separate rows"
+              aria-pressed={decision === 'separate'}
+              onClick={() => setChangedDecision(r._index, 'separate')}
+              className={decision === 'separate' ? 'opacity-100' : 'opacity-40'}
             >
               <XIcon className="size-4" />
-              Separate
             </Button>
           </div>
         );
@@ -416,10 +312,13 @@ export function ReviewStep() {
     ...entry,
     _index: i,
   }));
-  const appliedNetNewCount = netNewRows.length - excludedNetNewRows.size;
-  const appliedStaleCount = staleRows.length - keptStaleIds.size;
-  const appliedChangedCount = changedEntries.length - separateChangedRows.size;
-  const separateChangedCount = separateChangedRows.size;
+  const appliedChangedCount = [...changedDecisions.values()].filter(
+    (decision) => decision === 'apply'
+  ).length;
+  const separateChangedCount = [...changedDecisions.values()].filter(
+    (decision) => decision === 'separate'
+  ).length;
+  const allChangesDecided = changedDecisions.size === changedEntries.length;
 
   return (
     <>
@@ -434,11 +333,11 @@ export function ReviewStep() {
         <div>
           <h2 className="text-grey-500">New in Spreadsheet</h2>
           <p className="text-p1 text-grey-400">
-            New rows can be added to the system or skipped for now.
+            New entries to be added to the system.
           </p>
         </div>
         <DataTable
-          columns={netNewReviewColumns}
+          columns={netNewColumns}
           rows={netNewRows}
           getRowKey={(r) => r.row}
           emptyState={
@@ -455,16 +354,16 @@ export function ReviewStep() {
         <div>
           <h2 className="text-grey-500">Removed in Spreadsheet</h2>
           <p className="text-p1 text-grey-400">
-            Removed locations can be marked inactive or kept as-is.
+            Entries to be marked inactive in the system.
           </p>
         </div>
         <DataTable
-          columns={staleReviewColumns}
+          columns={staleColumns}
           rows={staleRows}
           getRowKey={(r) => r.location_id}
           emptyState={
             <EmptyState
-              title="No new entries found in the spreadsheet"
+              title="No removed entries found in the spreadsheet"
               description="It's feeling quite empty here"
             />
           }
@@ -477,7 +376,7 @@ export function ReviewStep() {
           <div>
             <h2 className="text-grey-500">Data that has Changed</h2>
             <p className="text-p1 text-grey-400">
-              Apply a matched change, or treat the spreadsheet row as a separate
+              Select whether each matched row is a change or a separate
               location.
             </p>
           </div>
@@ -504,7 +403,11 @@ export function ReviewStep() {
         <Button variant="tertiary" asChild>
           <Link to="/admin/routes/generation/validate">Back to Validation</Link>
         </Button>
-        <Button variant="primary" onClick={() => setConfirmOpen(true)}>
+        <Button
+          variant="primary"
+          disabled={!allChangesDecided}
+          onClick={() => setConfirmOpen(true)}
+        >
           Continue to Configure Routes
         </Button>
       </div>
@@ -515,12 +418,12 @@ export function ReviewStep() {
           <ModalHeader>
             <ModalTitle>Confirm Changes</ModalTitle>
             <ModalDescription>
-              This will add {appliedNetNewCount + separateChangedCount} new{' '}
-              {appliedNetNewCount + separateChangedCount === 1
+              This will add {netNewRows.length + separateChangedCount} new{' '}
+              {netNewRows.length + separateChangedCount === 1
                 ? 'location'
                 : 'locations'}
-              , mark {appliedStaleCount + separateChangedCount}{' '}
-              {appliedStaleCount + separateChangedCount === 1
+              , mark {staleRows.length + separateChangedCount}{' '}
+              {staleRows.length + separateChangedCount === 1
                 ? 'location'
                 : 'locations'}{' '}
               inactive, and apply {appliedChangedCount}{' '}

--- a/frontend/src/pages/admin/routes/generation/ReviewStep.tsx
+++ b/frontend/src/pages/admin/routes/generation/ReviewStep.tsx
@@ -14,7 +14,6 @@ import type {
   ValidatedLocationImportEntry,
 } from '@/api/generated/types.gen';
 import CheckIcon from '@/assets/icons/check.svg?react';
-import XIcon from '@/assets/icons/x.svg?react';
 import type { Column } from '@/common/components';
 import {
   Banner,
@@ -51,14 +50,6 @@ function isChanged<T>(v: T | ChangedField<T>): v is ChangedField<T> {
     'new_value' in (v as object) &&
     'old_value' in (v as object)
   );
-}
-
-function newValue<T>(value: T | ChangedField<T>): T {
-  return isChanged(value) ? value.new_value : value;
-}
-
-function oldValue<T>(value: T | ChangedField<T>): T {
-  return isChanged(value) ? value.old_value : value;
 }
 
 function ChangedCell({
@@ -157,32 +148,6 @@ function toIngestNetNew(entry: NetNewEntry): ValidatedLocationImportEntry {
   };
 }
 
-function changedEntryToNetNew(
-  entry: ChangedEntry
-): ValidatedLocationImportEntry {
-  return {
-    contact_name: entry.contact_name,
-    address: newValue(entry.address),
-    delivery_group: newValue(entry.delivery_group) ?? '',
-    phone_primary: newValue(entry.phone_primary),
-    phone_secondary: newValue(entry.phone_secondary),
-    num_children: newValue(entry.num_children),
-    halal: entry.halal,
-    dietary_restrictions: entry.dietary_restrictions,
-  };
-}
-
-function changedEntryToStale(entry: ChangedEntry): StaleEntry {
-  return {
-    location_id: entry.location_id,
-    contact_name: entry.contact_name,
-    address: oldValue(entry.address),
-    delivery_group: oldValue(entry.delivery_group),
-    phone_primary: oldValue(entry.phone_primary),
-    phone_secondary: oldValue(entry.phone_secondary),
-  };
-}
-
 export function ReviewStep() {
   const navigate = useNavigate();
   const { file, reviewResult, selectedDeliveryType } =
@@ -190,9 +155,9 @@ export function ReviewStep() {
   const { mutateAsync: ingestLocations, isPending: isIngesting } =
     useIngestLocations();
 
-  const [changedDecisions, setChangedDecisions] = useState<
-    Map<number, 'apply' | 'separate'>
-  >(new Map());
+  const [confirmedChanges, setConfirmedChanges] = useState<Set<number>>(
+    new Set()
+  );
   const [confirmOpen, setConfirmOpen] = useState(false);
   const [ingestError, setIngestError] = useState<string | null>(null);
 
@@ -205,35 +170,27 @@ export function ReviewStep() {
   const staleRows = data.stale ?? [];
   const changedEntries = data.changed ?? [];
 
-  const setChangedDecision = (
-    index: number,
-    decision: 'apply' | 'separate'
-  ) => {
-    setChangedDecisions((prev) => {
-      const next = new Map(prev);
-      next.set(index, decision);
+  const toggleConfirmed = (index: number) => {
+    setConfirmedChanges((prev) => {
+      const next = new Set(prev);
+      if (next.has(index)) {
+        next.delete(index);
+      } else {
+        next.add(index);
+      }
       return next;
     });
   };
 
   const handleConfirm = async () => {
     setIngestError(null);
-    const approvedChanged = changedEntries.filter(
-      (_, index) => changedDecisions.get(index) === 'apply'
-    );
-    const separateChanged = changedEntries.filter(
-      (_, index) => changedDecisions.get(index) === 'separate'
-    );
 
     try {
       await ingestLocations({
         delivery_type: selectedDeliveryType,
-        net_new: [
-          ...netNewRows.map(toIngestNetNew),
-          ...separateChanged.map(changedEntryToNetNew),
-        ],
-        stale: [...staleRows, ...separateChanged.map(changedEntryToStale)],
-        changed: approvedChanged,
+        net_new: netNewRows.map(toIngestNetNew),
+        stale: staleRows,
+        changed: changedEntries,
       });
       setConfirmOpen(false);
       navigate('/admin/routes/generation/configure');
@@ -275,34 +232,23 @@ export function ReviewStep() {
     },
     {
       key: 'actions',
-      header: 'Decision',
+      header: 'Confirmed',
       render: (r) => {
-        const decision = changedDecisions.get(r._index);
+        const isConfirmed = confirmedChanges.has(r._index);
         return (
-          <div className="flex items-center gap-2">
-            <Button
-              variant="primary"
-              shape="circular"
-              aria-label="Apply this change"
-              title="Apply change"
-              aria-pressed={decision === 'apply'}
-              onClick={() => setChangedDecision(r._index, 'apply')}
-              className={decision === 'apply' ? 'opacity-100' : 'opacity-40'}
-            >
-              <CheckIcon className="size-4" />
-            </Button>
-            <Button
-              variant="secondary"
-              shape="circular"
-              aria-label="Treat as separate rows"
-              title="Treat as separate rows"
-              aria-pressed={decision === 'separate'}
-              onClick={() => setChangedDecision(r._index, 'separate')}
-              className={decision === 'separate' ? 'opacity-100' : 'opacity-40'}
-            >
-              <XIcon className="size-4" />
-            </Button>
-          </div>
+          <Button
+            variant="primary"
+            shape="circular"
+            aria-label={
+              isConfirmed ? 'Unconfirm this change' : 'Confirm this change'
+            }
+            title={isConfirmed ? 'Unconfirm change' : 'Confirm change'}
+            aria-pressed={isConfirmed}
+            onClick={() => toggleConfirmed(r._index)}
+            className={isConfirmed ? 'opacity-100' : 'opacity-40'}
+          >
+            <CheckIcon className="size-4" />
+          </Button>
         );
       },
     },
@@ -312,13 +258,7 @@ export function ReviewStep() {
     ...entry,
     _index: i,
   }));
-  const appliedChangedCount = [...changedDecisions.values()].filter(
-    (decision) => decision === 'apply'
-  ).length;
-  const separateChangedCount = [...changedDecisions.values()].filter(
-    (decision) => decision === 'separate'
-  ).length;
-  const allChangesDecided = changedDecisions.size === changedEntries.length;
+  const allChangesConfirmed = confirmedChanges.size === changedEntries.length;
 
   return (
     <>
@@ -376,8 +316,7 @@ export function ReviewStep() {
           <div>
             <h2 className="text-grey-500">Data that has Changed</h2>
             <p className="text-p1 text-grey-400">
-              Select whether each matched row is a change or a separate
-              location.
+              Review and confirm each change before continuing.
             </p>
           </div>
           <div className="flex items-center gap-2">
@@ -405,7 +344,7 @@ export function ReviewStep() {
         </Button>
         <Button
           variant="primary"
-          disabled={!allChangesDecided}
+          disabled={!allChangesConfirmed}
           onClick={() => setConfirmOpen(true)}
         >
           Continue to Configure Routes
@@ -418,16 +357,14 @@ export function ReviewStep() {
           <ModalHeader>
             <ModalTitle>Confirm Changes</ModalTitle>
             <ModalDescription>
-              This will add {netNewRows.length + separateChangedCount} new{' '}
-              {netNewRows.length + separateChangedCount === 1
-                ? 'location'
-                : 'locations'}
-              , mark {staleRows.length + separateChangedCount}{' '}
-              {staleRows.length + separateChangedCount === 1
-                ? 'location'
-                : 'locations'}{' '}
-              inactive, and apply {appliedChangedCount}{' '}
-              {appliedChangedCount === 1 ? 'matched change' : 'matched changes'}
+              This will add {netNewRows.length} new{' '}
+              {netNewRows.length === 1 ? 'location' : 'locations'}, mark{' '}
+              {staleRows.length}{' '}
+              {staleRows.length === 1 ? 'location' : 'locations'} inactive, and
+              apply {changedEntries.length}{' '}
+              {changedEntries.length === 1
+                ? 'matched change'
+                : 'matched changes'}
               .
             </ModalDescription>
           </ModalHeader>


### PR DESCRIPTION
## Summary
- Shows the real net-new, removed, and changed rows from the import review response.
- Lets admins choose what to do with each row before committing the import.
- Applies changes through the existing ingest endpoint and sends changed rows marked as separate as old stale + new net-new rows.
- Allows CSV uploads in the Import step to match the PRD.

## Tests
- eslint . --max-warnings=0
- tsc -b
- vite build
- git diff --check

Note: this PR is stacked on #206 and targets its branch so the diff only shows this frontend ticket.