### PR TITLE
Replace 48 blanket 500 handlers with one app-wide middleware

### DIFF
--- a/backend/python/app/__init__.py
+++ b/backend/python/app/__init__.py
@@ -15,6 +15,7 @@ from app.dependencies.services import (
 from app.services.jobs import init_jobs
 
 from .config import settings
+from .middleware import UnhandledExceptionMiddleware
 from .models import init_app as init_models
 from .routers import init_app as init_routers
 
@@ -203,6 +204,10 @@ def create_app() -> FastAPI:
 
     # Add regex pattern for preview deployments
     cors_origins.append("https://uw-blueprint-starter-code--pr.*\\.web\\.app")
+
+    # Added before CORS so it ends up *inside* it: the last middleware added is
+    # the outermost, and a 500 without CORS headers is unreadable to a browser.
+    app.add_middleware(UnhandledExceptionMiddleware)
 
     app.add_middleware(
         CORSMiddleware,

--- a/backend/python/app/middleware.py
+++ b/backend/python/app/middleware.py
@@ -1,0 +1,66 @@
+"""ASGI middleware wired into the app in :func:`app.create_app`."""
+
+import logging
+
+from fastapi import status
+from fastapi.responses import JSONResponse
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+logger = logging.getLogger(__name__)
+
+
+class UnhandledExceptionMiddleware:
+    """Turn an unhandled exception into a 500 that says nothing about it.
+
+    Route handlers deliberately do *not* wrap their bodies in
+    ``except Exception``. Doing so per-handler cost us three things:
+
+    1. ``HTTPException`` subclasses ``Exception``, so a handler caught the
+       4xx it had just raised and re-emitted it as a 500 (see #216).
+    2. ``detail=str(e)`` leaked internal error text — SQL, constraint names,
+       third-party client messages — to whoever called the endpoint.
+    3. Re-raising as ``HTTPException`` made the failure look *expected* to
+       Starlette, so the original traceback was never logged.
+
+    This middleware sits inside the CORS layer (so the 500 still carries the
+    CORS headers a browser needs to read it) and outside the router, and
+    handles all three centrally: it logs the traceback and returns a fixed
+    body. Handlers keep only their specific ``except`` clauses, which map a
+    known failure to a meaningful 4xx.
+
+    If the response has already started, the body is committed and the status
+    line is long gone, so there is nothing to salvage — the exception is
+    re-raised for Starlette's ``ServerErrorMiddleware`` to deal with.
+    """
+
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        response_started = False
+
+        async def send_wrapper(message: Message) -> None:
+            nonlocal response_started
+            if message["type"] == "http.response.start":
+                response_started = True
+            await send(message)
+
+        try:
+            await self.app(scope, receive, send_wrapper)
+        except Exception:
+            logger.exception(
+                "Unhandled exception on %s %s",
+                scope.get("method", "?"),
+                scope.get("path", "?"),
+            )
+            if response_started:
+                raise
+            response = JSONResponse(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                content={"detail": "Internal server error"},
+            )
+            await response(scope, receive, send)

--- a/backend/python/app/routers/announcement_routes.py
+++ b/backend/python/app/routers/announcement_routes.py
@@ -35,25 +35,18 @@ async def get_announcements(
     current_user_id: UUID = Depends(get_current_database_user_id),
 ) -> list[AnnouncementRead]:
     """Retrieve all announcements with is_read status for the authenticated user."""
-    try:
-        announcements = await announcement_service.get_announcements(session)
-        last_read_at = await announcement_service.get_last_read_at(
-            session, current_user_id
-        )
+    announcements = await announcement_service.get_announcements(session)
+    last_read_at = await announcement_service.get_last_read_at(session, current_user_id)
 
-        results = []
-        for a in announcements:
-            item = AnnouncementRead.from_announcement(a)
-            if last_read_at is None:
-                item.is_read = False
-            else:
-                item.is_read = a.created_at is not None and a.created_at <= last_read_at
-            results.append(item)
-        return results
-    except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(e)
-        ) from e
+    results = []
+    for a in announcements:
+        item = AnnouncementRead.from_announcement(a)
+        if last_read_at is None:
+            item.is_read = False
+        else:
+            item.is_read = a.created_at is not None and a.created_at <= last_read_at
+        results.append(item)
+    return results
 
 
 @router.post("/mark-read", response_model=AnnouncementLastReadResponse)
@@ -71,10 +64,6 @@ async def mark_announcements_as_read(
         return AnnouncementLastReadResponse.model_validate(entry)
     except ValueError as e:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
-    except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(e)
-        ) from e
 
 
 @router.get("/{announcement_id}", response_model=AnnouncementRead)
@@ -103,15 +92,10 @@ async def create_announcement(
     current_user_id: UUID = Depends(get_current_database_user_id),
 ) -> AnnouncementRead:
     """Create a new announcement"""
-    try:
-        created_announcement = await announcement_service.create_announcement(
-            session, current_user_id, announcement
-        )
-        return AnnouncementRead.from_announcement(created_announcement)
-    except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(e)
-        ) from e
+    created_announcement = await announcement_service.create_announcement(
+        session, current_user_id, announcement
+    )
+    return AnnouncementRead.from_announcement(created_announcement)
 
 
 @router.put("/{announcement_id}", response_model=AnnouncementRead)
@@ -187,10 +171,5 @@ async def send_announcement_email(
     except ValueError as error:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail=str(error),
-        ) from error
-    except Exception as error:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=str(error),
         ) from error

--- a/backend/python/app/routers/auth_routes.py
+++ b/backend/python/app/routers/auth_routes.py
@@ -47,14 +47,6 @@ async def login(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail=str(e),
         ) from e
-    except HTTPException:
-        raise
-    except Exception as e:
-        error_message = getattr(e, "message", None)
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=error_message if error_message else str(e),
-        ) from e
 
 
 _FIREBASE_401_CODES = {
@@ -92,18 +84,13 @@ async def refresh(
         set_refresh_token_cookie(response, new_refresh_token)
 
         return auth_data
-    except HTTPException:
-        raise
     except Exception as e:
-        if str(e) in _FIREBASE_401_CODES:
-            raise HTTPException(status_code=401, detail="Session expired") from e
-
-        logger.error(f"Failed to refresh: {e}")
-        error_message = getattr(e, "message", None)
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=error_message if error_message else str(e),
-        ) from e
+        # ``renew_token`` signals "this session is gone, log in again" by
+        # raising with the bare code as the message. Anything else is a real
+        # failure: let it out so it is logged and answered as a 500.
+        if str(e) not in _FIREBASE_401_CODES:
+            raise
+        raise HTTPException(status_code=401, detail="Session expired") from e
 
 
 @router.post("/logout/{user_id}", status_code=status.HTTP_204_NO_CONTENT)
@@ -123,16 +110,7 @@ async def logout(
             detail="You are not authorized to logout this driver",
         )
 
-    try:
-        await auth_service.revoke_tokens(session, user_id)
-    except HTTPException:
-        raise
-    except Exception as e:
-        error_message = getattr(e, "message", None)
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=error_message if error_message else str(e),
-        ) from e
+    await auth_service.revoke_tokens(session, user_id)
 
 
 @router.post("/resetPassword/{email}", status_code=status.HTTP_204_NO_CONTENT)
@@ -152,13 +130,4 @@ async def reset_password(
             detail="You are not authorized to reset this email's password",
         )
 
-    try:
-        auth_service.reset_password(email)
-    except HTTPException:
-        raise
-    except Exception as e:
-        error_message = getattr(e, "message", None)
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=error_message if error_message else str(e),
-        ) from e
+    auth_service.reset_password(email)

--- a/backend/python/app/routers/auth_routes.py
+++ b/backend/python/app/routers/auth_routes.py
@@ -11,7 +11,7 @@ from app.dependencies.services import (
 )
 from app.models import get_session
 from app.schemas.auth import AuthResponse, LoginRequest
-from app.services.implementations.auth_service import AuthService
+from app.services.implementations.auth_service import AuthService, SessionExpiredError
 from app.utilities.cookies import set_refresh_token_cookie
 
 # Initialize logger
