### PR TITLE
Refuse auth for a user who is neither a driver nor an admin

### DIFF
--- a/backend/python/app/services/implementations/user_service.py
+++ b/backend/python/app/services/implementations/user_service.py
@@ -6,6 +6,7 @@ import firebase_admin.auth
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import select
 
+from app.models.driver import Driver
 from app.models.user import User, UserBase, UserUpdate
 
 if TYPE_CHECKING:
@@ -35,7 +36,7 @@ class UserService:
             raise e
 
     async def get_user_by_email(self, session: AsyncSession, email: str) -> User | None:
-        """Get user by email using Firebase"""
+        """Get user by email, if they are still a driver or an admin"""
         try:
             statement = select(User).where(User.email == email)
             result = await session.execute(statement)
@@ -43,6 +44,12 @@ class UserService:
 
             if not user:
                 self.logger.error(f"User with email {email} not found")
+                return None
+
+            if user.role.lower() != "admin" and not await session.scalar(
+                select(Driver.driver_id).where(Driver.user_id == user.user_id)
+            ):
+                self.logger.error(f"User with email {email} has no driver record")
                 return None
 
             return user

--- a/backend/python/tests/test_auth_orphan_guard.py
+++ b/backend/python/tests/test_auth_orphan_guard.py
@@ -1,0 +1,169 @@
+"""A `users` row that is neither a driver nor an admin cannot authenticate.
+
+Defence in depth for orphaned identities: whatever leaves a stranded `users`
+row — a bug in a delete path, a half-finished migration, a manual DB edit —
+should not leave a working login behind it. `UserService.get_user_by_email` is
+the single lookup both `/auth/login` and `/auth/forgot-password` go through, so
+the check lives there and both endpoints inherit it.
+"""
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import select
+
+from app.models.driver import Driver
+from app.models.password_reset_token import PasswordResetToken
+from app.models.user import User
+
+pytestmark = pytest.mark.asyncio
+
+PASSWORD = "correct horse battery staple"
+
+
+async def _make_user(
+    session: AsyncSession, *, email: str, role: str, with_driver: bool
+) -> User:
+    user = User(
+        first_name="Test",
+        last_name="Person",
+        email=email,
+        role=role,
+        auth_id=f"auth-{uuid4()}",
+    )
+    session.add(user)
+    await session.flush()
+
+    if with_driver:
+        session.add(
+            Driver(
+                user_id=user.user_id,
+                phone="+12125551234",
+                address="123 Main St, City, State 12345",
+                license_plate="ABC123",
+                car_make_model="Toyota Camry",
+            )
+        )
+
+    await session.commit()
+    return user
+
+
+def _firebase_accepts_the_password() -> Any:
+    """Sign-in succeeds, so the DB check is the only thing under test."""
+    token = MagicMock()
+    token.access_token = "access-token"
+    token.refresh_token = "refresh-token"
+    return patch(
+        "app.utilities.firebase_rest_client.FirebaseRestClient.sign_in_with_password",
+        return_value=token,
+    )
+
+
+# ---------------------------------------------------------------------------
+# /auth/login
+# ---------------------------------------------------------------------------
+
+
+async def test_driver_with_a_driver_row_can_log_in(
+    async_client: AsyncClient, test_session: AsyncSession
+) -> None:
+    """The guard must not lock out the ordinary case."""
+    await _make_user(
+        test_session, email="real.driver@example.com", role="driver", with_driver=True
+    )
+
+    with _firebase_accepts_the_password():
+        response = await async_client.post(
+            "/auth/login",
+            json={"email": "real.driver@example.com", "password": PASSWORD},
+        )
+
+    assert response.status_code == 200
+    assert response.json()["email"] == "real.driver@example.com"
+
+
+async def test_admin_without_a_driver_row_can_log_in(
+    async_client: AsyncClient, test_session: AsyncSession
+) -> None:
+    """Admins never have a `drivers` row — the role is what admits them."""
+    await _make_user(
+        test_session, email="boss@example.com", role="admin", with_driver=False
+    )
+
+    with _firebase_accepts_the_password():
+        response = await async_client.post(
+            "/auth/login", json={"email": "boss@example.com", "password": PASSWORD}
+        )
+
+    assert response.status_code == 200
+    assert response.json()["role"] == "admin"
+
+
+async def test_orphaned_user_cannot_log_in(
+    async_client: AsyncClient, test_session: AsyncSession
+) -> None:
+    """No driver row and not an admin: refused, even though Firebase said yes."""
+    await _make_user(
+        test_session, email="orphan@example.com", role="driver", with_driver=False
+    )
+
+    with _firebase_accepts_the_password():
+        response = await async_client.post(
+            "/auth/login", json={"email": "orphan@example.com", "password": PASSWORD}
+        )
+
+    assert response.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# /auth/forgot-password
+# ---------------------------------------------------------------------------
+
+
+async def test_orphaned_user_gets_no_password_reset_token(
+    async_client: AsyncClient, test_session: AsyncSession
+) -> None:
+    """204 either way (anti-enumeration), so assert on the token and the email."""
+    await _make_user(
+        test_session, email="orphan@example.com", role="driver", with_driver=False
+    )
+
+    with patch(
+        "app.services.implementations.email_dispatcher.EmailDispatcher.dispatch",
+        new_callable=AsyncMock,
+    ) as dispatch:
+        response = await async_client.post(
+            "/auth/forgot-password", json={"email": "orphan@example.com"}
+        )
+
+    assert response.status_code == 204
+    dispatch.assert_not_called()
+    tokens = (await test_session.execute(select(PasswordResetToken))).scalars().all()
+    assert tokens == []
+
+
+async def test_real_driver_still_gets_a_password_reset_token(
+    async_client: AsyncClient, test_session: AsyncSession
+) -> None:
+    """The other half of the contract: a real driver's reset still works."""
+    await _make_user(
+        test_session, email="real.driver@example.com", role="driver", with_driver=True
+    )
+
+    with patch(
+        "app.services.implementations.email_dispatcher.EmailDispatcher.dispatch",
+        new_callable=AsyncMock,
+    ) as dispatch:
+        response = await async_client.post(
+            "/auth/forgot-password", json={"email": "real.driver@example.com"}
+        )
+
+    assert response.status_code == 204
+    dispatch.assert_called_once()
+    tokens = (await test_session.execute(select(PasswordResetToken))).scalars().all()
+    assert len(tokens) == 1


