### PR TITLE
Stop auth handlers turning their own HTTP errors into 500s

### DIFF
--- a/backend/python/app/routers/auth_routes.py
+++ b/backend/python/app/routers/auth_routes.py
@@ -30,13 +30,9 @@ async def login(
     """
     Returns access token in response body and sets refreshToken as an httpOnly cookie
     """
-    logger.info(f"Login request: {login_request}")
+    # Never log login_request itself — its repr contains the plaintext password.
+    logger.info(f"Login request for {login_request.email}")
     try:
-        if not login_request.email or not login_request.password:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail="Email and password are required",
-            )
         auth_dto, refresh_token = await auth_service.generate_token(
             session, login_request.email, login_request.password
         )
@@ -51,6 +47,8 @@ async def login(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail=str(e),
         ) from e
+    except HTTPException:
+        raise
     except Exception as e:
         error_message = getattr(e, "message", None)
         raise HTTPException(
@@ -94,6 +92,8 @@ async def refresh(
         set_refresh_token_cookie(response, new_refresh_token)
 
         return auth_data
+    except HTTPException:
+        raise
     except Exception as e:
         if str(e) in _FIREBASE_401_CODES:
             raise HTTPException(status_code=401, detail="Session expired") from e
@@ -125,6 +125,8 @@ async def logout(
 
     try:
         await auth_service.revoke_tokens(session, user_id)
+    except HTTPException:
+        raise
     except Exception as e:
         error_message = getattr(e, "message", None)
         raise HTTPException(
@@ -152,6 +154,8 @@ async def reset_password(
 
     try:
         auth_service.reset_password(email)
+    except HTTPException:
+        raise
     except Exception as e:
         error_message = getattr(e, "message", None)
         raise HTTPException(

--- a/backend/python/app/services/implementations/auth_service.py
+++ b/backend/python/app/services/implementations/auth_service.py
@@ -107,9 +107,9 @@ class AuthService:
             user = await self.user_service.get_user_by_auth_id(session, auth_id)
 
             if user is None:
-                raise ValueError(
-                    "DB_USER_MISSINGG: User associated with this token does not exist."
-                )
+                # The message is the error *code* the router maps to a 401 — it
+                # is matched exactly, so it must not carry extra prose.
+                raise ValueError("DB_USER_MISSING")
 
             auth_response = AuthResponse(
                 access_token=new_access_token,

--- a/backend/python/tests/test_auth_routes.py
+++ b/backend/python/tests/test_auth_routes.py
@@ -1,0 +1,279 @@
+"""Status-code contract for the ``/auth`` routes.
+
+Every handler in ``app/routers/auth_routes.py`` wraps its body in a broad
+``except Exception`` that converts whatever it catches into a 500. Because
+``HTTPException`` subclasses ``Exception``, any deliberate 4xx raised inside
+such a body is swallowed and re-emitted as a 500 unless the handler re-raises
+``HTTPException`` first. These tests pin that contract for all four handlers,
+plus the status codes ``/auth/login`` and ``/auth/refresh`` are meant to return
+for bad input and for expired/unknown sessions.
+"""
+
+from collections.abc import Awaitable, Callable
+from logging import getLogger
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+from uuid import UUID, uuid4
+
+import jwt
+import pytest
+from fastapi import HTTPException
+from httpx import AsyncClient, Response
+
+from app.dependencies.auth import get_current_database_user_id, get_current_user_email
+from app.dependencies.services import get_auth_service
+from app.routers.auth_routes import _FIREBASE_401_CODES
+from app.schemas.auth import TokenResponse
+from app.services.implementations.auth_service import AuthService
+
+USER_ID: UUID = uuid4()
+EMAIL = "driver@example.com"
+
+
+class StubAuthService:
+    """Stands in for ``AuthService``; every method raises the configured error.
+
+    The auth handlers only ever reach the service after their own guards have
+    passed, so raising from here exercises the ``try`` body of each handler.
+    """
+
+    def __init__(self, error: Exception) -> None:
+        self.error = error
+
+    async def generate_token(self, *_args: Any, **_kwargs: Any) -> Any:
+        raise self.error
+
+    async def renew_token(self, *_args: Any, **_kwargs: Any) -> Any:
+        raise self.error
+
+    async def revoke_tokens(self, *_args: Any, **_kwargs: Any) -> None:
+        raise self.error
+
+    def reset_password(self, *_args: Any, **_kwargs: Any) -> None:
+        raise self.error
+
+
+Requester = Callable[[AsyncClient], Awaitable[Response]]
+
+# One entry per auth handler: the extra dependency overrides it needs to reach
+# its own body, and a callable that drives it. ``get_auth_service`` is
+# overridden separately by each test so the stub can raise a per-test error.
+AUTH_ENDPOINTS: list[Any] = [
+    pytest.param(
+        {},
+        lambda client: client.post(
+            "/auth/login", json={"email": EMAIL, "password": "correct horse"}
+        ),
+        id="login",
+    ),
+    pytest.param(
+        {},
+        lambda client: client.post(
+            "/auth/refresh", headers={"Cookie": "refreshToken=stub-refresh-token"}
+        ),
+        id="refresh",
+    ),
+    pytest.param(
+        {get_current_database_user_id: lambda: USER_ID},
+        lambda client: client.post(f"/auth/logout/{USER_ID}"),
+        id="logout",
+    ),
+    pytest.param(
+        {get_current_user_email: lambda: EMAIL},
+        lambda client: client.post(f"/auth/resetPassword/{EMAIL}"),
+        id="reset_password",
+    ),
+]
+
+
+async def _client_raising(
+    client_with_overrides: Any, error: Exception, overrides: dict[Any, Any]
+) -> AsyncClient:
+    """Build a client whose auth service raises ``error`` from every method."""
+    stub = StubAuthService(error)
+    client: AsyncClient = await client_with_overrides(
+        {get_auth_service: lambda: stub, **overrides}
+    )
+    return client
+
+
+class TestHandlerExceptionMapping:
+    """The broad ``except Exception`` must not rewrite deliberate HTTP errors."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(("overrides", "request_fn"), AUTH_ENDPOINTS)
+    async def test_http_exception_in_body_keeps_its_status(
+        self,
+        client_with_overrides: Any,
+        overrides: dict[Any, Any],
+        request_fn: Requester,
+    ) -> None:
+        """A 4xx raised inside the handler body reaches the client unchanged."""
+        error = HTTPException(status_code=409, detail="deliberate conflict")
+        client = await _client_raising(client_with_overrides, error, overrides)
+
+        response = await request_fn(client)
+
+        assert response.status_code == 409
+        assert response.json()["detail"] == "deliberate conflict"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(("overrides", "request_fn"), AUTH_ENDPOINTS)
+    async def test_unexpected_error_in_body_is_still_a_500(
+        self,
+        client_with_overrides: Any,
+        overrides: dict[Any, Any],
+        request_fn: Requester,
+    ) -> None:
+        """Genuinely unexpected failures keep mapping to 500."""
+        client = await _client_raising(
+            client_with_overrides, RuntimeError("database on fire"), overrides
+        )
+
+        response = await request_fn(client)
+
+        assert response.status_code == 500
+
+
+class TestLoginValidation:
+    """``LoginRequest`` validation is Pydantic's job, not the handler's."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("payload", "expected_status"),
+        [
+            # Rejected by Pydantic before the handler runs.
+            pytest.param({"password": "pw"}, 422, id="email-missing"),
+            pytest.param({"email": EMAIL}, 422, id="password-missing"),
+            pytest.param({}, 422, id="both-missing"),
+            pytest.param({"email": "", "password": "pw"}, 422, id="email-empty"),
+            pytest.param(
+                {"email": "not-an-email", "password": "pw"}, 422, id="email-malformed"
+            ),
+            pytest.param({"email": None, "password": "pw"}, 422, id="email-null"),
+            pytest.param({"email": EMAIL, "password": None}, 422, id="password-null"),
+            # Well-formed: reaches the service, which rejects the credentials.
+            # An empty password is a failed login (401), not a malformed request.
+            pytest.param({"email": EMAIL, "password": ""}, 401, id="password-empty"),
+            pytest.param({"email": EMAIL, "password": "wrong"}, 401, id="password-bad"),
+        ],
+    )
+    async def test_login_status_codes(
+        self,
+        client_with_overrides: Any,
+        payload: dict[str, Any],
+        expected_status: int,
+    ) -> None:
+        client = await _client_raising(
+            client_with_overrides, ValueError("Invalid email or password"), {}
+        )
+
+        response = await client.post("/auth/login", json=payload)
+
+        assert response.status_code == expected_status
+
+    @pytest.mark.asyncio
+    async def test_failed_login_does_not_reveal_which_field_was_wrong(
+        self, client_with_overrides: Any
+    ) -> None:
+        """Authentication failures return one generic 401 (no user enumeration)."""
+        client = await _client_raising(
+            client_with_overrides, ValueError("Invalid email or password"), {}
+        )
+
+        response = await client.post(
+            "/auth/login", json={"email": EMAIL, "password": "wrong"}
+        )
+
+        assert response.status_code == 401
+        assert response.json()["detail"] == "Invalid email or password"
+
+
+class TestRefresh:
+    @pytest.mark.asyncio
+    async def test_missing_cookie_is_401(self, client_with_overrides: Any) -> None:
+        client = await _client_raising(
+            client_with_overrides, AssertionError("service must not be reached"), {}
+        )
+
+        response = await client.post("/auth/refresh")
+
+        assert response.status_code == 401
+        assert response.json()["detail"] == "Refresh token not found"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("code", sorted(_FIREBASE_401_CODES))
+    async def test_expired_session_codes_are_401(
+        self, client_with_overrides: Any, code: str
+    ) -> None:
+        """Each known session-ended code maps to 401, so clients can re-login."""
+        client = await _client_raising(client_with_overrides, ValueError(code), {})
+
+        response = await client.post(
+            "/auth/refresh", headers={"Cookie": "refreshToken=stub-refresh-token"}
+        )
+
+        assert response.status_code == 401
+        assert response.json()["detail"] == "Session expired"
+
+    @pytest.mark.asyncio
+    async def test_unknown_failure_is_500(self, client_with_overrides: Any) -> None:
+        client = await _client_raising(
+            client_with_overrides, ValueError("SOMETHING_ELSE"), {}
+        )
+
+        response = await client.post(
+            "/auth/refresh", headers={"Cookie": "refreshToken=stub-refresh-token"}
+        )
+
+        assert response.status_code == 500
+
+
+class TestRenewTokenDbUserMissing:
+    """``renew_token``'s message is matched against ``_FIREBASE_401_CODES``.
+
+    The router compares ``str(e)`` to the code set exactly, so the service has
+    to raise the bare code — any surrounding prose silently downgrades a
+    "your session is gone, log in again" into a 500.
+    """
+
+    def _service(self, user: Any) -> AuthService:
+        user_service = MagicMock()
+        user_service.get_user_by_auth_id = AsyncMock(return_value=user)
+        service = AuthService(getLogger(__name__), user_service, MagicMock())
+        firebase_client: Any = MagicMock()
+        firebase_client.refresh_token.return_value = TokenResponse(
+            # renew_token decodes without verifying, so any well-formed token
+            # carrying a "sub" claim will do.
+            access_token=jwt.encode({"sub": "firebase-uid"}, "k" * 32, "HS256"),
+            refresh_token="new-refresh-token",
+        )
+        service.firebase_rest_client = firebase_client
+        return service
+
+    @pytest.mark.asyncio
+    async def test_missing_db_user_raises_the_bare_401_code(self) -> None:
+        service = self._service(user=None)
+
+        with pytest.raises(ValueError) as excinfo:
+            await service.renew_token(MagicMock(), "stub-refresh-token")
+
+        assert str(excinfo.value) == "DB_USER_MISSING"
+        assert str(excinfo.value) in _FIREBASE_401_CODES
+
+    @pytest.mark.asyncio
+    async def test_missing_db_user_surfaces_as_401_through_the_route(
+        self, client_with_overrides: Any
+    ) -> None:
+        """End-to-end: the service's error and the router's set line up."""
+        service = self._service(user=None)
+        client: AsyncClient = await client_with_overrides(
+            {get_auth_service: lambda: service}
+        )
+
+        response = await client.post(
+            "/auth/refresh", headers={"Cookie": "refreshToken=stub-refresh-token"}
+        )
+
+        assert response.status_code == 401
+        assert response.json()["detail"] == "Session expired"


### PR DESCRIPTION
## The bug

`POST /auth/login` raised `HTTPException(400, "Email and password are required")` **inside** a `try` whose final clause is `except Exception as e: raise HTTPException(500, ...)`. `HTTPException` subclasses `Exception`, so the handler caught its own 400 and re-emitted it as a 500.

## The fix

**Delete the check rather than reorder it.** It was redundant: `LoginRequest.email` is an `EmailStr`, so Pydantic rejects an empty or malformed email with a 422 before the handler runs, and an empty password reaches `generate_token`, which returns the generic 401 that avoids user enumeration. The only behaviour change is `{"email": "a@b.com", "password": ""}`: 400 → 401. Nothing in the frontend keys off that 400 (the inputs are `required`), and it was never in the OpenAPI spec, so `openapi.json` is unchanged.

**Guard the shape.** All four handlers (`login`, `refresh`, `logout`, `reset_password`) now re-raise `HTTPException` ahead of the broad clause, matching the convention already in `driver_routes`, `driver_history_routes`, `job_routes` and `report_routes`.

I scanned the other routers for the same shape: 24 broad `except Exception` blocks across 8 files lack the guard, but an AST check confirms none raises `HTTPException` in its try body or calls one of the three services that do — latent, not live. Left out of this PR; there's a task for the wider cleanup, which should also weigh deleting these blanket handlers outright (they echo raw exception text to clients as `detail` and swallow the traceback).

## Two more fixes in the same handlers

- **Plaintext password in the logs.** `login` did `logger.info(f"Login request: {login_request}")`, and the Pydantic repr of `LoginRequest` includes the password. Now logs the email only.
- **`DB_USER_MISSING` never matched.** `renew_token` raised `ValueError("DB_USER_MISSINGG: User associated with this token does not exist.")`, but `refresh` compares `str(e)` *exactly* against `_FIREBASE_401_CODES`. Between the typo and the trailing prose it never matched, so a user whose DB record is gone got a 500 instead of the 401 that tells the client to re-login. Now raises the bare code.

## Tests

New `tests/test_auth_routes.py`, 28 tests: a deliberate 4xx from the service body survives on each of the four handlers, unexpected errors still map to 500, the login status matrix (422 vs 401 across missing/empty/null/malformed fields), refresh's missing-cookie and session-expired paths, and the `DB_USER_MISSING` contract end-to-end.

7 of the 28 fail with the source changes stashed.

## Verification

- `ruff check` ✅, `ruff format --check` ✅, `mypy` ✅ (119 files)
- Full backend suite locally: 76 failed / 381 passed. The failure list is **identical** to baseline (pre-existing local location / route-group / system-settings failures, unrelated to auth); passed went 353 → 381, exactly the 28 new tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)