@@ -49,16 +49,6 @@ async def login(
         ) from e
 
 
-_FIREBASE_401_CODES = {
-    "TOKEN_EXPIRED",
-    "INVALID_REFRESH_TOKEN",
-    "INVALID_GRANT",
-    "USER_DISABLED",
-    "USER_NOT_FOUND",
-    "DB_USER_MISSING",  # Not a Firebase code
-}
-
-
 @router.post("/refresh", response_model=AuthResponse)
 async def refresh(
     request: Request,
@@ -84,13 +74,10 @@ async def refresh(
         set_refresh_token_cookie(response, new_refresh_token)
 
         return auth_data
-    except Exception as e:
-        # ``renew_token`` signals "this session is gone, log in again" by
-        # raising with the bare code as the message. Anything else is a real
-        # failure: let it out so it is logged and answered as a 500.
-        if str(e) not in _FIREBASE_401_CODES:
-            raise
-        raise HTTPException(status_code=401, detail="Session expired") from e
+    except SessionExpiredError as e:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Session expired"
+        ) from e
 
 
 @router.post("/logout/{user_id}", status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/python/app/routers/driver_history_routes.py
+++ b/backend/python/app/routers/driver_history_routes.py
@@ -38,21 +38,12 @@ async def get_driver_history_summary(
     _auth: DriverAccess = Depends(require_self_driver_or_admin),
 ) -> DriverHistorySummary:
     """Get lifetime and current year KM summary for a driver"""
-    try:
-        if not await driver_history_service.driver_exists(session, driver_id):
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND,
-                detail=f"Driver with id {driver_id} does not exist",
-            )
-        return await driver_history_service.get_driver_history_summary(
-            session, driver_id
-        )
-    except HTTPException:
-        raise
-    except Exception as e:
+    if not await driver_history_service.driver_exists(session, driver_id):
         raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(e)
-        ) from e
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Driver with id {driver_id} does not exist",
+        )
+    return await driver_history_service.get_driver_history_summary(session, driver_id)
 
 
 @router.get("/{year}/export", response_class=StreamingResponse)
@@ -68,49 +59,39 @@ async def export_all_drivers_history(
     - driver_id: Must be "all"
     - year: The year to export data for
     """
-    try:
-        if driver_id != "all":
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=f"Invalid driver_id: {driver_id}. Must be 'all' for year-based export",
-            )
-
-        current_year_totals = await driver_history_service.get_yearly_totals_by_driver(
-            session, year
-        )
-        past_year_totals = await driver_history_service.get_yearly_totals_by_driver(
-            session, year - 1
-        )
-
-        if not current_year_totals and not past_year_totals:
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND,
-                detail=f"No driver history found for year {year} or {year - 1}",
-            )
-
-        driver_data = await get_drivers(session, driver_id=None, email=None)
-
-        generator = DriverHistoryCSVGenerator(
-            current_year_totals, past_year_totals, driver_data
-        )
-
-        csv_data, filename = generator.generate_all_drivers_csv(year)
-        csv_output = generate_csv_from_list(csv_data, header=True)
-
-        return StreamingResponse(
-            iter([csv_output]),
-            media_type="text/csv",
-            headers={"Content-Disposition": f'attachment; filename="{filename}"'},
-        )
-
-    except HTTPException:
-        raise
-    except Exception as e:
-        logger.exception(f"Unexpected error exporting driver history: {e}")
+    if driver_id != "all":
         raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="An error occurred while exporting driver history",
-        ) from e
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Invalid driver_id: {driver_id}. Must be 'all' for year-based export",
+        )
+
+    current_year_totals = await driver_history_service.get_yearly_totals_by_driver(
+        session, year
+    )
+    past_year_totals = await driver_history_service.get_yearly_totals_by_driver(
+        session, year - 1
+    )
+
+    if not current_year_totals and not past_year_totals:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"No driver history found for year {year} or {year - 1}",
+        )
+
+    driver_data = await get_drivers(session, driver_id=None, email=None)
+
+    generator = DriverHistoryCSVGenerator(
+        current_year_totals, past_year_totals, driver_data
+    )
+
+    csv_data, filename = generator.generate_all_drivers_csv(year)
+    csv_output = generate_csv_from_list(csv_data, header=True)
+
+    return StreamingResponse(
+        iter([csv_output]),
+        media_type="text/csv",
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )
 
 
 @router.get("/", response_model=list[DriverHistoryRead])
@@ -136,22 +117,14 @@ async def get_driver_history(
             detail="Cannot provide month without year",
         )
 
-    try:
-        totals = await driver_history_service.get_monthly_totals(
-            session, driver_id, year, month
+    totals = await driver_history_service.get_monthly_totals(
+        session, driver_id, year, month
+    )
+
+    if not totals:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="No driver history found for the provided filters",
         )
 
-        if not totals:
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND,
-                detail="No driver history found for the provided filters",
-            )
-
-        return totals
-
-    except HTTPException:
-        raise
-    except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(e)
-        ) from e
+    return totals

--- a/backend/python/app/routers/driver_routes.py
+++ b/backend/python/app/routers/driver_routes.py
@@ -1,5 +1,4 @@
 import logging
-import traceback
 from datetime import datetime, timezone
 from uuid import UUID
 
@@ -58,35 +57,27 @@ async def get_drivers(
             detail="Cannot query by both driver_id and email",
         )
 
-    try:
-        if driver_id:
-            driver = await driver_service.get_driver_by_id(session, driver_id)
-            if not driver:
-                raise HTTPException(
-                    status_code=status.HTTP_404_NOT_FOUND,
-                    detail=f"Driver with id {driver_id} not found",
-                )
-            return [DriverRead.model_validate(driver)]
+    if driver_id:
+        driver = await driver_service.get_driver_by_id(session, driver_id)
+        if not driver:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Driver with id {driver_id} not found",
+            )
+        return [DriverRead.model_validate(driver)]
 
-        elif email:
-            driver = await driver_service.get_driver_by_email(session, email)
-            if not driver:
-                raise HTTPException(
-                    status_code=status.HTTP_404_NOT_FOUND,
-                    detail=f"Driver with email {email} not found",
-                )
-            return [DriverRead.model_validate(driver)]
+    elif email:
+        driver = await driver_service.get_driver_by_email(session, email)
+        if not driver:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Driver with email {email} not found",
+            )
+        return [DriverRead.model_validate(driver)]
 
-        else:
-            drivers = await driver_service.get_drivers(session)
-            return [DriverRead.model_validate(driver) for driver in drivers]
-
-    except HTTPException:
-        raise
-    except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(e)
-        ) from e
+    else:
+        drivers = await driver_service.get_drivers(session)
+        return [DriverRead.model_validate(driver) for driver in drivers]
 
 
 @router.get("/{driver_id}", response_model=DriverRead)
@@ -123,53 +114,37 @@ async def initialize_driver(
     NOTE: This does not create a firebase user, ie the User is in a hanging state
     We need to do this so that we can implement our invite only system
     """
-    user = None
+    async with session.begin_nested():
+        # Create user first
+        user_data = register_request.model_dump(
+            include=set(UserBase.model_fields.keys())
+        )
+        user_base = UserBase(**user_data)
+        user = await user_service.create_user(session, user_base)
 
-    try:
-        async with session.begin_nested():
-            # Create user first
-            user_data = register_request.model_dump(
-                include=set(UserBase.model_fields.keys())
-            )
-            user_base = UserBase(**user_data)
-            user = await user_service.create_user(session, user_base)
+        # Create driver after
+        driver_data = register_request.model_dump(
+            include=set(DriverCreate.model_fields.keys())
+        )
+        driver_data["user_id"] = user.user_id
+        driver = DriverCreate(**driver_data)
+        created_driver = await driver_service.create_driver(session, driver)
 
-            # Create driver after
-            driver_data = register_request.model_dump(
-                include=set(DriverCreate.model_fields.keys())
-            )
-            driver_data["user_id"] = user.user_id
-            driver = DriverCreate(**driver_data)
-            created_driver = await driver_service.create_driver(session, driver)
-
-            # Create User Invite Record
-            user_invite_create = UserInviteCreate(user_id=user.user_id)
-            user_invite = await user_invite_service.create_user_invite(
-                session, user_invite_create
-            )
-
-        await session.commit()
-        await session.refresh(created_driver)
-
-        # Send invitation email
-        auth_service.send_create_password_email(
-            register_request.email, user_invite.user_invite_id
+        # Create User Invite Record
+        user_invite_create = UserInviteCreate(user_id=user.user_id)
+        user_invite = await user_invite_service.create_user_invite(
+            session, user_invite_create
         )
 
-        return DriverRead.model_validate(created_driver)
+    await session.commit()
+    await session.refresh(created_driver)
 
-    except HTTPException:
-        raise
-    except Exception as e:
-        # Compensating transaction: rollback all changes
-        logger.error(f"Error registering driver: {e}")
-        logger.error(traceback.format_exc())
+    # Send invitation email
+    auth_service.send_create_password_email(
+        register_request.email, user_invite.user_invite_id
+    )
 
-        error_message = getattr(e, "message", None)
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=error_message if error_message else str(e),
-        ) from e
+    return DriverRead.model_validate(created_driver)
 
 
 @router.post(
@@ -188,56 +163,44 @@ async def complete_driver_registration(
     """
     Creates Firebase user and attaches to hanging state user in our local db, returns DriverRegisterResponse
     """
-    try:
-        async with session.begin_nested():
-            # Validate invite token and lock the row to prevent race conditions
-            user_invite_id = registration_data.user_invite_id
-            user_invite = await user_invite_service.get_user_invite_by_id(
-                session, user_invite_id, for_update=True
-            )
-
-            if (
-                not user_invite
-                or user_invite.is_used
-                or user_invite.expires_at < datetime.now(timezone.utc)
-            ):
-                raise HTTPException(
-                    status_code=status.HTTP_403_FORBIDDEN,
-                    detail="Invalid or expired registration link.",
-                )
-
-            # Create Firebase account for user
-            user = user_invite.user
-            await user_service.link_firebase_to_user(
-                session, user, registration_data.password
-            )
-
-            user_invite.is_used = True
-
-        await session.commit()
-
-        # Generate authentication tokens
-        auth_dto, refresh_token = await auth_service.generate_token(
-            session, user.email, registration_data.password
+    async with session.begin_nested():
+        # Validate invite token and lock the row to prevent race conditions
+        user_invite_id = registration_data.user_invite_id
+        user_invite = await user_invite_service.get_user_invite_by_id(
+            session, user_invite_id, for_update=True
         )
 
-        # Set refresh token as httpOnly cookie
-        set_refresh_token_cookie(response, refresh_token)
+        if (
+            not user_invite
+            or user_invite.is_used
+            or user_invite.expires_at < datetime.now(timezone.utc)
+        ):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Invalid or expired registration link.",
+            )
 
-        return DriverRegisterResponse(
-            driver=DriverRead.model_validate(user.driver), auth=auth_dto
+        # Create Firebase account for user
+        user = user_invite.user
+        await user_service.link_firebase_to_user(
+            session, user, registration_data.password
         )
-    except HTTPException:
-        raise
-    except Exception as e:
-        logger.error(f"Error registering driver: {e}")
-        logger.error(traceback.format_exc())
 
-        error_message = getattr(e, "message", None)
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=error_message if error_message else str(e),
-        ) from e
+        user_invite.is_used = True
+
+    await session.commit()
+
+    # Generate authentication tokens
+    auth_dto, refresh_token = await auth_service.generate_token(
+        session, user.email, registration_data.password
+    )
+
+    # Set refresh token as httpOnly cookie
+    set_refresh_token_cookie(response, refresh_token)
+
+    return DriverRegisterResponse(
+        driver=DriverRead.model_validate(user.driver), auth=auth_dto
+    )
 
 
 @router.put("/{driver_id}", response_model=DriverRead)

--- a/backend/python/app/routers/job_routes.py
+++ b/backend/python/app/routers/job_routes.py
@@ -28,13 +28,8 @@ async def get_jobs(
     _auth: bool = Depends(require_driver_or_admin),
 ) -> list[JobRead]:
     """Get all jobs"""
-    try:
-        jobs = await service.get_jobs(progress=progress)
-        return [JobRead.model_validate(job) for job in jobs]
-    except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(e)
-        ) from e
+    jobs = await service.get_jobs(progress=progress)
+    return [JobRead.model_validate(job) for job in jobs]
 
 
 @router.post("/generate", response_model=JobEnqueueResponse, status_code=202)
@@ -43,15 +38,9 @@ async def generate_job(
     service: JobService = Depends(get_job_service),
     _auth: bool = Depends(require_driver_or_admin),
 ) -> JobEnqueueResponse:
-    try:
-        job_id = await service.generate_job(_req)
-        await service.enqueue(job_id)
-        return JobEnqueueResponse(job_id=job_id)
-    except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Failed to enqueue job",
-        ) from e
+    job_id = await service.generate_job(_req)
+    await service.enqueue(job_id)
+    return JobEnqueueResponse(job_id=job_id)
 
 
 @router.get("/{job_id}", response_model=JobRead)
@@ -60,19 +49,11 @@ async def get_job(
     service: JobService = Depends(get_job_service),
     _auth: bool = Depends(require_driver_or_admin),
 ) -> JobRead:
-    try:
-        job = await service.get_job(job_id)
-        if not job:
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND, detail="Job not found"
-            )
-    except HTTPException:
-        # Don't let the 404 get swallowed and rewrapped as a 500 below.
-        raise
-    except Exception as e:
+    job = await service.get_job(job_id)
+    if not job:
         raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(e)
