### PR TITLE
Delete the legacy reminder-email job and its broken rendering path

### DIFF
--- a/backend/python/app/services/jobs/__init__.py
+++ b/backend/python/app/services/jobs/__init__.py
@@ -57,7 +57,7 @@ def _schedule_daily_reminder_emails(
     previously-registered reminder jobs are removed first so stale times stop
     firing after the settings change.
     """
-    from .email_jobs import process_daily_reminder_emails
+    from .email_jobs import send_route_reminders
 
     for job in scheduler_service.list_jobs():
         if str(job["id"]).startswith(DAILY_REMINDER_JOB_PREFIX):
@@ -69,7 +69,7 @@ def _schedule_daily_reminder_emails(
 
     for reminder_time, days_before in sorted(days_by_time.items()):
         scheduler_service.add_cron_job(
-            partial(process_daily_reminder_emails, sorted(set(days_before))),
+            partial(send_route_reminders, sorted(set(days_before))),
             job_id=_reminder_job_id(reminder_time),
             hour=reminder_time.hour,
             minute=reminder_time.minute,
@@ -104,7 +104,6 @@ async def init_jobs(
     2. Define your job function
     3. Import and register it here
     """
-    from .email_jobs import send_route_reminders
     from .route_freeze_jobs import process_daily_driver_history
 
     # Driver history mark daily routes as complete
@@ -115,11 +114,6 @@ async def init_jobs(
         minute=59,
     )
 
+    # Route reminders are scheduled entirely from the persisted email_reminders
+    # setting -- one cron job per configured time, each bound to its lead days.
     await refresh_daily_reminder_email_schedule(scheduler_service, session)
-    # Route reminders stay on the existing daily schedule.
-    scheduler_service.add_cron_job(
-        send_route_reminders,
-        job_id="route_reminders",
-        hour=7,
-        minute=0,
-    )

--- a/backend/python/app/services/jobs/email_jobs.py
+++ b/backend/python/app/services/jobs/email_jobs.py
@@ -7,131 +7,117 @@ Jobs use the unified EmailDispatcher to render and send emails.
 from __future__ import annotations
 
 from datetime import date, datetime, timedelta
-from typing import TYPE_CHECKING, Any, cast
 
 from sqlalchemy import and_
 from sqlmodel import col, select
-
-from app.config import settings
-
-if TYPE_CHECKING:
-    from sqlalchemy.sql.schema import Table
 
 from app.dependencies.services import get_email_dispatcher, get_logger
 from app.models.driver import Driver
 from app.models.route import Route
 from app.models.route_group import RouteGroup
 from app.models.user import User
-from app.services.implementations.email_service import EmailService
+
+# Placeholder until there is a deployment to link at. The template still needs
+# some value for Upcoming_Route_URL, and dispatch would raise without it.
+UPCOMING_ROUTE_URL = "https://app.example.com/routes"
 
 
-async def send_route_reminders() -> None:
-    """Scheduled job: Send route reminders to drivers for tomorrow's routes.
+async def send_route_reminders(reminder_days: list[int]) -> None:
+    """Scheduled job: email drivers about routes ``reminder_days`` days out.
 
-    Runs daily (typically at 7:00 AM) and sends reminder emails to all drivers
-    assigned to routes the next day.
+    The scheduler registers one instance of this job per distinct reminder time
+    (see ``refresh_daily_reminder_email_schedule``), passing the lead days
+    configured for that time. A lead day of 0 means routes driving today.
 
-    This job:
-    - Queries all driver assignments for tomorrow
-    - For each driver, renders and sends a route reminder email
-    - Logs successes and failures individually
-    - Continues sending even if one email fails
+    Renders through the EmailDispatcher, which substitutes the template's
+    Jinja2 placeholders. Sends are attempted for every driver; a failure is
+    logged and the remaining drivers are still emailed.
     """
 
     from app.models import async_session_maker_instance
 
     logger = get_logger()
-    dispatcher = get_email_dispatcher()
+
+    if not reminder_days:
+        logger.info("No reminder lead days configured, skipping emails")
+        return
 
     if async_session_maker_instance is None:
         logger.error("Database session maker not initialized")
         return
 
-    tomorrow = date.today() + timedelta(days=1)
-    start_of_day = datetime.combine(tomorrow, datetime.min.time())
-    end_of_day = datetime.combine(tomorrow, datetime.max.time())
+    dispatcher = get_email_dispatcher()
 
     try:
         async with async_session_maker_instance() as session:
-            # Get all drivers assigned to routes tomorrow
-            # Cast model tables to SQLAlchemy Table objects so mypy can reason
-            # about column expressions.
-            # Cast the model classes to Any before accessing `__table__` so
-            # mypy does not complain about missing attributes on the class
-            # objects.
-            Route_table = cast("Table", cast("Any", Route).__table__)
-            Driver_table = cast("Table", cast("Any", Driver).__table__)
-            User_table = cast("Table", cast("Any", User).__table__)
-            RouteGroup_table = cast("Table", cast("Any", RouteGroup).__table__)
+            target_dates = {date.today() + timedelta(days=day) for day in reminder_days}
 
-            # Select full models so typing is recognized by mypy; use table
-            # columns for SQL expressions.
+            # Narrow in SQL to the span the lead days cover, then match the exact
+            # dates below. The span is only a prefilter: non-contiguous lead days
+            # (say 1 and 3) cover a range that also contains days nobody asked for.
+            start_of_span = datetime.combine(min(target_dates), datetime.min.time())
+            end_of_span = datetime.combine(max(target_dates), datetime.max.time())
+
             statement = (
                 select(Route, User, RouteGroup)
-                .join(Driver, Route_table.c.driver_id == Driver_table.c.driver_id)
-                .join(User, Driver_table.c.user_id == User_table.c.user_id)
-                .join(
-                    RouteGroup,
-                    Route_table.c.route_group_id == RouteGroup_table.c.route_group_id,
-                )
+                .join(RouteGroup, RouteGroup.route_group_id == Route.route_group_id)  # type: ignore[arg-type]
+                .join(Driver, Driver.driver_id == Route.driver_id)  # type: ignore[arg-type]
+                .join(User, User.user_id == Driver.user_id)  # type: ignore[arg-type]
                 .where(
                     and_(
-                        RouteGroup_table.c.drive_date >= start_of_day,
-                        RouteGroup_table.c.drive_date <= end_of_day,
-                        Route_table.c.driver_id.isnot(None),
+                        RouteGroup.drive_date >= start_of_span,  # type: ignore[arg-type]
+                        RouteGroup.drive_date <= end_of_span,  # type: ignore[arg-type]
+                        col(Route.driver_id).isnot(None),
                     )
                 )
-                .order_by(User_table.c.email)
+                .order_by(User.email)
             )
 
             result = await session.execute(statement)
-            upcoming_routes = result.all()
+            upcoming_routes = [
+                row
+                for row in result.all()
+                if row.RouteGroup.drive_date.date() in target_dates
+            ]
 
             if not upcoming_routes:
-                logger.info("No upcoming routes found for tomorrow, skipping reminders")
+                logger.info(
+                    "No upcoming routes found for configured reminder days, "
+                    "skipping emails"
+                )
                 return
 
             sent_count = 0
             failed_count = 0
 
-            # Send reminder email to each driver
             for route, user, route_group in upcoming_routes:
-                recipient_email = user.email
-                driver_name = user.full_name
-                # Combine drive_date (date) with route start_time (time) if present
-                if route.start_time:
-                    route_date = datetime.combine(
-                        route_group.drive_date.date(), route.start_time
-                    )
-                else:
-                    route_date = route_group.drive_date
-                route_distance = route.length
+                # drive_date is a datetime but carries no meaningful time of day
+                # (it is always constructed at midnight); the route's start_time
+                # is the only real clock time, and it is optional.
+                date_only = route_group.drive_date.date().strftime("%A, %B %d, %Y")
+                time_only = (
+                    route.start_time.strftime("%I:%M %p") if route.start_time else "TBD"
+                )
 
-                # Format date, time, and distance for email
-                date_only = route_date.date().strftime("%A, %B %d, %Y")
-                time_only = route_date.time().strftime("%I:%M %p")
-                rounded_distance = str(round(route_distance))
-
-                # Prepare context matching `view-upcoming-route` template placeholders
                 context = {
-                    "Driver_Name_To_Replace": driver_name,
+                    "Driver_Name_To_Replace": user.full_name,
                     "Date_To_Replace": date_only,
                     "Time_To_Replace": time_only,
-                    "Route_Duration_To_Replace": rounded_distance,
-                    "Upcoming_Route_URL": "https://app.example.com/routes",  # Note: update to actual route URL!
+                    "Route_Duration_To_Replace": str(round(route.length)),
+                    "Upcoming_Route_URL": UPCOMING_ROUTE_URL,
                 }
 
                 try:
                     await dispatcher.dispatch(
                         email_type="view-upcoming-route",
-                        to=recipient_email,
+                        to=user.email,
                         context=context,
                     )
                     sent_count += 1
                 except Exception as e:
                     failed_count += 1
                     logger.error(
-                        f"Failed to send route reminder to {recipient_email}: {e!s}",
+                        f"Failed to send route reminder to {user.email}: {e!s}",
                         exc_info=True,
                     )
                     # Continue sending to other drivers even if one fails
@@ -144,109 +130,5 @@ async def send_route_reminders() -> None:
         logger.error(
             f"Failed to process route reminder emails: {error!s}",
             exc_info=True,
-        )
-        raise error
-
-
-async def process_daily_reminder_emails(reminder_days: list[int]) -> None:
-    """Send reminder emails for routes whose drive date falls on ``reminder_days``.
-
-    Emails each driver assigned (via Route.driver_id) to a route whose
-    RouteGroup.drive_date is one of the given lead days ahead of today. The
-    scheduler registers one instance of this job per distinct reminder time (see
-    ``refresh_daily_reminder_email_schedule``), passing the lead days for that time.
-    """
-
-    from app.models import (
-        async_session_maker_instance,  # Placed here to ensure testing file functions as normal
-    )
-
-    logger = get_logger()
-
-    if not reminder_days:
-        logger.info("No reminder lead days configured, skipping emails")
-        return
-
-    if async_session_maker_instance is None:
-        logger.error("Database session maker not initialized")
-        return
-
-    try:
-        async with async_session_maker_instance() as session:
-            target_dates = {date.today() + timedelta(days=day) for day in reminder_days}
-            start_of_day = datetime.combine(min(target_dates), datetime.min.time())
-            end_of_day = datetime.combine(max(target_dates), datetime.max.time())
-            statement = (
-                select(
-                    User.email,
-                    RouteGroup.drive_date,
-                    col(Route.start_time),
-                    Route.length,
-                )
-                .join(RouteGroup, RouteGroup.route_group_id == Route.route_group_id)  # type: ignore[arg-type]
-                .join(Driver, Driver.driver_id == Route.driver_id)  # type: ignore[arg-type]
-                .join(User, User.user_id == Driver.user_id)  # type: ignore[arg-type]
-                .where(
-                    and_(
-                        RouteGroup.drive_date >= start_of_day,  # type: ignore[arg-type]
-                        RouteGroup.drive_date <= end_of_day,  # type: ignore[arg-type]
-                        col(Route.driver_id).isnot(None),
-                    )
-                )
-                .order_by(User.email)
-            )
-
-            result = await session.execute(statement)
-            upcoming_routes = result.all()
-
-            if not upcoming_routes:
-                logger.info(
-                    "No Upcoming Routes found for configured reminder days, skipping emails"
-                )
-                return
-
-            email_service = EmailService(
-                logger,
-                {
-                    "refresh_token": settings.mailer_refresh_token,
-                    "token_uri": "https://oauth2.googleapis.com/token",
-                    "client_id": settings.mailer_client_id,
-                    "client_secret": settings.mailer_client_secret,
-                },
-                settings.mailer_user,
-                "Food4Kids",
-            )
-
-            with open("./app/templates/view-upcoming-route.html") as file:
-                template_html = file.read()
-
-            for row in upcoming_routes:
-                recipient_email = row.email
-                drive_date: datetime = row.drive_date
-                route_distance = row.length
-
-                date_only = drive_date.date().strftime("%A, %B %d, %Y")
-                # Per-route start time if set, else fall back to a sensible default.
-                start_time = row.start_time
-                time_only = start_time.strftime("%I:%M %p") if start_time else "TBD"
-                rounded_distance = str(round(route_distance))
-
-                formatted_email = template_html.replace("Date_To_Replace", date_only)
-                formatted_email = formatted_email.replace("Time_To_Replace", time_only)
-                formatted_email = formatted_email.replace(
-                    "Route_Duration_To_Replace", rounded_distance
-                )
-                logger.info(f"Sending Email to {recipient_email}")
-                email_service.send_email(
-                    to=recipient_email,
-                    subject="Upcoming Route Reminder",
-                    body=formatted_email,
-                )
-
-            logger.info("Successfully sent reminder emails")
-
-    except Exception as error:
-        logger.error(
-            f"Failed to process daily reminder emails: {error!s}", exc_info=True
         )
         raise error

--- a/backend/python/tests/test_email_reminder_jobs.py
+++ b/backend/python/tests/test_email_reminder_jobs.py
@@ -1,5 +1,6 @@
 """Tests for the reminder email scheduled job."""
 
+import re
 from datetime import date, datetime, time, timedelta
 from functools import partial
 from typing import Any, ClassVar
@@ -14,20 +15,53 @@ from app.models.system_settings import EmailReminder, SystemSettings
 from app.models.user import User
 from app.services.jobs import email_jobs, refresh_daily_reminder_email_schedule
 
+# Every name the view-upcoming-route template expects the backend to substitute.
+PLACEHOLDER_NAMES = (
+    "Driver_Name_To_Replace",
+    "Date_To_Replace",
+    "Time_To_Replace",
+    "Route_Duration_To_Replace",
+    "Upcoming_Route_URL",
+)
+
 
 class _FakeEmailService:
-    sent: ClassVar[list[dict[str, str]]] = []
+    """Captures sends in place of the real Gmail-backed EmailService."""
 
-    def __init__(self, *_args: Any, **_kwargs: Any) -> None:
-        pass
+    sent: ClassVar[list[dict[str, str]]] = []
 
     def send_email(self, to: str, subject: str, body: str) -> dict[str, Any]:
         self.sent.append({"to": to, "subject": subject, "body": body})
         return {"to": to, "subject": subject}
 
 
+@pytest.fixture
+def captured_emails(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, str]]:
+    """Route the job's dispatcher through a fake transport and return the outbox.
+
+    The dispatcher itself is real, so these tests exercise the actual Jinja2
+    render -- which is the point: the bug this job had was a rendering bug.
+    """
+    from app.services.implementations.email_dispatcher import EmailDispatcher
+    from app.templates.email_renderer import TemplateRenderer
+
+    _FakeEmailService.sent.clear()
+
+    import logging
+
+    dispatcher = EmailDispatcher(
+        email_service=_FakeEmailService(),  # type: ignore[arg-type]
+        template_renderer=TemplateRenderer(template_dir="./app/templates"),
+        logger=logging.getLogger("test-email-dispatcher"),
+    )
+    monkeypatch.setattr(email_jobs, "get_email_dispatcher", lambda: dispatcher)
+    return _FakeEmailService.sent
+
+
 async def _seed_driver_with_routes(
-    maker: async_sessionmaker[AsyncSession], offsets: tuple[int, ...]
+    maker: async_sessionmaker[AsyncSession],
+    offsets: tuple[int, ...],
+    start_time: time | None = time(9, 30),
 ) -> None:
     """Create one driver assigned to a route on each of the given day offsets."""
     async with maker() as session:
@@ -64,76 +98,228 @@ async def _seed_driver_with_routes(
                     length=offset * 10.0,
                     route_group_id=group.route_group_id,
                     driver_id=driver.driver_id,
+                    start_time=start_time,
                 )
             )
             await session.commit()
 
 
+def _maker(test_db_engine: Any) -> async_sessionmaker[AsyncSession]:
+    return async_sessionmaker(
+        test_db_engine, class_=AsyncSession, expire_on_commit=False
+    )
+
+
 @pytest.mark.asyncio
-async def test_process_daily_reminder_emails_uses_passed_lead_days(
-    test_db_engine: Any, monkeypatch: pytest.MonkeyPatch
+async def test_uses_passed_lead_days(
+    test_db_engine: Any,
+    monkeypatch: pytest.MonkeyPatch,
+    captured_emails: list[dict[str, str]],
 ) -> None:
     """The job emails routes that fall on any of the passed lead days."""
-    maker = async_sessionmaker(
-        test_db_engine, class_=AsyncSession, expire_on_commit=False
-    )
+    maker = _maker(test_db_engine)
     monkeypatch.setattr("app.models.async_session_maker_instance", maker)
-    monkeypatch.setattr(email_jobs, "EmailService", _FakeEmailService)
-    _FakeEmailService.sent.clear()
 
-    # Routes exist 1 and 3 days out; only the passed lead days should be emailed.
     await _seed_driver_with_routes(maker, offsets=(1, 3))
 
-    await email_jobs.process_daily_reminder_emails([1, 3])
+    await email_jobs.send_route_reminders([1, 3])
 
-    assert len(_FakeEmailService.sent) == 2
-    assert {item["to"] for item in _FakeEmailService.sent} == {"driver@test.dev"}
-    assert all(
-        item["subject"] == "Upcoming Route Reminder" for item in _FakeEmailService.sent
-    )
-    assert all(
-        "Date_To_Replace" not in item["body"]
-        and "Time_To_Replace" not in item["body"]
-        and "Route_Duration_To_Replace" not in item["body"]
-        for item in _FakeEmailService.sent
-    )
+    assert len(captured_emails) == 2
+    assert {item["to"] for item in captured_emails} == {"driver@test.dev"}
 
 
 @pytest.mark.asyncio
-async def test_process_daily_reminder_emails_only_targets_given_days(
-    test_db_engine: Any, monkeypatch: pytest.MonkeyPatch
+async def test_only_targets_given_days(
+    test_db_engine: Any,
+    monkeypatch: pytest.MonkeyPatch,
+    captured_emails: list[dict[str, str]],
 ) -> None:
     """A job bound to a single lead day ignores routes on other days."""
-    maker = async_sessionmaker(
-        test_db_engine, class_=AsyncSession, expire_on_commit=False
-    )
+    maker = _maker(test_db_engine)
     monkeypatch.setattr("app.models.async_session_maker_instance", maker)
-    monkeypatch.setattr(email_jobs, "EmailService", _FakeEmailService)
-    _FakeEmailService.sent.clear()
 
     await _seed_driver_with_routes(maker, offsets=(1, 3))
 
-    # Only the same-day-before-by-one lead day; the 3-day-out route must be skipped.
-    await email_jobs.process_daily_reminder_emails([1])
+    await email_jobs.send_route_reminders([1])
 
-    assert len(_FakeEmailService.sent) == 1
+    assert len(captured_emails) == 1
 
 
 @pytest.mark.asyncio
-async def test_process_daily_reminder_emails_noop_without_days(
-    test_db_engine: Any, monkeypatch: pytest.MonkeyPatch
+async def test_skips_days_inside_the_span_but_not_requested(
+    test_db_engine: Any,
+    monkeypatch: pytest.MonkeyPatch,
+    captured_emails: list[dict[str, str]],
+) -> None:
+    """Non-contiguous lead days do not sweep up the days between them.
+
+    Lead days 1 and 3 span a range that also contains day 2. Filtering on the
+    span alone would email the day-2 driver, who asked for no such reminder.
+    """
+    maker = _maker(test_db_engine)
+    monkeypatch.setattr("app.models.async_session_maker_instance", maker)
+
+    await _seed_driver_with_routes(maker, offsets=(1, 2, 3))
+
+    await email_jobs.send_route_reminders([1, 3])
+
+    assert len(captured_emails) == 2
+    day_two = (date.today() + timedelta(days=2)).strftime("%A, %B %d, %Y")
+    assert not any(day_two in item["body"] for item in captured_emails)
+
+
+@pytest.mark.asyncio
+async def test_lead_day_zero_targets_today(
+    test_db_engine: Any,
+    monkeypatch: pytest.MonkeyPatch,
+    captured_emails: list[dict[str, str]],
+) -> None:
+    """A lead day of 0 means routes driving today, not an empty selection."""
+    maker = _maker(test_db_engine)
+    monkeypatch.setattr("app.models.async_session_maker_instance", maker)
+
+    await _seed_driver_with_routes(maker, offsets=(0, 1))
+
+    await email_jobs.send_route_reminders([0])
+
+    assert len(captured_emails) == 1
+    assert date.today().strftime("%A, %B %d, %Y") in captured_emails[0]["body"]
+
+
+@pytest.mark.asyncio
+async def test_noop_without_days(
+    test_db_engine: Any,
+    monkeypatch: pytest.MonkeyPatch,
+    captured_emails: list[dict[str, str]],
 ) -> None:
     """An empty lead-day list sends nothing rather than erroring."""
-    maker = async_sessionmaker(
-        test_db_engine, class_=AsyncSession, expire_on_commit=False
-    )
+    maker = _maker(test_db_engine)
     monkeypatch.setattr("app.models.async_session_maker_instance", maker)
-    monkeypatch.setattr(email_jobs, "EmailService", _FakeEmailService)
-    _FakeEmailService.sent.clear()
 
-    await email_jobs.process_daily_reminder_emails([])
+    await email_jobs.send_route_reminders([])
 
-    assert _FakeEmailService.sent == []
+    assert captured_emails == []
+
+
+@pytest.mark.asyncio
+async def test_unassigned_routes_are_not_emailed(
+    test_db_engine: Any,
+    monkeypatch: pytest.MonkeyPatch,
+    captured_emails: list[dict[str, str]],
+) -> None:
+    """A route with no driver has nobody to remind."""
+    maker = _maker(test_db_engine)
+    monkeypatch.setattr("app.models.async_session_maker_instance", maker)
+
+    async with maker() as session:
+        group = RouteGroup(
+            name="Unassigned",
+            drive_date=datetime.combine(
+                date.today() + timedelta(days=1), datetime.min.time()
+            ),
+        )
+        session.add(group)
+        await session.commit()
+        await session.refresh(group)
+        session.add(
+            Route(
+                name="R-unassigned",
+                length=10.0,
+                route_group_id=group.route_group_id,
+                driver_id=None,
+            )
+        )
+        await session.commit()
+
+    await email_jobs.send_route_reminders([1])
+
+    assert captured_emails == []
+
+
+@pytest.mark.asyncio
+async def test_rendered_body_has_no_leftover_placeholders(
+    test_db_engine: Any,
+    monkeypatch: pytest.MonkeyPatch,
+    captured_emails: list[dict[str, str]],
+) -> None:
+    """Every placeholder is substituted -- no bare names, no leftover braces.
+
+    This is the regression that shipped: the job used to str.replace bare
+    identifiers against a template whose placeholders were Jinja2 `{{ Name }}`,
+    so recipients saw `{{ Friday, ... }}` and an unsubstituted greeting.
+    """
+    maker = _maker(test_db_engine)
+    monkeypatch.setattr("app.models.async_session_maker_instance", maker)
+
+    await _seed_driver_with_routes(maker, offsets=(1,))
+
+    await email_jobs.send_route_reminders([1])
+
+    assert len(captured_emails) == 1
+    body = captured_emails[0]["body"]
+
+    for name in PLACEHOLDER_NAMES:
+        assert name not in body, f"{name} was never substituted"
+    assert not re.search(r"\{\{|\}\}", body), "Jinja2 delimiters survived rendering"
+
+    # And the real values actually landed.
+    assert "Test Driver" in body
+    assert (date.today() + timedelta(days=1)).strftime("%A, %B %d, %Y") in body
+    assert "09:30 AM" in body
+    assert email_jobs.UPCOMING_ROUTE_URL in body
+
+
+@pytest.mark.asyncio
+async def test_missing_start_time_renders_tbd(
+    test_db_engine: Any,
+    monkeypatch: pytest.MonkeyPatch,
+    captured_emails: list[dict[str, str]],
+) -> None:
+    """A route with no start time says TBD rather than inventing a clock time.
+
+    RouteGroup.drive_date is a datetime but is always built at midnight, so
+    falling back to its time component would tell the driver 12:00 AM.
+    """
+    maker = _maker(test_db_engine)
+    monkeypatch.setattr("app.models.async_session_maker_instance", maker)
+
+    await _seed_driver_with_routes(maker, offsets=(1,), start_time=None)
+
+    await email_jobs.send_route_reminders([1])
+
+    assert len(captured_emails) == 1
+    body = captured_emails[0]["body"]
+    assert "TBD" in body
+    assert "12:00 AM" not in body
+
+
+@pytest.mark.asyncio
+async def test_one_failure_does_not_stop_the_rest(
+    test_db_engine: Any,
+    monkeypatch: pytest.MonkeyPatch,
+    captured_emails: list[dict[str, str]],
+) -> None:
+    """A send that raises is logged and the remaining drivers still get theirs."""
+    maker = _maker(test_db_engine)
+    monkeypatch.setattr("app.models.async_session_maker_instance", maker)
+
+    await _seed_driver_with_routes(maker, offsets=(1, 3))
+
+    calls = {"n": 0}
+    real_send = _FakeEmailService.send_email
+
+    def flaky(self: Any, to: str, subject: str, body: str) -> dict[str, Any]:
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise RuntimeError("SMTP exploded")
+        return real_send(self, to=to, subject=subject, body=body)
+
+    monkeypatch.setattr(_FakeEmailService, "send_email", flaky)
+
+    await email_jobs.send_route_reminders([1, 3])
+
+    assert calls["n"] == 2
+    assert len(captured_emails) == 1
 
 
 class _FakeScheduler:
@@ -174,9 +360,7 @@ async def test_refresh_schedules_one_job_per_distinct_time(
     test_db_engine: Any,
 ) -> None:
     """Each distinct reminder time becomes its own cron job, bound to its lead days."""
-    maker = async_sessionmaker(
-        test_db_engine, class_=AsyncSession, expire_on_commit=False
-    )
+    maker = _maker(test_db_engine)
     async with maker() as session:
         session.add(
             SystemSettings(
@@ -216,13 +400,24 @@ async def test_refresh_schedules_one_job_per_distinct_time(
 
 
 @pytest.mark.asyncio
+async def test_refresh_binds_the_dispatcher_backed_job(test_db_engine: Any) -> None:
+    """The scheduled callable is send_route_reminders, not a stale rendering path."""
+    maker = _maker(test_db_engine)
+    scheduler = _FakeScheduler()
+    async with maker() as session:
+        await refresh_daily_reminder_email_schedule(scheduler, session)
+
+    job = scheduler.jobs["daily_reminder_emails_0900"]["func"]
+    assert isinstance(job, partial)
+    assert job.func is email_jobs.send_route_reminders
+
+
+@pytest.mark.asyncio
 async def test_refresh_groups_shared_time_into_one_job(
     test_db_engine: Any,
 ) -> None:
     """Reminders sharing a time collapse into a single job covering both lead days."""
-    maker = async_sessionmaker(
-        test_db_engine, class_=AsyncSession, expire_on_commit=False
-    )
+    maker = _maker(test_db_engine)
     async with maker() as session:
         session.add(
             SystemSettings(
@@ -249,9 +444,7 @@ async def test_refresh_falls_back_to_default_when_unset(
     test_db_engine: Any,
 ) -> None:
     """With no settings row, the default 9 AM day-before reminder is scheduled."""
-    maker = async_sessionmaker(
-        test_db_engine, class_=AsyncSession, expire_on_commit=False
-    )
+    maker = _maker(test_db_engine)
     scheduler = _FakeScheduler()
     async with maker() as session:
         await refresh_daily_reminder_email_schedule(scheduler, session)


### PR DESCRIPTION
Follow-up to #224. That PR fixed the export that *creates* the `{{ }}` placeholders; this one fixes a consumer that was never updated to read them.

## The bug (live on `main`)

`process_daily_reminder_emails` opened `view-upcoming-route.html` raw and did `template_html.replace("Date_To_Replace", date_only)`. The template's placeholders are Jinja2 `{{ Date_To_Replace }}`, so the replace matched only the inner name and left the braces:

> **Date:** {{ Friday, July 31, 2026 }}

`Driver_Name_To_Replace` and `Upcoming_Route_URL` were never substituted at all, so the email opened `Hi {{ Driver_Name_To_Replace }},` with its CTA pointing at `{{ Upcoming_Route_URL }}`.

It was registered *alongside* the correct dispatcher-based `send_route_reminders`, and `DEFAULT_EMAIL_REMINDERS` is `days_before=1` — the same drivers the 07:00 job already emailed. **A driver with a route tomorrow got two emails: a good one at 07:00 and a broken one at 09:00.**

## How we ended up with two

- **#69** (`c5c2ead0`) wrote the `str.replace` path against `route_reminder.html`, which had **bare identifiers**. Correct at the time.
- **#142** (`d6044994`) added Jinja2 + `EmailDispatcher` + `send_route_reminders`, rewrote the templates with `{{ }}`, and **correctly unregistered** the legacy function — leaving it dead code.
- **#161** (`10e923d9`) built configurable reminder scheduling from system settings and wired it to **the dead function** rather than the dispatcher, presumably because it already accepted a days argument. That revived the stale rendering path against now-Jinja templates.

## The fix

Not a straight delete — `email_reminders` is a persisted, API-updatable setting and only the legacy job honored it. So this keeps #161's feature and #142's rendering:

- `send_route_reminders` now takes `reminder_days: list[int]` and dispatches through `EmailDispatcher`.
- The settings-driven schedule is the **only** registration. The hardcoded 07:00 job is gone, so a configured reminder no longer duplicates it.
- Dropped the `cast("Table", cast("Any", Route).__table__)` gymnastics in favour of plain SQLModel joins.

## Two more bugs found while porting

**Non-contiguous lead days swept up the days between them.** The filter was a `min..max` range, so lead days `[1, 3]` also emailed day-2 drivers, who had configured no such reminder. It survived because the only multi-day test used offsets `(1, 3)` with no day-2 route to catch it. Now matched on exact dates.

**A route with no `start_time` rendered "12:00 AM".** This one is in `send_route_reminders`, so it would have been *introduced* by consolidating naively. `RouteGroup.drive_date` is typed `datetime` but is always built at midnight (`datetime.combine(date, datetime.min.time())`), and is compared as a date everywhere else — so falling back to its time component tells the driver their route starts at midnight. Kept the legacy `"TBD"`, which is the one point where the old code was right.

## Behaviour change to note

The subject line is now the template default from `email_config.py` (`"View Your Upcoming F4K Route"`) rather than the legacy `"Upcoming Route Reminder"`. The dispatcher-based job already behaved this way; this keeps subjects defined in one place. Easy to override in `dispatch(subject=...)` if you prefer the old wording.

`Upcoming_Route_URL` is still the `https://app.example.com/routes` placeholder, now a named constant — left as-is since there is no deployment to link at yet.

## Tests

Rewritten against the surviving job. They drive a **real** `EmailDispatcher` over a fake transport, so the actual Jinja2 render is exercised — the bug here was a rendering bug, and the old tests missed it precisely because they asserted `"Date_To_Replace" not in body`, which passed while the braces and the unreplaced greeting sailed through.

New coverage: the span leak, lead day 0, unassigned routes, per-driver failure isolation, the `"TBD"` fallback, and a body assertion that no placeholder name and no `{{` survives rendering.

Both regression tests were verified to fail against the old behaviour: restoring the range-only query fails `test_skips_days_inside_the_span_but_not_requested`, and restoring the `drive_date` fallback fails `test_missing_start_time_renders_tbd`.

`ruff check`, `ruff format --check`, and `mypy .` (126 files) all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)