### PR TITLE
Remove stale Upcoming Routes bento card from admin homepage

### DIFF
--- a/frontend/src/pages/admin/home/AdminHomePage.tsx
+++ b/frontend/src/pages/admin/home/AdminHomePage.tsx
@@ -36,9 +36,6 @@ export const AdminHomePage = () => {
           </Card>
         </div>
         <Card>
-          <CardContent>TODO: Upcoming Routes</CardContent>
-        </Card>
-        <Card>
           <CardContent>TODO: Unassigned Routes</CardContent>
         </Card>
         <Card>


### PR DESCRIPTION
The admin homepage bento grid still rendered a `TODO: Upcoming Routes` card stub. Design dropped that widget — only Unassigned Routes remains — so the stub was holding a slot for a card that will never be built.

### Why now

This cleanup was recorded **only** in the description of F4KRP-211 (the "build out bento widgets" umbrella), not in any of its four child tickets. Those four have since been promoted from subtasks to standalone tasks under Epic F4KRP-11:

| Ticket | Widget | Due | Assignee |
|---|---|---|---|
| F4KRP-212 | Calendar | Aug 24 | Hy Lac |
| F4KRP-213 | Statistics toggles | Aug 7 | Wilson Li |
| F4KRP-214 | Unassigned Routes | Aug 8 | Kerushani |
| F4KRP-215 | Cost + Recent Notes | Aug 15 | Kerushani |

F4KRP-211 is being deleted, so this change lands the one piece of work that would otherwise have been lost with it.

### Change

A 3-line deletion. The remaining five stubs (Calendar, Route Generation Cost, Statistics Toggles, Unassigned Routes, Recent Notes) map 1:1 to the four tickets above and are untouched — each gets replaced as its widget is built.

### Verification

- `pnpm run lint` — clean (`--max-warnings=0`)
- `pnpm run format:check` — clean
- `pnpm run build` (`tsc -b && vite build`) — passes
- Grepped all remaining `upcoming` references in `frontend/src`: only `RouteStatusEnum`, the generated API client, and the driver route feeds. Nothing orphaned by this removal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)