-        ) from e
+            status_code=status.HTTP_404_NOT_FOUND, detail="Job not found"
+        )
     return JobRead.model_validate(job)
 
 
@@ -83,16 +64,9 @@ async def cancel_job(
     _auth: bool = Depends(require_admin),
 ) -> JobRead:
     """Cancel an in-flight route generation job."""
-    try:
-        job = await service.cancel_job(job_id)
-        if not job:
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND, detail="Job not found"
-            )
-    except HTTPException:
-        raise
-    except Exception as e:
+    job = await service.cancel_job(job_id)
+    if not job:
         raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(e)
-        ) from e
+            status_code=status.HTTP_404_NOT_FOUND, detail="Job not found"
+        )
     return JobRead.model_validate(job)

--- a/backend/python/app/routers/location_group_routes.py
+++ b/backend/python/app/routers/location_group_routes.py
@@ -25,14 +25,8 @@ async def get_location_groups(
     """
     Get all location groups
     """
-    try:
-        location_groups = await location_group_service.get_location_groups(session)
-        return [LocationGroupRead.model_validate(lg) for lg in location_groups]
-    except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Internal server error",
-        ) from e
+    location_groups = await location_group_service.get_location_groups(session)
+    return [LocationGroupRead.model_validate(lg) for lg in location_groups]
 
 
 @router.get("/{location_group_id}", response_model=LocationGroupRead)
@@ -66,16 +60,10 @@ async def create_location_group(
     """
     Create a new location group
     """
-    try:
-        new_location_group = await location_group_service.create_location_group(
-            session, location_group
-        )
-        return LocationGroupRead.model_validate(new_location_group)
-    except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Internal server error",
-        ) from e
+    new_location_group = await location_group_service.create_location_group(
+        session, location_group
+    )
+    return LocationGroupRead.model_validate(new_location_group)
 
 
 @router.patch("/{location_group_id}", response_model=LocationGroupRead)

--- a/backend/python/app/routers/location_routes.py
+++ b/backend/python/app/routers/location_routes.py
@@ -68,11 +68,6 @@ async def get_locations(
             status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
             detail=str(ve),
         ) from ve
-    except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=str(e),
-        ) from e
 
 
 @router.get("/{location_id}", response_model=LocationRead)
@@ -92,11 +87,6 @@ async def get_location(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=str(ve),
         ) from ve
-    except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=str(e),
-        ) from e
 
 
 @router.post("/", response_model=LocationRead, status_code=status.HTTP_201_CREATED)
@@ -117,11 +107,6 @@ async def create_location(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=str(ve),
         ) from ve
