### PR TITLE
Enforce that an assigned route has a start time

### DIFF
--- a/backend/python/app/models/route.py
+++ b/backend/python/app/models/route.py
@@ -2,11 +2,15 @@ from datetime import datetime, time
 from typing import TYPE_CHECKING, Optional
 from uuid import UUID, uuid4
 
-from sqlalchemy import Column, DateTime, Text
+from sqlalchemy import CheckConstraint, Column, DateTime, Text
 from sqlmodel import Field, Relationship, SQLModel
 
 from .base import BaseModel
 from .route_stop import RouteStopDetailRead
+
+# Named so the migration, the model, and the error-handling paths all refer to
+# the same constraint rather than repeating the string.
+ASSIGNED_ROUTE_HAS_START_TIME_CONSTRAINT = "ck_routes_assigned_route_has_start_time"
 
 if TYPE_CHECKING:
     from .driver import Driver
@@ -75,6 +79,17 @@ class Route(RouteBase, BaseModel, table=True):
     """Database table model for Routes"""
 
     __tablename__ = "routes"
+    __table_args__ = (
+        # An assigned route is a scheduled route: the driver has to be told
+        # when to show up. Unassigned routes may still be unscheduled, so the
+        # constraint only bites once driver_id is set. Declared on the model
+        # (not just in the migration) so metadata-created test databases carry
+        # it too.
+        CheckConstraint(
+            "driver_id IS NULL OR start_time IS NOT NULL",
+            name=ASSIGNED_ROUTE_HAS_START_TIME_CONSTRAINT,
+        ),
+    )
 
     route_id: UUID = Field(default_factory=uuid4, primary_key=True, nullable=False)
 

--- a/backend/python/app/seed_database.py
+++ b/backend/python/app/seed_database.py
@@ -198,6 +198,10 @@ DEFAULT_CAP_MAX = 20
 # Time constants
 # Default route start time (HH:MM:SS format)
 ROUTE_START_TIME = "08:00:00"
+ROUTE_START_TIME_OF_DAY = time(8, 0, 0)
+# Drivers are released in waves rather than all at once, so each route in a
+# group starts this many minutes after the previous one.
+ROUTE_START_STAGGER_MINUTES = 15
 
 # Location group schedule: group name -> (weekday, alternating slot).
 # weekday is Monday=0 .. Sunday=6. Groups sharing a weekday are suffixed
@@ -514,12 +518,23 @@ def materialize_route_for_group(
         else None
     )
 
+    # An assigned route must carry a start time (enforced by a CHECK
+    # constraint). Drivers leave in waves, so stagger each route in the group
+    # off the standard start; an unassigned route stays unscheduled.
+    start_time: time | None = None
+    if driver_id is not None:
+        start_time = (
+            datetime.combine(date.min, ROUTE_START_TIME_OF_DAY)
+            + timedelta(minutes=ROUTE_START_STAGGER_MINUTES * plan.cluster_idx)
+        ).time()
+
     route = Route(
         name=f"Route {plan.cluster_idx + 1}",
         notes=fake.sentence() if random.random() < PROBABILITY_ROUTE_NOTES else "",
         length=plan.length_km,
         route_group_id=route_group.route_group_id,
         driver_id=driver_id,
+        start_time=start_time,
     )
     set_timestamps(route)
     session.add(route)

--- a/backend/python/app/services/implementations/route_service.py
+++ b/backend/python/app/services/implementations/route_service.py
@@ -453,13 +453,25 @@ class RouteService:
             if patch.notes is not None:
                 route.notes = patch.notes
             # driver_id and start_time are nullable, so an explicit null means
-            # "clear it" (unassign / unschedule) — they typically travel
-            # together. Use model_fields_set to tell an explicit null apart
-            # from an omitted field (both are None on the model).
+            # "clear it" (unassign / unschedule) — they travel together. Use
+            # model_fields_set to tell an explicit null apart from an omitted
+            # field (both are None on the model).
             if "driver_id" in patch.model_fields_set:
                 route.driver_id = patch.driver_id
             if "start_time" in patch.model_fields_set:
                 route.start_time = patch.start_time