### PR DESCRIPTION
Follow-up to #222, raised there and deliberately kept out of it.

#222 fixed the delete path that was stranding `users` rows. This stops a stranded row from being able to authenticate at all — so the next bug, half-finished migration, or manual DB edit that leaves one behind doesn't also leave a working login behind it.

## The change

```python
if user.role.lower() != "admin" and not await session.scalar(
    select(Driver.driver_id).where(Driver.user_id == user.user_id)
):
    self.logger.error(f"User with email {email} has no driver record")
    return None
```

It lives in `UserService.get_user_by_email` because that is the **only** lookup both `/auth/login` and `/auth/forgot-password` go through, and it has no other callers — so one check covers both surfaces. Both callers already handle a `None` return correctly:

- **login** → `generate_token` raises its generic `Invalid email or password` → **401**
- **forgot-password** → its usual **204**, no token minted, no email sent (the 204 is deliberate anti-enumeration, so the assertions in the tests are on the token row and the dispatch, not the status code)

Admins have no `drivers` row, so the role branch is what admits them — `test_admin_without_a_driver_row_can_log_in` pins that.

## Notes on the diff

Colin asked for ~5 lines and no added comments. It came out at 8 insertions / 1 deletion:

- The deletion is the docstring. It said "Get user by email **using Firebase**", which was already false (main removed the Firebase call), and leaving "get user by email" on a function that now returns `None` for a real user found by email is a trap.
- The overage is the `logger.error` line. Every other `None` path in that function logs, and without it an admin debugging "why can't this driver sign in" gets silence. Easy to drop if you'd rather have the 5.

No comments added.

## Tests

`tests/test_auth_orphan_guard.py`, 5 tests, both directions of the contract:

| | expected |
|---|---|
| driver with a `drivers` row logs in | 200 |
| admin, no `drivers` row | 200 |
| orphan (`role="driver"`, no `drivers` row) | 401 |
| orphan requests reset | 204, no token, no email |
| real driver requests reset | 204, token minted, email sent |

Firebase sign-in is mocked to **succeed** throughout, so the DB check is the only thing under test.

## Verification

- `tests/test_auth_routes.py` + the new file: **37 passed**
- `ruff check` ✅ · `ruff format --check` ✅ · `mypy` ✅
- No migration, no OpenAPI change

The full local suite was still running when I pushed — the dev box is at load average 18 with four agents running suites at once, so it had been grinding for 30 minutes. CI on clean runners is the real gate; I'll confirm the local run too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)