-    except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=str(e),
-        ) from e
 
 
 @router.patch(
@@ -153,11 +138,6 @@ async def update_location(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=str(ve),
         ) from ve
-    except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=str(e),
-        ) from e
 
 
 @router.delete("/", status_code=status.HTTP_204_NO_CONTENT)
@@ -169,13 +149,7 @@ async def delete_all_locations(
     """
     Delete all locations
     """
-    try:
-        await location_service.delete_all_locations(session)
-    except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=str(e),
-        ) from e
+    await location_service.delete_all_locations(session)
 
 
 @router.delete("/{location_id}", status_code=status.HTTP_204_NO_CONTENT)
@@ -200,11 +174,6 @@ async def delete_location(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=str(ve),
         ) from ve
-    except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=str(e),
-        ) from e
 
 
 @router.post(
@@ -239,11 +208,6 @@ async def review_locations(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=str(ve),
         ) from ve
-    except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=str(e),
-        ) from e
 
 
 @router.post(
@@ -272,8 +236,3 @@ async def ingest_locations(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=str(ve),
         ) from ve
-    except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=str(e),
-        ) from e

--- a/backend/python/app/routers/note_chain_routes.py
+++ b/backend/python/app/routers/note_chain_routes.py
@@ -1,4 +1,3 @@
-import logging
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
@@ -11,7 +10,6 @@ from app.models.note import NoteCreate, NoteRead, NoteUpdate
 from app.models.note_chain import NoteChainRead
 from app.services.implementations.note_chain_service import NoteChainService
 
-logger = logging.getLogger(__name__)
 note_chain_service: NoteChainService = get_note_chain_service()
 
 router = APIRouter(prefix="/note-chains", tags=["note-chains"])
@@ -42,11 +40,6 @@ async def get_note_chain(
             status_code=status.HTTP_403_FORBIDDEN,
             detail=str(pe),
         ) from pe
-    except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=str(e),
-        ) from e
 
 
 @router.delete("/{note_chain_id}", status_code=status.HTTP_204_NO_CONTENT)
@@ -70,11 +63,6 @@ async def delete_note_chain(
             status_code=status.HTTP_403_FORBIDDEN,
             detail=str(pe),
         ) from pe
-    except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=str(e),
-        ) from e
 
 
 # --- Notes endpoints ---
@@ -105,11 +93,6 @@ async def get_notes(
             status_code=status.HTTP_403_FORBIDDEN,
             detail=str(pe),
         ) from pe
-    except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=str(e),
-        ) from e
 
 
 @router.post(
@@ -139,11 +122,6 @@ async def create_note(
             status_code=status.HTTP_403_FORBIDDEN,
             detail=str(pe),
         ) from pe
-    except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=str(e),
-        ) from e
 
 
 @router.patch("/{note_chain_id}/notes/{note_id}", response_model=NoteRead)
@@ -170,11 +148,6 @@ async def update_note(
             status_code=status.HTTP_403_FORBIDDEN,
             detail=str(pe),
         ) from pe
-    except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=str(e),
-        ) from e
 
 
 @router.delete(
@@ -201,8 +174,3 @@ async def delete_note(
             status_code=status.HTTP_403_FORBIDDEN,
             detail=str(pe),
         ) from pe
-    except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=str(e),
-        ) from e

--- a/backend/python/app/routers/note_routes.py
+++ b/backend/python/app/routers/note_routes.py
@@ -1,7 +1,6 @@
-import logging
 from enum import Enum
 
-from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi import APIRouter, Depends, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies.auth import require_admin
@@ -10,8 +9,6 @@ from app.models import get_session
 from app.models.note import NoteFeedItem
 from app.schemas.pagination import PaginatedResponse, PaginationParams
 from app.services.implementations.note_chain_service import NoteChainService
-
-logger = logging.getLogger(__name__)
 
 
 class NoteFeedSort(str, Enum):
@@ -37,14 +34,7 @@ async def get_notes_feed(
     _auth: bool = Depends(require_admin),
 ) -> PaginatedResponse[NoteFeedItem]:
     """Get location notes across all location note chains."""
-    try:
-        pagination = PaginationParams(page=page, page_size=page_size)
-        return await note_chain_service.get_location_notes_feed(
-            session, pagination, sort.value
-        )
-    except Exception as e:
-        logger.exception("Failed to get notes feed")
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Failed to get notes feed",
-        ) from e
+    pagination = PaginationParams(page=page, page_size=page_size)
+    return await note_chain_service.get_location_notes_feed(
+        session, pagination, sort.value
+    )

--- a/backend/python/app/routers/report_routes.py
+++ b/backend/python/app/routers/report_routes.py
@@ -50,19 +50,13 @@ async def get_total_deliveries_between(
     """Return total deliveries (route stop snapshots) between start and end.
     Query params are treated as EST if no timezone is provided.
     """
-    try:
-        start_est = _ensure_est(start)
-        end_est = _ensure_est(end)
+    start_est = _ensure_est(start)
+    end_est = _ensure_est(end)
 
-        # Pass scheduler-timezone-aware datetimes to the service. The service
-        # will normalize them to naive scheduler-local datetimes to match DB.
-        total = await service.get_total_deliveries_between(session, start_est, end_est)
-        return DeliveriesCountResponse(total_deliveries=total)
-    except Exception as e:
-        logger.exception(f"Failed to get deliveries between: {e}")
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(e)
-        ) from e
+    # Pass scheduler-timezone-aware datetimes to the service. The service
+    # will normalize them to naive scheduler-local datetimes to match DB.
+    total = await service.get_total_deliveries_between(session, start_est, end_est)
+    return DeliveriesCountResponse(total_deliveries=total)
 
 
 @router.get("/monthly/{year}/{month}/ranking", response_model=list[DriverRankingItem])
@@ -73,21 +67,13 @@ async def get_monthly_ranking(
     _auth: bool = Depends(require_admin),
 ) -> list[DriverRankingItem]:
     """Return monthly ranking list of drivers by km (descending)."""
-    try:
-        if month < 1 or month > 12:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid month"
-            )
-        rankings = await service.get_monthly_km_ranking(session, year, month)
-        items: list[DriverRankingItem] = [DriverRankingItem(**r) for r in rankings]
-        return items
-    except HTTPException:
-        raise
-    except Exception as e:
-        logger.exception(f"Failed to get monthly ranking: {e}")
+    if month < 1 or month > 12:
         raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(e)
-        ) from e
+            status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid month"
+        )
+    rankings = await service.get_monthly_km_ranking(session, year, month)
+    items: list[DriverRankingItem] = [DriverRankingItem(**r) for r in rankings]
+    return items
 
 
 @router.get("/monthly/{year}/{month}/totals", response_model=MonthlyTotalsResponse)
@@ -98,25 +84,17 @@ async def get_monthly_totals(
     _auth: bool = Depends(require_admin),
 ) -> MonthlyTotalsResponse:
     """Return total distance driven and total deliveries for the month."""
-    try:
-        if month < 1 or month > 12:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid month"
-            )
-        total_km = await service.get_total_km_for_month(session, year, month)
-        total_deliveries = await service.get_total_deliveries_for_month(
-            session, year, month
-        )
-        return MonthlyTotalsResponse(
-            year=year,
-            month=month,
-            total_km=total_km,
-            total_deliveries=total_deliveries,
-        )
-    except HTTPException:
-        raise
-    except Exception as e:
-        logger.exception(f"Failed to get monthly totals: {e}")
+    if month < 1 or month > 12:
         raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(e)
-        ) from e
+            status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid month"
+        )
+    total_km = await service.get_total_km_for_month(session, year, month)
+    total_deliveries = await service.get_total_deliveries_for_month(
+        session, year, month
+    )
+    return MonthlyTotalsResponse(
+        year=year,
+        month=month,
+        total_km=total_km,
+        total_deliveries=total_deliveries,
+    )

--- a/backend/python/app/routers/route_group_routes.py
+++ b/backend/python/app/routers/route_group_routes.py
@@ -73,10 +73,6 @@ async def get_route_groups(
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=str(ve)
         ) from ve
