### PR TITLE
Pin CI toolchain (mypy, pytest, type stubs) to green versions

### DIFF
--- a/backend/python/requirements.txt
+++ b/backend/python/requirements.txt
@@ -18,7 +18,7 @@ pydantic-settings>=2.0.0
 
 # Google Cloud & APIs
 google-api-python-client>=2.176.0
-google-api-python-client-stubs>=1.30.0
+google-api-python-client-stubs==1.39.0
 google-auth>=2.0.0
 google-auth-httplib2>=0.2.0
 google-api-core>=2.0.0
@@ -42,22 +42,30 @@ urllib3>=2.0.0
 uritemplate>=3.0.1
 
 # Development & Testing
-mypy>=1.8.0
-mypy-extensions>=1.0.0
+# Lint/type-check/test tools are pinned exactly: an unbounded `>=` lets CI
+# resolve whatever is newest, and a linter/checker bump silently adds rules
+# (ruff 0.16.0 stabilized RUF036 and started formatting markdown code blocks,
+# turning lint red tree-wide). Bump these deliberately and re-run CI rather
+# than float. Versions below are the current CI-verified-green set.
+mypy==2.3.0
+mypy-extensions==1.1.0
 ruff==0.16.0
-pytest>=6.2.4
-pytest-mock>=3.6.1
-pytest-asyncio>=0.21.0
-pytest-cov>=4.0.0
+pytest==9.1.1
+pytest-mock==3.15.1
+pytest-asyncio==1.4.0
+pytest-cov==7.1.0
 httpx>=0.24.0
 aiosqlite>=0.21.0
 asyncpg>=0.29.0
 
 # Type stubs
-types-requests>=2.32.0
-types-PyYAML>=6.0.0
-types-setuptools>=80.0.0
-types-firebase-admin>=0.1.1
+# Pinned exactly: stub releases feed the mypy step, so a new stub version can
+# introduce type errors and break lint the same way a mypy bump does. Bump
+# deliberately alongside mypy. (pandas-stubs / types-seaborn pinned below.)
+types-requests==2.33.0.20260712
+types-PyYAML==6.0.12.20260518
+types-setuptools==83.0.0.20260716
+types-firebase-admin==0.1.1
 
 # Utilities
 python-dotenv>=0.21.0
@@ -80,8 +88,8 @@ scikit-learn-extra==0.2.0
 seaborn==0.13.2
 matplotlib>=3.10.8
 pandas==2.3.3
-pandas-stubs
-types-seaborn
+pandas-stubs==3.0.3.260530
+types-seaborn==0.13.2.20260518
 googlemaps>=4.10.0
 openpyxl>=3.1.5
 


### PR DESCRIPTION
## Why

`backend/python/requirements.txt` floated the lint / type-check / test tools on unbounded `>=`, so CI silently installed the newest release of each. That's exactly what just broke lint tree-wide: ruff auto-upgraded to **0.16.0**, which stabilized `RUF036` and began formatting fenced Python inside markdown, turning `run-lint` red on every open PR and on main (fixed by pinning `ruff==0.16.0` in #200 / #212).

The same hazard is still live for the rest of the toolchain:

- **mypy** `>=1.8.0` → CI running **2.3.0** (a major-version jump). The next mypy release can add checks and redden `run-lint` with zero code changes.
- **pytest-asyncio** `>=0.21.0` → **1.4.0** — a breaking major already floated in silently.
- **Type stubs** feed the mypy step, so a new stub version introduces type errors the same way a mypy bump does. `pandas-stubs` and `types-seaborn` had **no version bound at all**.

## What

Pin the CI toolchain to the exact versions CI already runs **green** — verified by the passing `run-lint` (ruff + mypy) and `test` jobs on #200 and #212, which installed precisely this set:

| Package | Was | Now |
|---|---|---|
| mypy | `>=1.8.0` | `==2.3.0` |
| mypy-extensions | `>=1.0.0` | `==1.1.0` |
| pytest | `>=6.2.4` | `==9.1.1` |
| pytest-mock | `>=3.6.1` | `==3.15.1` |
| pytest-asyncio | `>=0.21.0` | `==1.4.0` |
| pytest-cov | `>=4.0.0` | `==7.1.0` |
| google-api-python-client-stubs | `>=1.30.0` | `==1.39.0` |
| types-requests | `>=2.32.0` | `==2.33.0.20260712` |
| types-PyYAML | `>=6.0.0` | `==6.0.12.20260518` |
| types-setuptools | `>=80.0.0` | `==83.0.0.20260716` |
| types-firebase-admin | `>=0.1.1` | `==0.1.1` |
| pandas-stubs | *(unbounded)* | `==3.0.3.260530` |
| types-seaborn | *(unbounded)* | `==0.13.2.20260518` |

`ruff` was already pinned to `0.16.0` in #200. Runtime/app deps keep their existing floor/ceiling scheme (already managed deliberately — see the `fastapi` pin). Bump these deliberately and re-run CI rather than float.

🤖 Generated with [Claude Code](https://claude.com/claude-code)