+
+            # Enforce the assigned-route invariant here rather than letting the
+            # DB CHECK constraint surface as a 500. Evaluated on the merged
+            # state, so it catches assigning a driver to a route that has no
+            # start time just as well as clearing the start time of a route
+            # that already has one.
+            if route.driver_id is not None and route.start_time is None:
+                raise ValueError(
+                    "An assigned route must have a start_time; "
+                    "set start_time in the same request, or clear driver_id "
+                    "to leave the route unassigned."
+                )
 
             # Update stops + re-run routing if location_ids provided
             if patch.location_ids is not None:

--- a/backend/python/app/services/jobs/email_jobs.py
+++ b/backend/python/app/services/jobs/email_jobs.py
@@ -13,7 +13,7 @@ from sqlmodel import col, select
 
 from app.dependencies.services import get_email_dispatcher, get_logger
 from app.models.driver import Driver
-from app.models.route import Route
+from app.models.route import ASSIGNED_ROUTE_HAS_START_TIME_CONSTRAINT, Route
 from app.models.route_group import RouteGroup
 from app.models.user import User
 
@@ -91,27 +91,32 @@ async def send_route_reminders(reminder_days: list[int]) -> None:
             failed_count = 0
 
             for route, user, route_group in upcoming_routes:
-                # drive_date is a datetime but carries no meaningful time of day
-                # (it is always constructed at midnight); the route's start_time
-                # is the only real clock time, and it is optional.
-                date_only = route_group.drive_date.date().strftime("%A, %B %d, %Y")
-                time_only = (
-                    route.start_time.strftime("%I:%M %p") if route.start_time else "TBD"
-                )
-
-                context = {
-                    "Driver_Name_To_Replace": user.full_name,
-                    "Date_To_Replace": date_only,
-                    "Time_To_Replace": time_only,
-                    "Route_Duration_To_Replace": str(round(route.length)),
-                    "Upcoming_Route_URL": UPCOMING_ROUTE_URL,
-                }
-
                 try:
+                    # drive_date is a datetime but carries no meaningful time of
+                    # day (it is always built at midnight), so start_time is the
+                    # only real clock time. Every route here is assigned, and an
+                    # assigned route is guaranteed a start_time by a CHECK
+                    # constraint -- so a null one means the database drifted from
+                    # its own schema, and inventing a time would hide that.
+                    if route.start_time is None:
+                        raise ValueError(
+                            f"Route {route.route_id} is assigned to a driver but "
+                            f"has no start_time, violating "
+                            f"{ASSIGNED_ROUTE_HAS_START_TIME_CONSTRAINT}"
+                        )
+
                     await dispatcher.dispatch(
                         email_type="view-upcoming-route",
                         to=user.email,
-                        context=context,
+                        context={
+                            "Driver_Name_To_Replace": user.full_name,
+                            "Date_To_Replace": route_group.drive_date.date().strftime(
+                                "%A, %B %d, %Y"
+                            ),
+                            "Time_To_Replace": route.start_time.strftime("%I:%M %p"),
+                            "Route_Duration_To_Replace": str(round(route.length)),
+                            "Upcoming_Route_URL": UPCOMING_ROUTE_URL,
+                        },
                     )
                     sent_count += 1
                 except Exception as e:

--- a/backend/python/migrations/versions/a4c81f2d9b37_assigned_route_requires_start_time.py
+++ b/backend/python/migrations/versions/a4c81f2d9b37_assigned_route_requires_start_time.py
@@ -1,0 +1,60 @@
+"""An assigned route must have a start time
+
+Adds a CHECK constraint enforcing that routes.driver_id can only be set when
+routes.start_time is also set. An assigned route is a scheduled route -- the
+driver has to be told when to show up -- and the reminder email had been
+papering over the gap with a "TBD" placeholder.
+
+Unassigned routes are left alone: a route can legitimately exist before it is
+scheduled, so the constraint only bites once a driver is attached.
+
+Revision ID: a4c81f2d9b37
+Revises: c9a1e5f30b74
+Create Date: 2026-07-28 00:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "a4c81f2d9b37"
+down_revision = "c9a1e5f30b74"
+branch_labels = None
+depends_on = None
+
+CONSTRAINT_NAME = "ck_routes_assigned_route_has_start_time"
+
+# Matches the seed generator's standard start; only ever applied to rows that
+# are already violating the invariant.
+FALLBACK_START_TIME = "08:00:00"
+
+
+def upgrade():
+    # Existing databases are development/seed data only -- there is no
+    # production deployment -- and the old seed generator assigned drivers
+    # without ever setting a start time. Give those rows the standard start
+    # rather than failing the migration and forcing a re-seed.
+    connection = op.get_bind()
+    backfilled = connection.execute(
+        sa.text(
+            "UPDATE routes SET start_time = :fallback "
+            "WHERE driver_id IS NOT NULL AND start_time IS NULL"
+        ),
+        {"fallback": FALLBACK_START_TIME},
+    ).rowcount
+    if backfilled:
+        print(
+            f"assigned-route start_time backfill: set {backfilled} row(s) "
+            f"to {FALLBACK_START_TIME}"
+        )
+
+    op.create_check_constraint(
+        CONSTRAINT_NAME,
+        "routes",
+        "driver_id IS NULL OR start_time IS NOT NULL",
+    )
+
+
+def downgrade():
+    op.drop_constraint(CONSTRAINT_NAME, "routes", type_="check")

--- a/backend/python/tests/test_auth_integration.py
+++ b/backend/python/tests/test_auth_integration.py
@@ -26,7 +26,7 @@ registry. ``path`` matches FastAPI's templated path exactly (e.g.
 
 import re
 from collections.abc import AsyncGenerator, Iterator
-from datetime import datetime
+from datetime import datetime, time
 from enum import Enum
 from types import SimpleNamespace
 from typing import Any
@@ -325,6 +325,7 @@ async def seed(test_session: AsyncSession) -> Seed:
         length=10.0,
         route_group_id=route_group.route_group_id,
         driver_id=self_driver.driver_id,
+        start_time=time(8, 0),
     )
     location = Location(
         location_group_id=location_group.location_group_id,
@@ -528,6 +529,7 @@ async def scoping_routes(test_session: AsyncSession, seed: Seed) -> dict[str, An
         length=4.0,
         route_group_id=seed.route_group_id,
         driver_id=seed.other_driver_id,
+        start_time=time(8, 0),
     )
     unassigned_route = Route(
         name="Unassigned Route",

--- a/backend/python/tests/test_driver_delete.py
+++ b/backend/python/tests/test_driver_delete.py
@@ -7,6 +7,7 @@ reset. See the `delete_driver` docstring for what the endpoint removes, what it
 deliberately keeps, and why the Firebase delete happens before the DB commit.
 """
 
+from datetime import time
 from typing import Any
 from unittest.mock import AsyncMock, patch
 from uuid import UUID, uuid4