-    except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(e)
-        ) from e
 
 
 @router.post("", response_model=RouteGroupRead, status_code=status.HTTP_201_CREATED)
@@ -89,12 +85,7 @@ async def create_route_group(
     """
     Create a new route group
     """
-    try:
-        return await route_group_service.create_route_group(session, route_group)
-    except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(e)
-        ) from e
+    return await route_group_service.create_route_group(session, route_group)
 
 
 @router.patch("/{route_group_id}", response_model=RouteGroupRead)
@@ -108,22 +99,15 @@ async def update_route_group(
     """
     Update an existing route group
     """
-    try:
-        updated_route_group = await route_group_service.update_route_group(
-            session, route_group_id, route_group
-        )
-        if not updated_route_group:
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND,
-                detail=f"RouteGroup with id {route_group_id} not found",
-            )
-        return updated_route_group
-    except HTTPException:
-        raise
-    except Exception as e:
+    updated_route_group = await route_group_service.update_route_group(
+        session, route_group_id, route_group
+    )
+    if not updated_route_group:
         raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(e)
-        ) from e
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"RouteGroup with id {route_group_id} not found",
+        )
+    return updated_route_group
 
 
 @router.post(
@@ -140,22 +124,15 @@ async def duplicate_route_group(
     """
     Duplicate a route group and its routes/stops for a new planning cycle.
     """
-    try:
-        duplicated_route_group = await route_group_service.duplicate_route_group(
-            session, route_group_id
-        )
-        if not duplicated_route_group:
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND,
-                detail=f"RouteGroup with id {route_group_id} not found",
-            )
-        return duplicated_route_group
-    except HTTPException:
-        raise
-    except Exception as e:
+    duplicated_route_group = await route_group_service.duplicate_route_group(
+        session, route_group_id
+    )
+    if not duplicated_route_group:
         raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(e)
-        ) from e
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"RouteGroup with id {route_group_id} not found",
+        )
+    return duplicated_route_group
 
 
 @router.delete("/{route_group_id}", status_code=status.HTTP_204_NO_CONTENT)
@@ -168,16 +145,9 @@ async def delete_route_group(
     """
     Delete a route group and all its route group memberships
     """
-    try:
-        success = await route_group_service.delete_route_group(session, route_group_id)
-        if not success:
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND,
-                detail=f"RouteGroup with id {route_group_id} not found",
-            )
-    except HTTPException:
-        raise
-    except Exception as e:
+    success = await route_group_service.delete_route_group(session, route_group_id)
+    if not success:
         raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(e)
-        ) from e
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"RouteGroup with id {route_group_id} not found",
+        )

--- a/backend/python/app/routers/system_settings_routes.py
+++ b/backend/python/app/routers/system_settings_routes.py
@@ -29,14 +29,8 @@ async def get_system_settings(
     _auth: bool = Depends(require_admin),
 ) -> SystemSettingsRead | None:
     """Return the singleton system settings row, or null if none has been created."""
-    try:
-        settings = await system_settings_service.get_settings(session)
-        return SystemSettingsRead.model_validate(settings) if settings else None
-    except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Internal server error",
-        ) from e
+    settings = await system_settings_service.get_settings(session)
+    return SystemSettingsRead.model_validate(settings) if settings else None
 
 
 @router.patch("/", response_model=SystemSettingsRead)
@@ -69,11 +63,6 @@ async def patch_system_settings(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=str(ve),
         ) from ve
-    except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Internal server error",
-        ) from e
 
 
 @router.post("/delivery-types/rename", response_model=SystemSettingsRead)
@@ -97,9 +86,4 @@ async def rename_delivery_type(
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
             detail=str(e),
-        ) from e
-    except Exception as e:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Internal server error",
         ) from e

--- a/backend/python/app/services/implementations/auth_service.py
+++ b/backend/python/app/services/implementations/auth_service.py
@@ -8,7 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import settings
 from app.schemas.auth import AuthResponse
-from app.utilities.firebase_rest_client import FirebaseRestClient
+from app.utilities.firebase_rest_client import FirebaseRestClient, FirebaseRestError
 
 if TYPE_CHECKING:
     from firebase_admin.auth import UserRecord
@@ -16,6 +16,28 @@ if TYPE_CHECKING:
     from app.services.implementations.driver_service import DriverService
     from app.services.implementations.email_service import EmailService
     from app.services.implementations.user_service import UserService
+
+
+class SessionExpiredError(Exception):
+    """The refresh token can no longer produce a session; re-login is required.
+
+    The one signal ``/auth/refresh`` maps to a 401. Raising this is how
+    ``renew_token`` says "this is the client's problem, not ours" — everything
+    else it lets out is an unexpected failure and becomes a 500.
+    """
+
+
+# Firebase error codes that mean the refresh token itself is finished. Any
+# other code is a fault on our side or Firebase's, not an expired session.
+REAUTH_REQUIRED_FIREBASE_CODES = frozenset(
+    {
+        "TOKEN_EXPIRED",
+        "INVALID_REFRESH_TOKEN",
+        "INVALID_GRANT",
+        "USER_DISABLED",
+        "USER_NOT_FOUND",
+    }
+)
 
 
 class AuthService:
@@ -95,34 +117,44 @@ class AuthService:
     async def renew_token(
         self, session: AsyncSession, refresh_token: str
     ) -> tuple[AuthResponse, str]:
+        """Exchange a refresh token for a fresh session.
+
+        :raises SessionExpiredError: if the token can no longer produce a
+            session — Firebase rejected it, or it is valid but its user is no
+            longer in our database. Both mean the client must log in again.
+        """
         try:
             token_response = self.firebase_rest_client.refresh_token(refresh_token)
-            new_access_token = token_response.access_token
-            payload = jwt.decode(
-                new_access_token,
-                options={"verify_signature": False},
-                algorithms=["RS256"],
-            )
-            auth_id = payload.get("sub", "")
-            user = await self.user_service.get_user_by_auth_id(session, auth_id)
+        except FirebaseRestError as e:
+            if e.code in REAUTH_REQUIRED_FIREBASE_CODES:
+                raise SessionExpiredError(
+                    f"Firebase rejected the refresh token: {e.code}"
+                ) from e
+            raise
 
-            if user is None:
-                # The message is the error *code* the router maps to a 401 — it
-                # is matched exactly, so it must not carry extra prose.
-                raise ValueError("DB_USER_MISSING")
+        new_access_token = token_response.access_token
+        payload = jwt.decode(
+            new_access_token,
+            options={"verify_signature": False},
+            algorithms=["RS256"],
+        )
+        auth_id = payload.get("sub", "")
+        user = await self.user_service.get_user_by_auth_id(session, auth_id)
 
-            auth_response = AuthResponse(
-                access_token=new_access_token,
-                id=user.user_id,
-                first_name=user.first_name,
-                last_name=user.last_name,
-                email=user.email,
-                role=user.role,
+        if user is None:
+            raise SessionExpiredError(
+                f"No user in the database for Firebase auth_id {auth_id}"
             )
-            return auth_response, token_response.refresh_token
-        except Exception as e:
-            self.logger.error(f"Failed to refresh token: {e}")
-            raise e
+
+        auth_response = AuthResponse(
+            access_token=new_access_token,
+            id=user.user_id,
+            first_name=user.first_name,
+            last_name=user.last_name,
+            email=user.email,
+            role=user.role,
+        )
+        return auth_response, token_response.refresh_token
 
     def reset_password(self, email: str) -> None:
         if not self.email_service:

--- a/backend/python/app/services/implementations/route_service.py
+++ b/backend/python/app/services/implementations/route_service.py
@@ -212,14 +212,11 @@ class RouteService:
 
             children_per_box = await resolve_children_per_box(session)
             rows = await self._fetch_ordered_stops(session, route_id)
-        except HTTPException:
-            raise
-        except Exception as error:
-            self.logger.exception("Failed to get route " + str(route_id))
+        except Exception:
+            # Roll back so the caller's session is usable, then let the error
+            # through: UnhandledExceptionMiddleware logs it and answers 500.
             await session.rollback()
-            raise HTTPException(
-                status_code=500, detail="Failed to retrieve route."
-            ) from error
+            raise
 
         stops = [
             RouteStopDetailRead(

--- a/backend/python/app/utilities/firebase_rest_client.py
+++ b/backend/python/app/utilities/firebase_rest_client.py
@@ -11,6 +11,20 @@ FIREBASE_SIGN_IN_URL = (
 FIREBASE_REFRESH_TOKEN_URL = "https://securetoken.googleapis.com/v1/token"
 
 
+class FirebaseRestError(Exception):
+    """A non-200 from the Firebase REST API.
+
+    Carries Firebase's own error code (``TOKEN_EXPIRED``, ``USER_DISABLED``,
+    …) as an attribute. Callers that care which failure it was read ``.code``
+    — never ``str(exc)``, which is what made the code a load-bearing string
+    and cost us the bug in #216.
+    """
+
+    def __init__(self, code: str) -> None:
+        super().__init__(code)
+        self.code = code
+
+
 class FirebaseRestClient:
     def __init__(self, logger: logging.Logger) -> None:
         """
@@ -32,7 +46,7 @@ class FirebaseRestClient:
         :type password: str
         :return: access and refresh tokens
         :rtype: TokenResponse
-        :raises Exception: if Firebase API call fails
+        :raises FirebaseRestError: if Firebase API call fails
         """
         headers = {"Content-Type": "application/json"}
         data = {"email": email, "password": password, "returnSecureToken": "true"}
@@ -50,15 +64,16 @@ class FirebaseRestClient:
         response_json = response.json()
 
         if response.status_code != 200:
+            firebase_code = response_json["error"]["message"]
             error_message = [
                 "Failed to sign-in via Firebase REST API, status code =",
                 str(response.status_code),
                 "error message =",
-                response_json["error"]["message"],
+                firebase_code,
             ]
             self.logger.error(" ".join(error_message))
 
-            raise Exception("Failed to sign-in via Firebase REST API")
+            raise FirebaseRestError(firebase_code)
 
         return TokenResponse(
             access_token=response_json["idToken"],
@@ -74,7 +89,7 @@ class FirebaseRestClient:
         :type ref_token: str
         :return: access and refresh tokens
         :rtype: TokenResponse
-        :raises Exception: if Firebase API call fails
+        :raises FirebaseRestError: if Firebase API call fails
         """
         headers = {"Content-Type": "application/x-www-form-urlencoded"}
         data = f"grant_type=refresh_token&refresh_token={ref_token}"
@@ -100,7 +115,7 @@ class FirebaseRestClient:
             ]
             self.logger.error(" ".join(error_message))
 
-            raise Exception(firebase_code)
+            raise FirebaseRestError(firebase_code)
 
         return TokenResponse(
             access_token=response_json["id_token"],

--- a/backend/python/app/utilities/routes_utils.py
+++ b/backend/python/app/utilities/routes_utils.py
@@ -107,5 +107,3 @@ async def fetch_route_polyline(
         ) from e
     except google_exceptions.RetryError as e:
         raise HTTPException(status_code=504, detail="Request timed out") from e
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Unexpected error: {e!s}") from e

--- a/backend/python/tests/test_auth_routes.py
+++ b/backend/python/tests/test_auth_routes.py
@@ -1,12 +1,13 @@
 """Status-code contract for the ``/auth`` routes.
 
-Every handler in ``app/routers/auth_routes.py`` wraps its body in a broad
-``except Exception`` that converts whatever it catches into a 500. Because
-``HTTPException`` subclasses ``Exception``, any deliberate 4xx raised inside
-such a body is swallowed and re-emitted as a 500 unless the handler re-raises
-``HTTPException`` first. These tests pin that contract for all four handlers,
-plus the status codes ``/auth/login`` and ``/auth/refresh`` are meant to return
-for bad input and for expired/unknown sessions.
+The handlers in ``app/routers/auth_routes.py`` used to wrap their bodies in a
+broad ``except Exception`` that converted whatever it caught into a 500 —
+including, since ``HTTPException`` subclasses ``Exception``, the deliberate 4xx
+they had just raised. The blanket handlers are gone (unexpected errors now
+reach ``UnhandledExceptionMiddleware``), but the contract is the same and is
+still worth pinning: these tests cover all four handlers, plus the status codes
+``/auth/login`` and ``/auth/refresh`` are meant to return for bad input and for
+expired/unknown sessions.
 """
 
 from collections.abc import Awaitable, Callable
@@ -98,7 +99,7 @@ async def _client_raising(
 
 
 class TestHandlerExceptionMapping:
-    """The broad ``except Exception`` must not rewrite deliberate HTTP errors."""
+    """Nothing between the handler and the client rewrites a deliberate 4xx."""
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(("overrides", "request_fn"), AUTH_ENDPOINTS)

--- a/backend/python/tests/test_auth_routes.py
+++ b/backend/python/tests/test_auth_routes.py
@@ -23,9 +23,13 @@ from httpx import AsyncClient, Response
 
 from app.dependencies.auth import get_current_database_user_id, get_current_user_email
 from app.dependencies.services import get_auth_service
-from app.routers.auth_routes import _FIREBASE_401_CODES
 from app.schemas.auth import TokenResponse
-from app.services.implementations.auth_service import AuthService
+from app.services.implementations.auth_service import (
+    REAUTH_REQUIRED_FIREBASE_CODES,
+    AuthService,
+    SessionExpiredError,
+)
+from app.utilities.firebase_rest_client import FirebaseRestError
 
 USER_ID: UUID = uuid4()
 EMAIL = "driver@example.com"
@@ -203,12 +207,11 @@ class TestRefresh:
         assert response.json()["detail"] == "Refresh token not found"
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize("code", sorted(_FIREBASE_401_CODES))
-    async def test_expired_session_codes_are_401(
-        self, client_with_overrides: Any, code: str
-    ) -> None:
-        """Each known session-ended code maps to 401, so clients can re-login."""
-        client = await _client_raising(client_with_overrides, ValueError(code), {})
+    async def test_session_expired_is_401(self, client_with_overrides: Any) -> None:
+        """``SessionExpiredError`` is the one signal that means "log in again"."""
+        client = await _client_raising(
+            client_with_overrides, SessionExpiredError("token is finished"), {}
+        )
 
         response = await client.post(
             "/auth/refresh", headers={"Cookie": "refreshToken=stub-refresh-token"}
@@ -218,10 +221,22 @@ class TestRefresh:
         assert response.json()["detail"] == "Session expired"
 
     @pytest.mark.asyncio
-    async def test_unknown_failure_is_500(self, client_with_overrides: Any) -> None:
-        client = await _client_raising(
-            client_with_overrides, ValueError("SOMETHING_ELSE"), {}
-        )
+    @pytest.mark.parametrize(
+        "error",
+        [
+            pytest.param(ValueError("SOMETHING_ELSE"), id="value-error"),
+            # Every one of these used to reach the router, which decided by
+            # comparing str(e) to a set it owned. Now only the service's own
+            # SessionExpiredError means 401 — a raw Firebase error is a 500,
+            # even one whose text looks exactly like a session-ended code.
+            pytest.param(FirebaseRestError("TOKEN_EXPIRED"), id="raw-firebase-code"),
+            pytest.param(RuntimeError("database on fire"), id="runtime-error"),
+        ],
+    )
+    async def test_anything_else_is_500(
+        self, client_with_overrides: Any, error: Exception
+    ) -> None:
+        client = await _client_raising(client_with_overrides, error, {})
 
         response = await client.post(
             "/auth/refresh", headers={"Cookie": "refreshToken=stub-refresh-token"}
@@ -230,44 +245,79 @@ class TestRefresh:
         assert response.status_code == 500
 
 
-class TestRenewTokenDbUserMissing:
-    """``renew_token``'s message is matched against ``_FIREBASE_401_CODES``.
+class TestRenewTokenSessionExpiry:
+    """``renew_token`` is the single place that decides "log in again".
 
-    The router compares ``str(e)`` to the code set exactly, so the service has
-    to raise the bare code — any surrounding prose silently downgrades a
-    "your session is gone, log in again" into a 500.
+    Before, it signalled by *message*: it raised with a bare error code that
+    the router string-matched against a set. That contract broke silently the
+    moment the message carried a typo or any extra prose — which is exactly
+    what #216 found. These tests pin the decision at the service, where it
+    belongs, so the router needs to know only one exception type.
     """
 
-    def _service(self, user: Any) -> AuthService:
+    def _service(
+        self, user: Any = None, refresh_error: Exception | None = None
+    ) -> AuthService:
         user_service = MagicMock()
         user_service.get_user_by_auth_id = AsyncMock(return_value=user)
         service = AuthService(getLogger(__name__), user_service, MagicMock())
         firebase_client: Any = MagicMock()
-        firebase_client.refresh_token.return_value = TokenResponse(
-            # renew_token decodes without verifying, so any well-formed token
-            # carrying a "sub" claim will do.
-            access_token=jwt.encode({"sub": "firebase-uid"}, "k" * 32, "HS256"),
-            refresh_token="new-refresh-token",
-        )
+        if refresh_error is not None:
+            firebase_client.refresh_token.side_effect = refresh_error
+        else:
+            firebase_client.refresh_token.return_value = TokenResponse(
+                # renew_token decodes without verifying, so any well-formed
+                # token carrying a "sub" claim will do.
+                access_token=jwt.encode({"sub": "firebase-uid"}, "k" * 32, "HS256"),
+                refresh_token="new-refresh-token",
+            )
         service.firebase_rest_client = firebase_client
         return service
 
     @pytest.mark.asyncio
-    async def test_missing_db_user_raises_the_bare_401_code(self) -> None:
+    async def test_missing_db_user_is_a_session_expiry(self) -> None:
+        """A token Firebase still honours, for a user we no longer have."""
         service = self._service(user=None)
 
-        with pytest.raises(ValueError) as excinfo:
+        with pytest.raises(SessionExpiredError):
             await service.renew_token(MagicMock(), "stub-refresh-token")
 
-        assert str(excinfo.value) == "DB_USER_MISSING"
-        assert str(excinfo.value) in _FIREBASE_401_CODES
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("code", sorted(REAUTH_REQUIRED_FIREBASE_CODES))
+    async def test_reauth_firebase_codes_become_session_expiry(self, code: str) -> None:
+        """Each code Firebase uses for a dead token maps to the domain error."""
+        service = self._service(refresh_error=FirebaseRestError(code))
+
+        with pytest.raises(SessionExpiredError):
+            await service.renew_token(MagicMock(), "stub-refresh-token")
 
     @pytest.mark.asyncio
-    async def test_missing_db_user_surfaces_as_401_through_the_route(
-        self, client_with_overrides: Any
+    async def test_other_firebase_codes_are_not_swallowed(self) -> None:
+        """An unexpected Firebase failure must stay unexpected — a 500, not a
+        401 that tells the user to log in again for no reason."""
+        service = self._service(refresh_error=FirebaseRestError("QUOTA_EXCEEDED"))
+
+        with pytest.raises(FirebaseRestError) as excinfo:
+            await service.renew_token(MagicMock(), "stub-refresh-token")
+
+        assert excinfo.value.code == "QUOTA_EXCEEDED"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "service_kwargs",
+        [
+            pytest.param({"user": None}, id="missing-db-user"),
+            pytest.param(
+                {"refresh_error": FirebaseRestError("TOKEN_EXPIRED")},
+                id="firebase-rejected-token",
+            ),
+        ],
+    )
+    async def test_session_expiry_surfaces_as_401_through_the_route(
+        self, client_with_overrides: Any, service_kwargs: dict[str, Any]
     ) -> None:
-        """End-to-end: the service's error and the router's set line up."""
-        service = self._service(user=None)
+        """End-to-end through the real service: no string contract in between."""
+        service = self._service(**service_kwargs)
         client: AsyncClient = await client_with_overrides(
             {get_auth_service: lambda: service}
         )

--- a/backend/python/tests/test_unhandled_exception_middleware.py
+++ b/backend/python/tests/test_unhandled_exception_middleware.py
@@ -1,0 +1,201 @@
+"""Contract for the app-wide 500 handler.
+
+Route handlers no longer wrap their bodies in ``except Exception``.
+:class:`~app.middleware.UnhandledExceptionMiddleware` is what turns an
+unexpected failure into a 500 now, and these tests pin the three things the
+per-handler version got wrong (see #216): a deliberate ``HTTPException`` must
+survive, the response body must not carry internal error text, and the
+traceback must actually reach the log.
+"""
+
+import ast
+import logging
+import pathlib
+from collections.abc import AsyncIterator
+
+import pytest
+from fastapi import APIRouter, HTTPException, status
+from fastapi.responses import StreamingResponse
+from httpx import ASGITransport, AsyncClient
+
+from app import create_app
+
+SECRET = "connection to 10.0.0.7 refused: password authentication failed"
+
+ALLOWED_ORIGIN = "http://localhost:3000"
+
+probe_router = APIRouter(prefix="/_probe")
+
+
+@probe_router.get("/boom")
+async def probe_boom() -> None:
+    raise RuntimeError(SECRET)
+
+
+@probe_router.get("/ok")
+async def probe_ok() -> dict[str, str]:
+    return {"status": "ok"}
+
+
+@probe_router.get("/teapot")
+async def probe_teapot() -> None:
+    raise HTTPException(status_code=418, detail="deliberate")
+
+
+@probe_router.get("/value-error")
+async def probe_value_error() -> None:
+    raise ValueError(SECRET)
+
+
+@probe_router.get("/stream-boom")
+async def probe_stream_boom() -> StreamingResponse:
+    async def body() -> AsyncIterator[bytes]:
+        yield b"first chunk"
+        raise RuntimeError(SECRET)
+
+    return StreamingResponse(body(), media_type="text/plain")
+
+
+@pytest.fixture
+def probe_client() -> AsyncClient:
+    """A client for the real app, with routes that fail on demand bolted on.
+
+    Built from ``create_app`` rather than a hand-rolled FastAPI instance so the
+    middleware *ordering* is the one the app actually ships.
+    """
+    app = create_app()
+    app.include_router(probe_router)
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+class TestUnhandledExceptions:
+    @pytest.mark.asyncio
+    async def test_unexpected_error_becomes_a_500(
+        self, probe_client: AsyncClient
+    ) -> None:
+        async with probe_client as client:
+            response = await client.get("/_probe/boom")
+
+        assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+        assert response.json() == {"detail": "Internal server error"}
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("path", ["/_probe/boom", "/_probe/value-error"])
+    async def test_500_body_never_leaks_the_exception_text(
+        self, probe_client: AsyncClient, path: str
+    ) -> None:
+        """``detail=str(e)`` used to hand internal error text to the caller."""
+        async with probe_client as client:
+            response = await client.get(path)
+
+        assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+        assert SECRET not in response.text
+
+    @pytest.mark.asyncio
+    async def test_traceback_is_logged(
+        self, probe_client: AsyncClient, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Re-raising as ``HTTPException`` made the failure look expected to
+        Starlette, so nothing ever logged it."""
+        with caplog.at_level(logging.ERROR, logger="app.middleware"):
+            async with probe_client as client:
+                await client.get("/_probe/boom")
+
+        (record,) = [r for r in caplog.records if r.name == "app.middleware"]
+        assert record.exc_info is not None
+        assert SECRET in caplog.text
+        assert "GET" in record.getMessage()
+        assert "/_probe/boom" in record.getMessage()
+
+    @pytest.mark.asyncio
+    async def test_deliberate_http_error_is_untouched(
+        self, probe_client: AsyncClient
+    ) -> None:
+        """The #216 bug: a handler's own 4xx must not be rewritten as a 500."""
+        async with probe_client as client:
+            response = await client.get("/_probe/teapot")
+
+        assert response.status_code == 418
+        assert response.json() == {"detail": "deliberate"}
+
+    @pytest.mark.asyncio
+    async def test_successful_request_is_unaffected(
+        self, probe_client: AsyncClient
+    ) -> None:
+        async with probe_client as client:
+            response = await client.get("/_probe/ok")
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json() == {"status": "ok"}
+
+    @pytest.mark.asyncio
+    async def test_500_carries_cors_headers(self, probe_client: AsyncClient) -> None:
+        """The middleware must sit *inside* CORS.
+
+        Outside it (which is where ``add_exception_handler(Exception, ...)``
+        puts you) the 500 ships without ``Access-Control-Allow-Origin``, and a
+        browser reports an opaque CORS failure instead of the error.
+        """
+        async with probe_client as client:
+            response = await client.get(
+                "/_probe/boom", headers={"Origin": ALLOWED_ORIGIN}
+            )
+
+        assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+        assert response.headers["access-control-allow-origin"] == ALLOWED_ORIGIN
+
+    @pytest.mark.asyncio
+    async def test_failure_mid_stream_is_not_swallowed(
+        self, probe_client: AsyncClient
+    ) -> None:
+        """Once the response has started the status line is already sent, so
+        there is no 500 to substitute — the error must propagate rather than
+        be quietly dropped."""
+        with pytest.raises(RuntimeError, match="refused"):
+            async with probe_client as client:
+                await client.get("/_probe/stream-boom")
+
+
+class TestNoBlanketHandlersRemain:
+    """Structural guard: the pattern itself must not come back.
+
+    A blanket ``except Exception`` that raises its own 500 re-introduces all
+    three failure modes at once, and the next one added will not have a test of
+    its own. Catching an exception to do real cleanup and then re-raising is
+    fine — it is *converting* it to a 500 that this forbids.
+    """
+
+    @staticmethod
+    def _blanket_500_handlers(path: pathlib.Path) -> list[int]:
+        tree = ast.parse(path.read_text())
+        found = []
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Try):
+                continue
+            for handler in node.handlers:
+                if handler.type is None or ast.unparse(handler.type) != "Exception":
+                    continue
+                raises = [
+                    ast.unparse(n.exc)
+                    for n in ast.walk(handler)
+                    if isinstance(n, ast.Raise) and n.exc is not None
+                ]
+                if any(
+                    "500_INTERNAL_SERVER_ERROR" in r or "status_code=500" in r
+                    for r in raises
+                ):
+                    found.append(handler.lineno)
+        return found
+
+    def test_nothing_in_app_raises_a_500_from_a_broad_except(self) -> None:
+        app_dir = pathlib.Path(__file__).parent.parent / "app"
+        offenders = {
+            str(path.relative_to(app_dir)): lines
+            for path in sorted(app_dir.rglob("*.py"))
+            if (lines := self._blanket_500_handlers(path))
+        }
+        assert offenders == {}, (
+            "Let unexpected errors reach UnhandledExceptionMiddleware, which "
+            "logs the traceback and returns a 500 that leaks nothing, instead "
+            f"of raising your own: {offenders}"
+        )


### PR DESCRIPTION
Follow-up to #216, which fixed four handlers and left this note:

> 24 broad `except Exception` blocks across 8 files lack the guard … Left out of this PR; there's a task for the wider cleanup, which should also weigh deleting these blanket handlers outright.

No such task existed, so here it is. Re-measured on `main`: **46** `try/except Exception` blocks across 12 router files, **29** of them without the `except HTTPException: raise` guard.

## Delete them rather than guard them

Adding the guard 29 more times fixes one of three problems and leaves the other two:

1. **Own 4xx becomes a 500.** `HTTPException` subclasses `Exception`, so an unguarded handler catches the error it just raised. All 29 router blocks were latent — no unguarded try body raises `HTTPException` directly, and the services that do are only reached from guarded handlers. But `utilities/routes_utils.fetch_route_polyline` was **live**: its own `HTTPException(500, "Google Maps API returned no routes")` came back out of the broad clause below as `Unexpected error: 500: Google Maps API returned no routes`.
2. **Internal error text leaked to clients.** 32 of the 46 blocks used `detail=str(e)` — SQL, constraint names, third-party client messages, straight into the response body.
3. **Tracebacks never logged.** Converting to `HTTPException` makes the failure look *expected* to Starlette, so `ServerErrorMiddleware` never sees it and nothing logs the original error.

`UnhandledExceptionMiddleware` (new, `app/middleware.py`) handles all three centrally: logs the traceback with method and path, returns a fixed `{"detail": "Internal server error"}`. Handlers keep only their specific `except` clauses — the ones that map a known failure to a meaningful 4xx.

Two details worth reviewing:

- **It is registered *before* CORS**, so it ends up *inside* it. The last middleware added is the outermost, and `add_exception_handler(Exception, …)` — the obvious alternative — puts you outside CORS entirely, where the 500 ships with no `Access-Control-Allow-Origin` and a browser reports an opaque CORS failure instead of the error. There's a test for this.
- **If the response has already started** (a `StreamingResponse` that fails mid-body) the status line is gone and there is nothing to substitute, so it logs and re-raises rather than corrupting a half-sent response.

## Outside the routers

Two blocks of the same shape, both fixed since they'd otherwise sit just below the structural test's reach:

- `utilities/routes_utils.py` — the live one above; the blanket clause is deleted, the 503/504 mappings for real Google API errors stay.
- `route_service.get_route` — kept the `session.rollback()` (real cleanup the middleware can't do), dropped the conversion to a 500. Note this also drops the `except HTTPException: raise` above it, so the 404 raised in the try body now passes through the rollback on its way out. Harmless on a read, and it keeps the handler to one branch.

## The last broad catch: `/auth/refresh`

`refresh` was the one handler that still needed `except Exception`, and only because the error it had to recognise had no type. `FirebaseRestClient` raised a bare `Exception(firebase_code)`, so the router decided 401-vs-500 by comparing `str(e)` against a set of magic strings it owned — including `DB_USER_MISSING`, which isn't even a Firebase code.

**That string contract is what broke in #216.** `renew_token` raised `ValueError("DB_USER_MISSINGG: …")` — a typo plus trailing prose — so the comparison never matched and a user whose DB record was gone got a 500 instead of the 401 telling them to re-login. #216 kept the contract and added a comment asking the service not to add prose. This removes the contract:

- **`FirebaseRestError(code)`** replaces both bare `Exception`s in `firebase_rest_client`, carrying Firebase's code as an attribute instead of as the message.
- **`renew_token` is now the only place that decides "log in again"**, raising `SessionExpiredError` for both cases (Firebase rejected the token; the token is valid but its user is gone). `REAUTH_REQUIRED_FIREBASE_CODES` moves next to the client whose codes it lists.
- **`refresh` narrows to `except SessionExpiredError` → 401.** Routers now contain **zero** `except Exception`.

`_FIREBASE_401_CODES` and the `DB_USER_MISSING` magic string are gone from the test suite too. The per-code parametrization moved down to the service, where it exercises the real translation rather than asserting on a set the router owned — plus new cases that a raw `FirebaseRestError` reaching the router is a 500 (even one whose text is exactly `TOKEN_EXPIRED`) and that an unrecognised Firebase code isn't swallowed into a spurious 401.

Also gone: `driver_routes`' `traceback.format_exc()` logging (the middleware logs the traceback now) and a `user = None` that only the deleted compensating-transaction handler read.

## Tests

New `tests/test_unhandled_exception_middleware.py`, 9 tests: the 500 body never carries the exception text, the traceback reaches the log with method and path, a deliberate 4xx survives untouched, the 500 carries CORS headers, a mid-stream failure propagates instead of being swallowed, and a structural test that fails if **any** `except Exception` under `app/` raises its own 500 — so the pattern can't come back quietly.

`test_auth_routes.py` grew from 28 to 32 tests. The unchanged ones are the main evidence that behaviour is preserved: a deliberate 4xx from each of the four auth handlers survives, and unexpected errors still map to 500.

## Verification

- `ruff check` ✅, `ruff format --check` ✅, `mypy` ✅ (121 files)
- `openapi.json` byte-identical (error responses were never in the spec), so no client regeneration
- Backend suite locally: 76 failed / 394 passed. The failure list is **identical** to `main`'s baseline (76 pre-existing local location / route-group / system-settings failures), and passed went 381 → 394 — the 9 middleware tests plus 4 net new auth tests. `test_models.py` excluded from both runs; it needs a sync DB this machine can't reach.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