@@ -449,6 +450,9 @@ async def test_routes_are_detached_not_deleted(
     route survives unassigned (`driver_id SET NULL`)."""
     driver_json = await _initialize_driver(async_client)
     test_route.driver_id = UUID(driver_json["driver_id"])
+    # Assigning a driver means the route is scheduled (ck_routes_assigned_
+    # route_has_start_time), so the start time has to travel with it.
+    test_route.start_time = time(8, 0)
     await test_session.commit()
 
     with patch("firebase_admin.auth.delete_user"):

--- a/backend/python/tests/test_email_reminder_jobs.py
+++ b/backend/python/tests/test_email_reminder_jobs.py
@@ -6,10 +6,11 @@ from functools import partial
 from typing import Any, ClassVar
 
 import pytest
+from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from app.models.driver import Driver
-from app.models.route import Route
+from app.models.route import ASSIGNED_ROUTE_HAS_START_TIME_CONSTRAINT, Route
 from app.models.route_group import RouteGroup
 from app.models.system_settings import EmailReminder, SystemSettings
 from app.models.user import User
@@ -61,7 +62,7 @@ def captured_emails(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, str]]:
 async def _seed_driver_with_routes(
     maker: async_sessionmaker[AsyncSession],
     offsets: tuple[int, ...],
-    start_time: time | None = time(9, 30),
+    start_time: time = time(9, 30),
 ) -> None:
     """Create one driver assigned to a route on each of the given day offsets."""
     async with maker() as session:
@@ -270,27 +271,36 @@ async def test_rendered_body_has_no_leftover_placeholders(
 
 
 @pytest.mark.asyncio
-async def test_missing_start_time_renders_tbd(
+async def test_assigned_route_without_start_time_is_not_emailed(
     test_db_engine: Any,
     monkeypatch: pytest.MonkeyPatch,
     captured_emails: list[dict[str, str]],
 ) -> None:
-    """A route with no start time says TBD rather than inventing a clock time.
+    """An assigned route with no start time fails loudly instead of guessing.
 
-    RouteGroup.drive_date is a datetime but is always built at midnight, so
-    falling back to its time component would tell the driver 12:00 AM.
+    The CHECK constraint makes this state unreachable through the app, so
+    reaching it means the database drifted from its schema. Inventing a time
+    (RouteGroup.drive_date is always midnight, so the obvious fallback renders
+    "12:00 AM") would quietly tell a driver the wrong thing.
     """
     maker = _maker(test_db_engine)
     monkeypatch.setattr("app.models.async_session_maker_instance", maker)
 
-    await _seed_driver_with_routes(maker, offsets=(1,), start_time=None)
+    # Insert past the ORM's constraint so we can exercise the guard at all.
+    await _seed_driver_with_routes(maker, offsets=(1,))
+    async with maker() as session:
+        await session.execute(
+            text(
+                "ALTER TABLE routes DROP CONSTRAINT "
+                f"{ASSIGNED_ROUTE_HAS_START_TIME_CONSTRAINT}"
+            )
+        )
+        await session.execute(text("UPDATE routes SET start_time = NULL"))
+        await session.commit()
 
     await email_jobs.send_route_reminders([1])
 
-    assert len(captured_emails) == 1
-    body = captured_emails[0]["body"]
-    assert "TBD" in body
-    assert "12:00 AM" not in body
+    assert captured_emails == []
 
 
 @pytest.mark.asyncio

--- a/backend/python/tests/test_mileage_derived.py
+++ b/backend/python/tests/test_mileage_derived.py
@@ -8,7 +8,7 @@ history automatically and can never drift.
 """
 
 import logging
-from datetime import date, datetime, timedelta
+from datetime import date, datetime, time, timedelta
 from typing import Any
 from unittest.mock import patch
 from uuid import UUID, uuid4
@@ -70,6 +70,7 @@ async def _add_frozen_route(
         length=km,
         route_group_id=rg.route_group_id,
         driver_id=driver_id,
+        start_time=time(8, 0),
     )
     session.add(route)
     await session.commit()
@@ -201,12 +202,14 @@ async def frozen_world(test_session: AsyncSession) -> dict[str, Any]:
         length=FROZEN_KM,
         route_group_id=rg.route_group_id,
         driver_id=driver_a.driver_id,
+        start_time=time(8, 0),
     )
     future_route = Route(
         name="R-future",
         length=99.0,
         route_group_id=future_rg.route_group_id,
         driver_id=driver_a.driver_id,
+        start_time=time(8, 0),
     )
     test_session.add_all([route, future_route])
     await test_session.commit()

--- a/backend/python/tests/test_route_assigned_start_time.py
+++ b/backend/python/tests/test_route_assigned_start_time.py
@@ -1,0 +1,273 @@
+"""The assigned-route invariant: driver_id set implies start_time set.
+
+An assigned route is a scheduled route -- the driver has to be told when to
+show up. Enforced twice on purpose: a CHECK constraint so no write path can
+get around it, and a service-layer check so a client sees a 400 instead of the
+database raising a 500 at them.
+"""
+
+from datetime import date, datetime, time, timedelta
+from typing import Any
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.driver import Driver
+from app.models.route import (
+    ASSIGNED_ROUTE_HAS_START_TIME_CONSTRAINT,
+    Route,
+    RoutePatchRequest,
+)
+from app.models.route_group import RouteGroup
+from app.models.user import User
+from app.services.implementations.route_service import RouteService
+
+
+async def _make_driver(session: AsyncSession) -> Driver:
+    user = User(
+        first_name="Assigned",
+        last_name="Driver",
+        email=f"driver-{uuid4().hex[:8]}@test.dev",
+        auth_id=f"uid-{uuid4().hex[:8]}",
+    )
+    driver = Driver(
+        user_id=user.user_id,
+        phone="+12125551234",
+        address="1 Depot Rd",
+        license_plate="DRV1",
+        car_make_model="Toyota Corolla",
+    )
+    session.add_all([user, driver])
+    await session.commit()
+    await session.refresh(driver)
+    return driver
+
+
+async def _make_route_group(session: AsyncSession) -> RouteGroup:
+    group = RouteGroup(
+        name=f"Group {uuid4().hex[:6]}",
+        drive_date=datetime.combine(
+            date.today() + timedelta(days=1), datetime.min.time()
+        ),
+    )
+    session.add(group)
+    await session.commit()
+    await session.refresh(group)
+    return group
+
+
+# --------------------------------------------------------------------------
+# Database constraint
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_constraint_rejects_assigned_route_without_start_time(
+    test_session: AsyncSession,
+) -> None:
+    """The database refuses an assigned route that has no start time."""
+    driver = await _make_driver(test_session)
+    group = await _make_route_group(test_session)
+
+    test_session.add(
+        Route(
+            name="R1",
+            length=10.0,
+            route_group_id=group.route_group_id,
+            driver_id=driver.driver_id,
+            start_time=None,
+        )
+    )
+
+    with pytest.raises(IntegrityError) as excinfo:
+        await test_session.commit()
+    assert ASSIGNED_ROUTE_HAS_START_TIME_CONSTRAINT in str(excinfo.value)
+    await test_session.rollback()
+
+
+@pytest.mark.asyncio
+async def test_constraint_allows_unassigned_route_without_start_time(
+    test_session: AsyncSession,
+) -> None:
+    """An unscheduled, unassigned route is still legal."""
+    group = await _make_route_group(test_session)
+
+    test_session.add(
+        Route(
+            name="R-unassigned",
+            length=10.0,
+            route_group_id=group.route_group_id,
+            driver_id=None,
+            start_time=None,
+        )
+    )
+    await test_session.commit()  # must not raise
+
+
+@pytest.mark.asyncio
+async def test_constraint_allows_unassigned_route_with_start_time(
+    test_session: AsyncSession,
+) -> None:
+    """A route may be scheduled before anyone is assigned to it."""
+    group = await _make_route_group(test_session)
+
+    test_session.add(
+        Route(
+            name="R-scheduled",
+            length=10.0,
+            route_group_id=group.route_group_id,
+            driver_id=None,
+            start_time=time(8, 0),
+        )
+    )
+    await test_session.commit()  # must not raise
+
+
+@pytest.mark.asyncio
+async def test_constraint_allows_assigned_route_with_start_time(
+    test_session: AsyncSession,
+) -> None:
+    """The ordinary case still works."""
+    driver = await _make_driver(test_session)
+    group = await _make_route_group(test_session)
+
+    test_session.add(
+        Route(
+            name="R-ok",
+            length=10.0,
+            route_group_id=group.route_group_id,
+            driver_id=driver.driver_id,
+            start_time=time(8, 15),
+        )
+    )
+    await test_session.commit()  # must not raise
+
+
+# --------------------------------------------------------------------------
+# Service-layer validation (so clients get a 400, not a 500)
+# --------------------------------------------------------------------------
+
+
+async def _route(
+    session: AsyncSession, *, driver: Driver | None, start_time: time | None
+) -> Route:
+    group = await _make_route_group(session)
+    route = Route(
+        name="R",
+        length=10.0,
+        route_group_id=group.route_group_id,
+        driver_id=driver.driver_id if driver else None,
+        start_time=start_time,
+    )
+    session.add(route)
+    await session.commit()
+    await session.refresh(route)
+    return route
+
+
+@pytest.mark.asyncio
+async def test_patch_rejects_assigning_driver_without_start_time(
+    test_session: AsyncSession,
+) -> None:
+    """Assigning a driver to an unscheduled route is a client error."""
+    driver = await _make_driver(test_session)
+    route = await _route(test_session, driver=None, start_time=None)
+
+    with pytest.raises(ValueError, match="must have a start_time"):
+        await RouteService(logger=_logger()).update_route(
+            test_session, route.route_id, RoutePatchRequest(driver_id=driver.driver_id)
+        )
+
+
+@pytest.mark.asyncio
+async def test_patch_rejects_clearing_start_time_of_assigned_route(
+    test_session: AsyncSession,
+) -> None:
+    """Unscheduling a route without unassigning it is a client error."""
+    driver = await _make_driver(test_session)
+    route = await _route(test_session, driver=driver, start_time=time(8, 0))
+
+    with pytest.raises(ValueError, match="must have a start_time"):
+        await RouteService(logger=_logger()).update_route(
+            test_session, route.route_id, RoutePatchRequest(start_time=None)
+        )
+
+
+@pytest.mark.asyncio
+async def test_patch_allows_assigning_driver_and_start_time_together(
+    test_session: AsyncSession,
+) -> None:
+    """The two fields travel together, which is the supported way to schedule."""
+    driver = await _make_driver(test_session)
+    route = await _route(test_session, driver=None, start_time=None)
+
+    updated = await RouteService(logger=_logger()).update_route(
+        test_session,
+        route.route_id,
+        RoutePatchRequest(driver_id=driver.driver_id, start_time=time(8, 30)),
+    )
+
+    assert updated is not None
+    assert updated.driver_id == driver.driver_id
+    assert updated.start_time == time(8, 30)
+
+
+@pytest.mark.asyncio
+async def test_patch_allows_unassigning_and_clearing_together(
+    test_session: AsyncSession,
+) -> None:
+    """Clearing both at once returns the route to unassigned + unscheduled."""
+    driver = await _make_driver(test_session)
+    route = await _route(test_session, driver=driver, start_time=time(8, 0))
+
+    updated = await RouteService(logger=_logger()).update_route(
+        test_session,
+        route.route_id,
+        RoutePatchRequest(driver_id=None, start_time=None),
+    )
+
+    assert updated is not None
+    assert updated.driver_id is None
+    assert updated.start_time is None
+
+
+@pytest.mark.asyncio
+async def test_patch_allows_unassigning_while_keeping_start_time(
+    test_session: AsyncSession,
+) -> None:
+    """A route may keep its schedule after the driver drops off it."""
+    driver = await _make_driver(test_session)
+    route = await _route(test_session, driver=driver, start_time=time(8, 0))
+
+    updated = await RouteService(logger=_logger()).update_route(
+        test_session, route.route_id, RoutePatchRequest(driver_id=None)
+    )
+
+    assert updated is not None
+    assert updated.driver_id is None
+    assert updated.start_time == time(8, 0)
+
+
+@pytest.mark.asyncio
+async def test_patch_unrelated_field_on_assigned_route_still_works(
+    test_session: AsyncSession,
+) -> None:
+    """The check reads merged state, so it must not fire on an untouched route."""
+    driver = await _make_driver(test_session)
+    route = await _route(test_session, driver=driver, start_time=time(8, 0))
+
+    updated = await RouteService(logger=_logger()).update_route(
+        test_session, route.route_id, RoutePatchRequest(name="Renamed")
+    )
+
+    assert updated is not None
+    assert updated.name == "Renamed"
+    assert updated.start_time == time(8, 0)
+
+
+def _logger() -> Any:
+    import logging
+
+    return logging.getLogger("test-route-service")

--- a/backend/python/tests/test_route_freeze_jobs.py
+++ b/backend/python/tests/test_route_freeze_jobs.py
@@ -7,7 +7,7 @@ global at the test engine (monkeypatch) and seed committed rows the job's
 separate sessions can see.
 """
 
-from datetime import date, datetime, timedelta, timezone
+from datetime import date, datetime, time, timedelta, timezone
 from typing import Any
 from zoneinfo import ZoneInfo
 
@@ -114,6 +114,7 @@ async def _seed(
             length=ROUTE_KM,
             route_group_id=rg.route_group_id,
             driver_id=driver.driver_id if assign_driver else None,
+            start_time=time(8, 0),
         )
         s.add(route)
         await s.commit()

--- a/backend/python/tests/test_routes.py
+++ b/backend/python/tests/test_routes.py
@@ -10,7 +10,7 @@ Tests cover:
 """
 
 import json
-from datetime import date, datetime, timedelta, timezone
+from datetime import date, datetime, time, timedelta, timezone
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import UUID, uuid4
@@ -2578,6 +2578,7 @@ class TestRouteRoutes:
             length=1.0,
             route_group_id=test_route_group.route_group_id,
             driver_id=test_driver.driver_id,
+            start_time=time(8, 0),
         )
         unassigned = Route(
             name="Unassigned Route",
@@ -2615,6 +2616,7 @@ class TestRouteRoutes:
             length=1.0,
             route_group_id=test_route_group.route_group_id,
             driver_id=test_driver.driver_id,
+            start_time=time(8, 0),
         )
         unassigned = Route(
             name="Unassigned",
@@ -3463,6 +3465,7 @@ class TestRouteRoutes:
             length=5.0,
             route_group_id=past_group.route_group_id,
             driver_id=driver.driver_id,
+            start_time=time(8, 0),
         )
         test_session.add(past)
         await test_session.commit()
@@ -3753,6 +3756,7 @@ class TestRouteGroupRoutes:
             ends_at_warehouse=True,
             route_group_id=route_group.route_group_id,
             driver_id=test_driver.driver_id,
+            start_time=time(8, 0),
         )
         route_b = Route(
             name="Route B",
@@ -4077,12 +4081,14 @@ class TestRouteGroupRoutes:
                     length=1.0,
                     route_group_id=full.route_group_id,
                     driver_id=did,
+                    start_time=time(8, 0),
                 ),
                 Route(
                     name="F2",
                     length=1.0,
                     route_group_id=full.route_group_id,
                     driver_id=did,
+                    start_time=time(8, 0),
                 ),
                 # partial: one staffed, one not
                 Route(
@@ -4090,6 +4096,7 @@ class TestRouteGroupRoutes:
                     length=1.0,
                     route_group_id=partial.route_group_id,
                     driver_id=did,
+                    start_time=time(8, 0),
                 ),
                 Route(name="P2", length=1.0, route_group_id=partial.route_group_id),
                 Route(


### PR DESCRIPTION
Stacked on #227 — that PR's commit shows here until it merges.

An assigned route is a scheduled route: the driver has to be told when to show up. Nothing enforced that. [route_service.py](backend/python/app/services/implementations/route_service.py) merely noted the two fields "typically travel together," and the reminder email papered over the gap with a `"TBD"` placeholder.

## Enforced twice, on purpose

**A CHECK constraint** — `driver_id IS NULL OR start_time IS NOT NULL` — so no write path can get around it. Declared on the model as well as in the migration, so metadata-created test databases carry it too (which is what makes the seed tests below meaningful).

**A service-layer check** in `update_route`, evaluated on the *merged* state, so a client gets a 400 instead of the database throwing a 500 at them. It catches both directions: assigning a driver to an unscheduled route, and clearing the start time of an assigned one.

Unassigned routes are untouched. A route can exist before it is scheduled, and may keep its start time after a driver drops off it — both are tested.

## Write paths audited

`PATCH /routes/{id}` (now validated), route-group duplication (already copies both fields together), driver deletion (`ondelete="SET NULL"`, so it lands on the legal side), and the seed generator. `RouteCreate` is declared but has no route, and the sweep algorithm builds in-memory plans, not rows.

**The seed generator was the sole violator**: it assigned drivers by a random ratio and never set `start_time` at all — the only two `start_time` mentions in that file were `SystemSettings.route_start_time`. Seeded assigned routes now get a staggered start off the standard 08:00, matching the model's own note that driver start times are staggered.

## The TBD branch is now unreachable

So it raises instead of silently inventing a time. Reaching it would mean the database drifted from its own schema — and the obvious fallback (`RouteGroup.drive_date`, always constructed at midnight) would quietly tell a driver their route starts at 12:00 AM.

## Migration

Backfills any violating rows to 08:00 and reports the count rather than failing. There is no production deployment, so the only databases affected are development ones seeded by the old generator; failing the migration would just force a re-seed for no benefit.

## Verification

Exercised against a real Postgres rather than assumed:

- Seeded a violating row (assigned, no start time) **and** a legal unassigned row, then migrated: the violating row was backfilled to 08:00, the unassigned row was left alone, the constraint was installed, and a freshly-inserted violation was rejected by the database.
- `downgrade` drops the constraint and `upgrade` reinstalls it; `alembic heads` reports exactly one head.
- 23 tests pass across the invariant and reminder-job suites, including four constraint cases (assigned/unassigned × with/without start time) and six PATCH cases.
- `test_seed_database.py` — 23 passed. The test database is built from SQLModel metadata, which now carries the constraint, so this is direct proof the seed generator satisfies the invariant.
- `ruff check`, `ruff format --check`, `mypy .` (127 files) all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Follow-up: existing fixtures had to change

The first CI run failed, and it caught something my local runs could not.

Thirteen fixtures across five test files built **assigned routes with no start time** — a state the app is no longer allowed to produce. They now set a start time alongside the driver. I found them by walking the AST for every `Route(...)` with a non-null `driver_id` rather than grepping, which caught `driver_id=driver.driver_id if assign_driver else None` (a text search would have missed the conditional) and `test_driver_delete.py`, which assigns by attribute and so matched no `driver_id=` pattern at all.

**Why local testing missed it:** those fixtures live in `test_routes.py` and `test_auth_integration.py`, which fail locally for an unrelated reason — they need `GOOGLE_MAPS_API_KEY`, supplied in CI as a secret. Running with `GOOGLE_MAPS_API_KEY=dummy-key-for-local-tests` gets them past client construction and makes the constraint failures visible locally.

**A/B against #227 with identical environment and separate databases:**

| | this branch | #227 baseline |
|---|---|---|
| unique failing tests | 77 | 77 |
| passed | **443** | 433 |

The failure sets are byte-identical — zero regressions — and the +10 is exactly the new tests in `test_route_assigned_start_time.py`. The 77 shared failures are the `GOOGLE_MAPS_API_KEY`-dependent ones on both sides.
