### PR TITLE
Finish pagination + small routes page nits + navbar sizing

### DIFF
--- a/backend/python/app/models/route.py
+++ b/backend/python/app/models/route.py
@@ -6,6 +6,7 @@ from sqlalchemy import CheckConstraint, Column, DateTime, Text
 from sqlmodel import Field, Relationship, SQLModel
 
 from .base import BaseModel
+from .enum import RouteStatusEnum
 from .route_stop import RouteStopDetailRead
 
 # Named so the migration, the model, and the error-handling paths all refer to
@@ -185,7 +186,10 @@ class RouteWithDateRead(SQLModel):
     box_total: int
     delivery_type: str | None = None
     driver_name: str | None = None
-    status: str
+    # Same Upcoming/Completed vocabulary as RouteGroupRead.status, so clients
+    # get one union rather than a bare string on one endpoint and an enum on
+    # the other.
+    status: RouteStatusEnum
 
 
 class SuggestedDriverResponse(SQLModel):

--- a/backend/python/app/models/route_group.py
+++ b/backend/python/app/models/route_group.py
@@ -17,11 +17,6 @@ class RouteGroupBase(SQLModel):
     name: str = Field(min_length=1, max_length=255, nullable=False)
     notes: str = Field(default="")
     drive_date: datetime
-    # Delivery type chosen when the group is created ahead of route
-    # generation. Once the group has routes, reads derive the delivery type
-    # from its stops' locations instead and this is only a fallback (see
-    # RouteGroupService.get_route_groups).
-    delivery_type: str | None = Field(default=None, max_length=100)
 
 
 class RouteGroup(RouteGroupBase, BaseModel, table=True):
@@ -76,6 +71,9 @@ class RouteGroupRead(RouteGroupBase):
     num_locations: int = 0
     num_boxes: int = 0
     num_drivers_assigned: int = 0
+    # Derived from the group's stops' locations, not stored: a group's delivery
+    # type is whatever it delivers. None until the group has stops.
+    delivery_type: str | None = None
     status: RouteStatusEnum
     routes: list[RouteReadSummary] = []
 

--- a/backend/python/app/routers/route_group_routes.py
+++ b/backend/python/app/routers/route_group_routes.py
@@ -18,6 +18,7 @@ from app.models.route_group import (
     RouteGroupRead,
     RouteGroupUpdate,
 )
+from app.schemas.pagination import PaginatedResponse, PaginationParams, get_pagination
 from app.services.implementations.location_service import (
     InvalidDeliveryTypeError,
     LocationService,
@@ -51,11 +52,12 @@ async def get_route_groups(
     search: str | None = Query(
         None, description="Case-insensitive filter on the route group name"
     ),
+    pagination: PaginationParams = Depends(get_pagination),
     session: AsyncSession = Depends(get_session),
     route_group_service: RouteGroupService = Depends(get_route_group_service),
     location_service: LocationService = Depends(get_location_service),
     _auth: bool = Depends(require_admin),
-) -> list[RouteGroupRead]:
+) -> PaginatedResponse[RouteGroupRead]:
     """
     Retrieve all route groups, optionally filtered by date range, weekday, delivery type, route status, and driver assignment status.
     Can include associated routes in the response.
@@ -73,6 +75,7 @@ async def get_route_groups(
             driver_assignment_status,
             include_routes,
             search,
+            pagination,
         )
     except InvalidDeliveryTypeError as ve:
         raise HTTPException(

--- a/backend/python/app/routers/route_group_routes.py
+++ b/backend/python/app/routers/route_group_routes.py
@@ -85,22 +85,12 @@ async def create_route_group(
     route_group: RouteGroupCreate,
     session: AsyncSession = Depends(get_session),
     route_group_service: RouteGroupService = Depends(get_route_group_service),
-    location_service: LocationService = Depends(get_location_service),
     _auth: bool = Depends(require_admin),
 ) -> RouteGroupRead:
     """
     Create a new route group
     """
-    try:
-        if route_group.delivery_type:
-            await location_service.validate_delivery_types(
-                session, [route_group.delivery_type]
-            )
-        return await route_group_service.create_route_group(session, route_group)
-    except InvalidDeliveryTypeError as ve:
-        raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=str(ve)
-        ) from ve
+    return await route_group_service.create_route_group(session, route_group)
 
 
 @router.patch("/{route_group_id}", response_model=RouteGroupRead)

--- a/backend/python/app/seed_database.py
+++ b/backend/python/app/seed_database.py
@@ -969,7 +969,6 @@ def main() -> None:
                 name="TEST - Empty Group (no routes)",
                 notes="Seeded fixture: empty group, safe to delete.",
                 drive_date=fixture_date,
-                delivery_type="Family",
             )
             set_timestamps(empty_group)
             session.add(empty_group)
@@ -981,7 +980,6 @@ def main() -> None:
                 name="TEST - Fixture Routes",
                 notes="Seeded fixture: unassigned routes for banner/delete tests.",
                 drive_date=fixture_date,
-                delivery_type="Family",
             )
             set_timestamps(fixture_group)
             session.add(fixture_group)

--- a/backend/python/app/services/implementations/route_group_service.py
+++ b/backend/python/app/services/implementations/route_group_service.py
@@ -110,7 +110,6 @@ class RouteGroupService:
                 if overrides and overrides.drive_date
                 else route_group.drive_date
             ),
-            delivery_type=route_group.delivery_type,
         )
         session.add(duplicated_group)
 
@@ -216,17 +215,17 @@ class RouteGroupService:
             .label("num_drivers_assigned")
         )
 
-        # Prefer the delivery type derived from the group's stops; fall back to
-        # the type chosen when the group was created (used by empty groups made
-        # ahead of route generation via the Add Route Group dialog).
-        delivery_type_expr = func.coalesce(
+        # A group's delivery type is a property of the stops it serves, not of
+        # the group: it is whatever its locations are. A group with no stops
+        # yet has no delivery type to report, and reads NULL.
+        delivery_type_expr = (
             select(Location.delivery_type)
             .where(Location.location_id.in_(group_location_ids))  # type: ignore[attr-defined]
             .limit(1)
             .correlate(RouteGroup)
-            .scalar_subquery(),
-            RouteGroup.delivery_type,
-        ).label("delivery_type")
+            .scalar_subquery()
+            .label("delivery_type")
+        )
 
         now = datetime.now(self.timezone).replace(tzinfo=None)
         today_start = now.replace(hour=0, minute=0, second=0, microsecond=0)

--- a/backend/python/app/services/implementations/route_group_service.py
+++ b/backend/python/app/services/implementations/route_group_service.py
@@ -26,7 +26,9 @@ from app.models.route_group import (
     RouteReadSummary,
 )
 from app.models.route_stop import RouteStop
+from app.schemas.pagination import PaginatedResponse, PaginationParams
 from app.utilities.boxes import box_count_expr, resolve_children_per_box
+from app.utilities.pagination import paginate_query
 
 ROUTE_GROUP_COPY_PREFIX = "Copy of "
 ROUTE_GROUP_NAME_MAX_LENGTH = 255
@@ -288,10 +290,15 @@ class RouteGroupService:
         driver_assignment_status: list[DriverAssignmentStatusEnum] | None = None,
         include_routes: bool = False,
         search: str | None = None,
-    ) -> list[RouteGroupRead]:
+        pagination: PaginationParams | None = None,
+    ) -> PaginatedResponse[RouteGroupRead]:
         """Get route groups with optional date filtering and aggregate stats.
 
         ``search`` filters (case-insensitive substring) on the group name.
+
+        Paginated like the routes and locations lists: filters and search are
+        applied first, so a page is drawn from the matches rather than being
+        filtered after slicing.
         """
 
         children_per_box = await resolve_children_per_box(session)
@@ -386,10 +393,18 @@ class RouteGroupService:
         statement = statement.options(selectinload(RouteGroup.routes))  # type: ignore[arg-type]
         statement = statement.order_by(RouteGroup.drive_date)
 
-        result = await session.execute(statement)
+        if pagination is None:
+            pagination = PaginationParams()
+
+        result, total = await paginate_query(session, statement, pagination)
         rows = result.all()
 
-        return [self._row_to_read(row, include_routes) for row in rows]
+        return PaginatedResponse.create(
+            items=[self._row_to_read(row, include_routes) for row in rows],
+            total=total,
+            page=pagination.page,
+            page_size=pagination.page_size,
+        )
 
     async def delete_route_group(
         self, session: AsyncSession, route_group_id: UUID

--- a/backend/python/app/services/implementations/route_group_service.py
+++ b/backend/python/app/services/implementations/route_group_service.py
@@ -220,9 +220,14 @@ class RouteGroupService:
         # A group's delivery type is a property of the stops it serves, not of
         # the group: it is whatever its locations are. A group with no stops
         # yet has no delivery type to report, and reads NULL.
+        # A group whose stops span more than one delivery type has no single
+        # right answer here, and nothing yet enforces that they cannot. Ordering
+        # makes the arbitrary pick at least a stable one, so the same group does
+        # not report different types on consecutive loads.
         delivery_type_expr = (
             select(Location.delivery_type)
             .where(Location.location_id.in_(group_location_ids))  # type: ignore[attr-defined]
+            .order_by(Location.delivery_type)
             .limit(1)
             .correlate(RouteGroup)
             .scalar_subquery()
@@ -391,7 +396,14 @@ class RouteGroupService:
                 statement = statement.where(or_(*assignment_conditions))
 
         statement = statement.options(selectinload(RouteGroup.routes))  # type: ignore[arg-type]
-        statement = statement.order_by(RouteGroup.drive_date)
+        # Groups routinely share a drive date, and paginate_query runs the count
+        # and the page as separate statements — so ordering by the date alone
+        # lets the database break ties differently between them and a row can be
+        # skipped or repeated across page boundaries. Name then id makes the
+        # order total, so every page is cut from the same sequence.
+        statement = statement.order_by(
+            RouteGroup.drive_date, RouteGroup.name, RouteGroup.route_group_id
+        )
 
         if pagination is None:
             pagination = PaginationParams()

--- a/backend/python/app/services/implementations/route_service.py
+++ b/backend/python/app/services/implementations/route_service.py
@@ -248,7 +248,12 @@ class RouteService:
             if order == "desc"
             else col(RouteGroup.drive_date).asc()
         )
-        statement = statement.order_by(drive_date_order, col(Route.name))
+        # route_id last so the order is total: two routes on the same date can
+        # share a name, and paginate_query's count and page are separate
+        # statements, so any remaining tie can shuffle a row between pages.
+        statement = statement.order_by(
+            drive_date_order, col(Route.name), col(Route.route_id)
+        )
 
         if pagination is None:
             pagination = PaginationParams()

--- a/backend/python/migrations/versions/c1f4a80b7e35_drop_stored_delivery_type_from_route_.py
+++ b/backend/python/migrations/versions/c1f4a80b7e35_drop_stored_delivery_type_from_route_.py
@@ -11,7 +11,7 @@ Groups with no stops now report delivery_type: null rather than a value nobody
 could have entered.
 
 Revision ID: c1f4a80b7e35
-Revises: bc7876e56dd1
+Revises: c9a1e5f30b74
 Create Date: 2026-07-28 00:00:00.000000
 
 """
@@ -21,7 +21,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "c1f4a80b7e35"
-down_revision = "bc7876e56dd1"
+down_revision = "c9a1e5f30b74"
 branch_labels = None
 depends_on = None
 

--- a/backend/python/migrations/versions/c1f4a80b7e35_drop_stored_delivery_type_from_route_.py
+++ b/backend/python/migrations/versions/c1f4a80b7e35_drop_stored_delivery_type_from_route_.py
@@ -11,7 +11,7 @@ Groups with no stops now report delivery_type: null rather than a value nobody
 could have entered.
 
 Revision ID: c1f4a80b7e35
-Revises: c9a1e5f30b74
+Revises: a4c81f2d9b37
 Create Date: 2026-07-28 00:00:00.000000
 
 """
@@ -21,7 +21,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "c1f4a80b7e35"
-down_revision = "c9a1e5f30b74"
+down_revision = "a4c81f2d9b37"
 branch_labels = None
 depends_on = None
 

--- a/backend/python/migrations/versions/c1f4a80b7e35_drop_stored_delivery_type_from_route_.py
+++ b/backend/python/migrations/versions/c1f4a80b7e35_drop_stored_delivery_type_from_route_.py
@@ -1,0 +1,37 @@
+"""Drop the stored delivery_type from route_groups
+
+A group's delivery type is a property of the stops it serves — it is whatever
+its locations are — so reads always derived it from those locations, and the
+column added in b8e2a4c6d9f1 only ever acted as a fallback for a group with no
+stops yet. The one way to set it (the Add Route Group dialog) was never built,
+so nothing writes the column and the fallback can never fire. Two sources for
+one value, one of which is always NULL, is worse than deriving it in one place.
+
+Groups with no stops now report delivery_type: null rather than a value nobody
+could have entered.
+
+Revision ID: c1f4a80b7e35
+Revises: bc7876e56dd1
+Create Date: 2026-07-28 00:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "c1f4a80b7e35"
+down_revision = "bc7876e56dd1"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.drop_column("route_groups", "delivery_type")
+
+
+def downgrade() -> None:
+    op.add_column(
+        "route_groups",
+        sa.Column("delivery_type", sa.String(length=100), nullable=True),
+    )

--- a/backend/python/tests/test_routes.py
+++ b/backend/python/tests/test_routes.py
@@ -2636,6 +2636,9 @@ class TestRouteRoutes:
             length=4.2,
             route_group_id=test_route_group.route_group_id,
             driver_id=test_driver.driver_id,
+            # An assigned route must carry a start time (see the
+            # ck_routes_assigned_route_has_start_time constraint).
+            start_time=time(8, 0),
         )
         empty = Route(
             name="Empty", length=0.0, route_group_id=test_route_group.route_group_id

--- a/backend/python/tests/test_routes.py
+++ b/backend/python/tests/test_routes.py
@@ -4167,6 +4167,39 @@ class TestRouteGroupRoutes:
         assert [g["name"] for g in last.json()["items"]] == ["Page Test 5"]
 
     @pytest.mark.asyncio
+    async def test_get_route_groups_pages_do_not_overlap_on_a_shared_date(
+        self, async_client: AsyncClient, test_session: AsyncSession
+    ) -> None:
+        """Groups sharing a drive date still page without gaps or repeats.
+
+        Ordering by drive_date alone leaves ties for the database to break, and
+        it does not have to break them the same way twice — so a row could be
+        served on two pages while another is served on none. Every group here
+        shares one date, which is the normal case (a day's worth of routes), so
+        the tie-break is the only thing deciding the order.
+        """
+        shared_date = datetime(2026, 8, 3, 9, 0)
+        test_session.add_all(
+            [
+                RouteGroup(name=f"Tied {i:02d}", drive_date=shared_date)
+                for i in range(1, 8)
+            ]
+        )
+        await test_session.commit()
+
+        seen: list[str] = []
+        for page in (1, 2, 3):
+            response = await async_client.get(
+                "/route-groups",
+                params={"search": "Tied", "page": page, "page_size": 3},
+            )
+            assert response.status_code == 200
+            seen.extend(g["name"] for g in response.json()["items"])
+
+        # Every group exactly once, and in the total order the tie-break defines.
+        assert seen == [f"Tied {i:02d}" for i in range(1, 8)]
+
+    @pytest.mark.asyncio
     async def test_get_route_groups_filters_by_driver_assignment_status(
         self,
         async_client: AsyncClient,

--- a/backend/python/tests/test_routes.py
+++ b/backend/python/tests/test_routes.py
@@ -21,7 +21,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies.auth import DriverAccess, require_self_driver_or_admin
 from app.dependencies.services import get_google_maps_client
-from app.models.enum import ProgressEnum
+from app.models.enum import ProgressEnum, RouteStatusEnum
 from app.models.location import Location
 from app.models.location_group import LocationGroup
 from app.models.note_chain import NoteChain
@@ -2603,6 +2603,84 @@ class TestRouteRoutes:
         assert empty.json()["items"] == []
 
     @pytest.mark.asyncio
+    async def test_get_routes_returns_derived_row_values(
+        self,
+        async_client: AsyncClient,
+        test_session: AsyncSession,
+        test_route_group: Any,
+        test_location_group: Any,
+        test_driver: Any,
+    ) -> None:
+        """The list rows carry the values the Routes tab renders.
+
+        delivery_type, driver_name and status are computed in the query rather
+        than stored, so nothing else catches them going wrong: the filters can
+        all pass while the displayed row is derived some other way. This pins
+        the values themselves, including the empty route that has no stop to
+        read a delivery type from.
+        """
+        location = Location(
+            location_group_id=test_location_group.location_group_id,
+            name="Derived",
+            contact_name="Derived",
+            address="1 Derived St",
+            phone_primary="5550000009",
+            delivery_type="School",
+            num_children=3,
+        )
+        test_session.add(location)
+        await test_session.flush()
+
+        served = Route(
+            name="Served",
+            length=4.2,
+            route_group_id=test_route_group.route_group_id,
+            driver_id=test_driver.driver_id,
+        )
+        empty = Route(
+            name="Empty", length=0.0, route_group_id=test_route_group.route_group_id
+        )
+        test_session.add_all([served, empty])
+        await test_session.flush()
+        test_session.add(
+            RouteStop(
+                route_id=served.route_id,
+                location_id=location.location_id,
+                stop_number=1,
+            )
+        )
+        await test_session.commit()
+        await test_session.refresh(served)
+        await test_session.refresh(empty)
+
+        response = await async_client.get("/routes")
+        assert response.status_code == 200
+        rows = {item["route_id"]: item for item in response.json()["items"]}
+
+        served_row = rows[str(served.route_id)]
+        # Read off the stop's location, not off the group.
+        assert served_row["delivery_type"] == "School"
+        assert served_row["driver_name"] == "John Doe"
+        assert served_row["group_name"] == test_route_group.name
+        assert served_row["route_group_id"] == str(test_route_group.route_group_id)
+        assert served_row["num_stops"] == 1
+
+        empty_row = rows[str(empty.route_id)]
+        # No stops -> no location -> no delivery type, and no driver assigned.
+        assert empty_row["delivery_type"] is None
+        assert empty_row["driver_name"] is None
+        assert empty_row["num_stops"] == 0
+
+        # Both routes share a group, so they share its drive_date and status.
+        expected_status = (
+            RouteStatusEnum.UPCOMING
+            if test_route_group.drive_date.date() >= date.today()
+            else RouteStatusEnum.COMPLETED
+        )
+        assert served_row["status"] == expected_status.value
+        assert empty_row["status"] == expected_status.value
+
+    @pytest.mark.asyncio
     async def test_get_routes_filters_by_driver_assignment_status(
         self,
         async_client: AsyncClient,
@@ -3633,12 +3711,15 @@ class TestRouteGroupRoutes:
         assert "route_group_id" in result
 
     @pytest.mark.asyncio
-    async def test_create_route_group_with_delivery_type(
+    async def test_create_route_group_has_no_delivery_type_until_it_has_stops(
         self, async_client: AsyncClient, sample_route_group_data: dict[str, Any]
     ) -> None:
-        """A group created with a delivery type keeps it while it has no
-        routes: it comes back on the create response and on GET /route-groups
-        (where groups with routes derive it from their stops instead)."""
+        """Delivery type is derived from the group's stops, never stored.
+
+        A freshly created group has no stops, so it reports None — and a
+        delivery_type in the request body is not a field on the create model,
+        so it cannot set one.
+        """
         data = sample_route_group_data.copy()
         data["drive_date"] = data["drive_date"].isoformat()
         data["delivery_type"] = "School"
@@ -3646,7 +3727,7 @@ class TestRouteGroupRoutes:
         response = await async_client.post("/route-groups", json=data)
         assert response.status_code == 201
         result = response.json()
-        assert result["delivery_type"] == "School"
+        assert result["delivery_type"] is None
 
         response = await async_client.get("/route-groups")
         assert response.status_code == 200
@@ -3655,19 +3736,7 @@ class TestRouteGroupRoutes:
             for rg in response.json()
             if str(rg["route_group_id"]) == str(result["route_group_id"])
         )
-        assert created["delivery_type"] == "School"
-
-    @pytest.mark.asyncio
-    async def test_create_route_group_invalid_delivery_type(
-        self, async_client: AsyncClient, sample_route_group_data: dict[str, Any]
-    ) -> None:
-        """POST /route-groups rejects delivery types that aren't configured."""
-        data = sample_route_group_data.copy()
-        data["drive_date"] = data["drive_date"].isoformat()
-        data["delivery_type"] = "Not A Real Type"
-
-        response = await async_client.post("/route-groups", json=data)
-        assert response.status_code == 422
+        assert created["delivery_type"] is None
 
     @pytest.mark.asyncio
     async def test_get_route_groups_with_data(
@@ -3895,12 +3964,11 @@ class TestRouteGroupRoutes:
     async def test_duplicate_route_group_with_overrides(
         self, async_client: AsyncClient, test_session: AsyncSession
     ) -> None:
-        """The optional body overrides the copy's name/drive_date; delivery_type carries over."""
+        """The optional body overrides the copy's name and drive_date."""
         route_group = RouteGroup(
             name="Tuesday A - Cambridge North",
             notes="",
             drive_date=datetime(2026, 7, 9, 9, 0),
-            delivery_type="Family",
         )
         test_session.add(route_group)
         await test_session.commit()
@@ -3918,7 +3986,8 @@ class TestRouteGroupRoutes:
         assert body["route_group_id"] != str(route_group.route_group_id)
         assert body["name"] == "Tuesday A - Cambridge North (Copy)"
         assert body["drive_date"] == "2026-07-16T00:00:00"
-        assert body["delivery_type"] == "Family"
+        # The copy has no stops yet, so it has no delivery type to report.
+        assert body["delivery_type"] is None
 
     @pytest.mark.asyncio
     async def test_duplicate_route_group_not_found(

--- a/backend/python/tests/test_routes.py
+++ b/backend/python/tests/test_routes.py
@@ -3693,7 +3693,7 @@ class TestRouteGroupRoutes:
         """Test GET /route-groups returns empty list when no route groups exist."""
         response = await async_client.get("/route-groups")
         assert response.status_code == 200
-        assert response.json() == []
+        assert response.json()["items"] == []
 
     @pytest.mark.asyncio
     async def test_create_route_group(
@@ -3733,7 +3733,7 @@ class TestRouteGroupRoutes:
         assert response.status_code == 200
         created = next(
             rg
-            for rg in response.json()
+            for rg in response.json()["items"]
             if str(rg["route_group_id"]) == str(result["route_group_id"])
         )
         assert created["delivery_type"] is None
@@ -3745,7 +3745,7 @@ class TestRouteGroupRoutes:
         """Test GET /route-groups returns list of route groups."""
         response = await async_client.get("/route-groups")
         assert response.status_code == 200
-        data = response.json()
+        data = response.json()["items"]
         assert len(data) >= 1
         assert any(
             str(rg["route_group_id"]) == str(test_route_group.route_group_id)
@@ -4069,7 +4069,7 @@ class TestRouteGroupRoutes:
         # Verify deletion by trying to get all route groups
         get_response = await async_client.get("/route-groups")
         assert response.status_code == 204
-        data = get_response.json()
+        data = get_response.json()["items"]
         assert not any(
             str(rg["route_group_id"]) == str(test_route_group.route_group_id)
             for rg in data
@@ -4095,7 +4095,7 @@ class TestRouteGroupRoutes:
             f"/route-groups?start_date={start_date}&end_date={end_date}"
         )
         assert response.status_code == 200
-        data = response.json()
+        data = response.json()["items"]
         assert isinstance(data, list)
 
     @pytest.mark.asyncio
@@ -4117,10 +4117,51 @@ class TestRouteGroupRoutes:
 
         resp = await async_client.get("/route-groups", params={"search": "cambridge"})
         assert resp.status_code == 200
-        # The list endpoint returns a plain list (not paginated).
-        assert {rg["route_group_id"] for rg in resp.json()} == {
+        assert {rg["route_group_id"] for rg in resp.json()["items"]} == {
             str(cambridge.route_group_id)
         }
+
+    @pytest.mark.asyncio
+    async def test_get_route_groups_paginates_after_filtering(
+        self, async_client: AsyncClient, test_session: AsyncSession
+    ) -> None:
+        """Pages are drawn from the matches, not filtered after slicing.
+
+        The ordering is by drive_date, so page 2 of a page_size=2 run over five
+        groups holds the third and fourth oldest — and `total` counts every
+        match rather than the page.
+        """
+        groups = [
+            RouteGroup(name=f"Page Test {i}", drive_date=datetime(2026, 7, i, 9, 0))
+            for i in range(1, 6)
+        ]
+        # A group the search excludes, to prove `total` reflects the filter.
+        other = RouteGroup(name="Excluded", drive_date=datetime(2026, 7, 6, 9, 0))
+        test_session.add_all([*groups, other])
+        await test_session.commit()
+
+        first = await async_client.get(
+            "/route-groups", params={"search": "Page Test", "page": 1, "page_size": 2}
+        )
+        assert first.status_code == 200
+        body = first.json()
+        assert body["total"] == 5
+        assert body["total_pages"] == 3
+        assert [g["name"] for g in body["items"]] == ["Page Test 1", "Page Test 2"]
+
+        second = await async_client.get(
+            "/route-groups", params={"search": "Page Test", "page": 2, "page_size": 2}
+        )
+        assert second.status_code == 200
+        assert [g["name"] for g in second.json()["items"]] == [
+            "Page Test 3",
+            "Page Test 4",
+        ]
+
+        last = await async_client.get(
+            "/route-groups", params={"search": "Page Test", "page": 3, "page_size": 2}
+        )
+        assert [g["name"] for g in last.json()["items"]] == ["Page Test 5"]
 
     @pytest.mark.asyncio
     async def test_get_route_groups_filters_by_driver_assignment_status(
@@ -4179,7 +4220,7 @@ class TestRouteGroupRoutes:
             "/route-groups", params={"driver_assignment_status": "Assigned"}
         )
         assert assigned.status_code == 200
-        assigned_ids = {rg["route_group_id"] for rg in assigned.json()}
+        assigned_ids = {rg["route_group_id"] for rg in assigned.json()["items"]}
         assert str(full.route_group_id) in assigned_ids
         # Partial, all-unassigned, and empty groups are NOT "Assigned".
         assert str(partial.route_group_id) not in assigned_ids
@@ -4190,7 +4231,7 @@ class TestRouteGroupRoutes:
             "/route-groups", params={"driver_assignment_status": "Unassigned"}
         )
         assert unassigned.status_code == 200
-        unassigned_ids = {rg["route_group_id"] for rg in unassigned.json()}
+        unassigned_ids = {rg["route_group_id"] for rg in unassigned.json()["items"]}
         assert str(partial.route_group_id) in unassigned_ids
         assert str(none_assigned.route_group_id) in unassigned_ids
         assert str(empty.route_group_id) in unassigned_ids
@@ -4257,7 +4298,7 @@ class TestRouteGroupRoutes:
             "/route-groups", params={"delivery_type": "Family"}
         )
         assert resp.status_code == 200
-        ids = {rg["route_group_id"] for rg in resp.json()}
+        ids = {rg["route_group_id"] for rg in resp.json()["items"]}
         assert str(fam_group.route_group_id) in ids
         assert str(sch_group.route_group_id) not in ids
 
@@ -4284,7 +4325,9 @@ class TestRouteGroupRoutes:
         response = await async_client.get("/route-groups?include_routes=true")
         assert response.status_code == 200
         group = next(
-            g for g in response.json() if g["route_group_id"] == str(rg.route_group_id)
+            g
+            for g in response.json()["items"]
+            if g["route_group_id"] == str(rg.route_group_id)
         )
         assert group["num_routes"] == 1
         assert [r["route_id"] for r in group["routes"]] == [str(route.route_id)]
@@ -4302,7 +4345,9 @@ class TestRouteGroupRoutes:
         response = await async_client.get("/route-groups")
         assert response.status_code == 200
         group = next(
-            g for g in response.json() if g["route_group_id"] == str(rg.route_group_id)
+            g
+            for g in response.json()["items"]
+            if g["route_group_id"] == str(rg.route_group_id)
         )
         assert group["num_locations"] == 0
         assert group["num_boxes"] == 0
@@ -4348,7 +4393,9 @@ class TestRouteGroupRoutes:
         response = await async_client.get("/route-groups")
         assert response.status_code == 200
         group = next(
-            g for g in response.json() if g["route_group_id"] == str(rg.route_group_id)
+            g
+            for g in response.json()["items"]
+            if g["route_group_id"] == str(rg.route_group_id)
         )
         assert group["delivery_type"] == "School"
         assert group["num_locations"] == 1
@@ -4393,7 +4440,9 @@ class TestRouteGroupRoutes:
         response = await async_client.get("/route-groups")
         assert response.status_code == 200
         group = next(
-            g for g in response.json() if g["route_group_id"] == str(rg.route_group_id)
+            g
+            for g in response.json()["items"]
+            if g["route_group_id"] == str(rg.route_group_id)
         )
         assert group["delivery_type"] == "Pantry"
 
@@ -4462,7 +4511,9 @@ class TestRouteGroupRoutes:
         response = await async_client.get("/route-groups")
         assert response.status_code == 200
         group = next(
-            g for g in response.json() if g["route_group_id"] == str(rg.route_group_id)
+            g
+            for g in response.json()["items"]
+            if g["route_group_id"] == str(rg.route_group_id)
         )
         # ceil(3/2) + ceil(5/2) = 2 + 3 = 5
         assert group["num_boxes"] == 5
@@ -4497,7 +4548,9 @@ class TestRouteGroupRoutes:
         response = await async_client.get("/route-groups")
         assert response.status_code == 200
         group = next(
-            g for g in response.json() if g["route_group_id"] == str(rg.route_group_id)
+            g
+            for g in response.json()["items"]
+            if g["route_group_id"] == str(rg.route_group_id)
         )
         assert group["status"] == "Upcoming"
 

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -2428,6 +2428,42 @@
         "title": "PaginatedResponse[NoteFeedItem]",
         "type": "object"
       },
+      "PaginatedResponse_RouteGroupRead_": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/RouteGroupRead"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "page": {
+            "title": "Page",
+            "type": "integer"
+          },
+          "page_size": {
+            "title": "Page Size",
+            "type": "integer"
+          },
+          "total": {
+            "title": "Total",
+            "type": "integer"
+          },
+          "total_pages": {
+            "title": "Total Pages",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "items",
+          "total",
+          "page",
+          "page_size",
+          "total_pages"
+        ],
+        "title": "PaginatedResponse[RouteGroupRead]",
+        "type": "object"
+      },
       "PaginatedResponse_RouteWithDateRead_": {
         "properties": {
           "items": {
@@ -6697,6 +6733,33 @@
               "description": "Case-insensitive filter on the route group name",
               "title": "Search"
             }
+          },
+          {
+            "description": "Page number (1-indexed)",
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "default": 1,
+              "description": "Page number (1-indexed)",
+              "minimum": 1,
+              "title": "Page",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Number of items per page",
+            "in": "query",
+            "name": "page_size",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "description": "Number of items per page",
+              "maximum": 200,
+              "minimum": 1,
+              "title": "Page Size",
+              "type": "integer"
+            }
           }
         ],
         "responses": {
@@ -6704,11 +6767,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/RouteGroupRead"
-                  },
-                  "title": "Response Get Route Groups",
-                  "type": "array"
+                  "$ref": "#/components/schemas/PaginatedResponse_RouteGroupRead_"
                 }
               }
             },

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -2689,18 +2689,6 @@
       "RouteGroupCreate": {
         "description": "Create request model",
         "properties": {
-          "delivery_type": {
-            "anyOf": [
-              {
-                "maxLength": 100,
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Delivery Type"
-          },
           "drive_date": {
             "format": "date-time",
             "title": "Drive Date",
@@ -2775,7 +2763,6 @@
           "delivery_type": {
             "anyOf": [
               {
-                "maxLength": 100,
                 "type": "string"
               },
               {
@@ -3278,8 +3265,7 @@
             "title": "Start Time"
           },
           "status": {
-            "title": "Status",
-            "type": "string"
+            "$ref": "#/components/schemas/RouteStatusEnum"
           }
         },
         "required": [

--- a/frontend/src/api/generated/@tanstack/react-query.gen.ts
+++ b/frontend/src/api/generated/@tanstack/react-query.gen.ts
@@ -2071,6 +2071,59 @@ export const getRouteGroupsOptions = (options?: Options<GetRouteGroupsData>) =>
     queryKey: getRouteGroupsQueryKey(options),
   });
 
+export const getRouteGroupsInfiniteQueryKey = (
+  options?: Options<GetRouteGroupsData>
+): QueryKey<Options<GetRouteGroupsData>> =>
+  createQueryKey('getRouteGroups', options, true);
+
+/**
+ * Get Route Groups
+ *
+ * Retrieve all route groups, optionally filtered by date range, weekday, delivery type, route status, and driver assignment status.
+ * Can include associated routes in the response.
+ */
+export const getRouteGroupsInfiniteOptions = (
+  options?: Options<GetRouteGroupsData>
+) =>
+  infiniteQueryOptions<
+    GetRouteGroupsResponse,
+    AxiosError<GetRouteGroupsError>,
+    InfiniteData<GetRouteGroupsResponse>,
+    QueryKey<Options<GetRouteGroupsData>>,
+    | number
+    | Pick<
+        QueryKey<Options<GetRouteGroupsData>>[0],
+        'body' | 'headers' | 'path' | 'query'
+      >
+  >(
+    // @ts-ignore
+    {
+      queryFn: async ({ pageParam, queryKey, signal }) => {
+        // @ts-ignore
+        const page: Pick<
+          QueryKey<Options<GetRouteGroupsData>>[0],
+          'body' | 'headers' | 'path' | 'query'
+        > =
+          typeof pageParam === 'object'
+            ? pageParam
+            : {
+                query: {
+                  page: pageParam,
+                },
+              };
+        const params = createInfiniteParams(queryKey, page);
+        const { data } = await getRouteGroups({
+          ...options,
+          ...params,
+          signal,
+          throwOnError: true,
+        });
+        return data;
+      },
+      queryKey: getRouteGroupsInfiniteQueryKey(options),
+    }
+  );
+
 /**
  * Create Route Group
  *

--- a/frontend/src/api/generated/index.ts
+++ b/frontend/src/api/generated/index.ts
@@ -373,6 +373,7 @@ export type {
   PaginatedResponseLocationRead,
   PaginatedResponseLocationReadWritable,
   PaginatedResponseNoteFeedItem,
+  PaginatedResponseRouteGroupRead,
   PaginatedResponseRouteWithDateRead,
   PatchSystemSettingsData,
   PatchSystemSettingsError,

--- a/frontend/src/api/generated/types.gen.ts
+++ b/frontend/src/api/generated/types.gen.ts
@@ -1424,6 +1424,32 @@ export type PaginatedResponseNoteFeedItem = {
 };
 
 /**
+ * PaginatedResponse[RouteGroupRead]
+ */
+export type PaginatedResponseRouteGroupRead = {
+  /**
+   * Items
+   */
+  items: Array<RouteGroupRead>;
+  /**
+   * Page
+   */
+  page: number;
+  /**
+   * Page Size
+   */
+  page_size: number;
+  /**
+   * Total
+   */
+  total: number;
+  /**
+   * Total Pages
+   */
+  total_pages: number;
+};
+
+/**
  * PaginatedResponse[RouteWithDateRead]
  */
 export type PaginatedResponseRouteWithDateRead = {
@@ -4117,6 +4143,18 @@ export type GetRouteGroupsData = {
      * Case-insensitive filter on the route group name
      */
     search?: string | null;
+    /**
+     * Page
+     *
+     * Page number (1-indexed)
+     */
+    page?: number;
+    /**
+     * Page Size
+     *
+     * Number of items per page
+     */
+    page_size?: number;
   };
   url: '/route-groups';
 };
@@ -4133,11 +4171,9 @@ export type GetRouteGroupsError =
 
 export type GetRouteGroupsResponses = {
   /**
-   * Response Get Route Groups
-   *
    * Successful Response
    */
-  200: Array<RouteGroupRead>;
+  200: PaginatedResponseRouteGroupRead;
 };
 
 export type GetRouteGroupsResponse =

--- a/frontend/src/api/generated/types.gen.ts
+++ b/frontend/src/api/generated/types.gen.ts
@@ -1590,10 +1590,6 @@ export type RouteGenerationSettings = {
  */
 export type RouteGroupCreate = {
   /**
-   * Delivery Type
-   */
-  delivery_type?: string | null;
-  /**
    * Drive Date
    */
   drive_date: string;
@@ -1926,10 +1922,7 @@ export type RouteWithDateRead = {
    * Start Time
    */
   start_time: string | null;
-  /**
-   * Status
-   */
-  status: string;
+  status: RouteStatusEnum;
 };
 
 /**

--- a/frontend/src/api/route-groups.ts
+++ b/frontend/src/api/route-groups.ts
@@ -19,14 +19,15 @@ import type { GetRouteGroupsData } from './generated/types.gen';
  * returned on RouteGroupRead (F4KRP-196). Consumers should import that
  * generated type rather than a hand-written row shape.
  *
- * The `search` query filters (case-insensitive) on the group name server-side;
- * the filter chips narrow by weekday/delivery type/status. `placeholderData`
- * keeps the previous list visible while a new search/filter refetches.
+ * The `search` query filters (case-insensitive) on the group name server-side,
+ * before pagination; the filter chips narrow by weekday/delivery type/status.
+ * `placeholderData` keeps the previous page visible while a new
+ * search/filter/page refetches so the table doesn't flash empty.
  */
 export function useRouteGroups(query: GetRouteGroupsData['query']) {
   return useQuery({
     ...getRouteGroupsOptions({ query }),
-    placeholderData: (prev) => prev ?? [],
+    placeholderData: (prev) => prev,
   });
 }
 

--- a/frontend/src/common/components/Account.tsx
+++ b/frontend/src/common/components/Account.tsx
@@ -17,7 +17,10 @@ export const Account = () => {
         </span>
       </div>
       <div className="inline-flex flex-col items-start">
-        <p className="text-m-p2 font-nunito leading-[22px]">{user?.fullName}</p>
+        {/* The design sets this one line in Nunito and the role beneath it in
+            Nunito Sans; mixing the two in a two-line block reads as a slip, so
+            the name follows the role (and the rest of the body copy). */}
+        <p className="text-m-p2 leading-[22px]">{user?.fullName}</p>
         <p className="text-m-p2 text-grey-400 leading-[22px] font-light capitalize">
           {user?.role}
         </p>

--- a/frontend/src/common/components/Account.tsx
+++ b/frontend/src/common/components/Account.tsx
@@ -6,14 +6,21 @@ export const Account = () => {
   const initials =
     `${user?.firstName?.charAt(0) || ''}${user?.lastName?.charAt(0) || ''}`.toUpperCase();
 
+  // Sizes and styles are the admin frames' top bar: a 48px pink disc with
+  // 16/22 Nunito Medium initials, then the name and role both at 16/22. The
+  // design gives every avatar the same pink, so this is not per-user colour.
   return (
     <div className="flex items-center gap-4">
-      <div className="flex size-10 items-center justify-center rounded-full bg-blue-300">
-        <span className="text-p2 text-grey-100">{initials}</span>
+      <div className="bg-brand-pink flex size-12 items-center justify-center rounded-full">
+        <span className="text-m-p2 font-nunito text-grey-100 leading-[22px] font-medium">
+          {initials}
+        </span>
       </div>
       <div className="inline-flex flex-col items-start">
-        <p className="text-p1 font-medium">{user?.fullName}</p>
-        <p className="text-p2 text-grey-400 capitalize">{user?.role}</p>
+        <p className="text-m-p2 font-nunito leading-[22px]">{user?.fullName}</p>
+        <p className="text-m-p2 text-grey-400 leading-[22px] font-light capitalize">
+          {user?.role}
+        </p>
       </div>
     </div>
   );

--- a/frontend/src/common/components/Button.variants.ts
+++ b/frontend/src/common/components/Button.variants.ts
@@ -31,6 +31,9 @@ export const buttonVariants = cva(
         ],
         /* 40px on mobile, 44px from tablet up (per CTA design frame) */
         circular: 'size-[40px] tablet:size-[44px] rounded-full',
+        /* The top bar's own icon button, drawn at 48 on every admin frame —
+         * larger than the 44 the table toolbars use. */
+        circularLarge: 'size-12 rounded-full',
         /* In-table action pill (the Routes tab's "Assign"): 34px tall with
          * 16px sides and a 14/18 SemiBold body-font label, per the Routes
          * design frame. Sized to its label — it sits inside a cell, so it

--- a/frontend/src/common/components/Button.variants.ts
+++ b/frontend/src/common/components/Button.variants.ts
@@ -31,6 +31,11 @@ export const buttonVariants = cva(
         ],
         /* 40px on mobile, 44px from tablet up (per CTA design frame) */
         circular: 'size-[40px] tablet:size-[44px] rounded-full',
+        /* In-table action pill (the Routes tab's "Assign"): 34px tall with
+         * 16px sides and a 14/18 SemiBold body-font label, per the Routes
+         * design frame. Sized to its label — it sits inside a cell, so it
+         * neither reserves a minimum width nor goes full-width on mobile. */
+        compact: 'text-p2 h-[34px] rounded-full px-4 font-semibold',
       },
     },
     compoundVariants: [

--- a/frontend/src/common/components/DataTable.tsx
+++ b/frontend/src/common/components/DataTable.tsx
@@ -145,7 +145,10 @@ function DataTable<T>({
                       // pill) sets the row height instead of a stack of
                       // padding rules fighting over it.
                       // Headers are the H3 style — Nunito Sans Bold 16/20.
-                      'text-h3 h-[54px] px-4 py-2.5 text-left font-bold whitespace-nowrap',
+                      // The design runs its columns edge to edge inside the
+                      // card's 24px padding, so the last one has no trailing
+                      // gap of its own — that is what puts the kebab flush.
+                      'text-h3 h-[54px] px-4 py-2.5 text-left font-bold whitespace-nowrap last:pr-0',
                       col.headerClassName
                     )}
                   >
@@ -189,7 +192,7 @@ function DataTable<T>({
                       key={col.key}
                       className={cn(
                         // Every body string in the design is 14/18 SemiBold.
-                        'text-p2 text-grey-500 h-[54px] px-4 py-2.5 font-semibold whitespace-nowrap',
+                        'text-p2 text-grey-500 h-[54px] px-4 py-2.5 font-semibold whitespace-nowrap last:pr-0',
                         col.getCellClassName?.(row)
                       )}
                     >

--- a/frontend/src/common/components/DataTable.tsx
+++ b/frontend/src/common/components/DataTable.tsx
@@ -140,7 +140,11 @@ function DataTable<T>({
                         : undefined
                     }
                     className={cn(
-                      'text-p1 px-4 py-2.5 text-left font-semibold whitespace-nowrap',
+                      // 54px per the design, header and body alike. A height
+                      // rather than padding so a taller cell (a date button, a
+                      // pill) sets the row height instead of a stack of
+                      // padding rules fighting over it.
+                      'text-p1 h-[54px] px-4 py-2.5 text-left font-semibold whitespace-nowrap',
                       col.headerClassName
                     )}
                   >
@@ -183,7 +187,7 @@ function DataTable<T>({
                     <td
                       key={col.key}
                       className={cn(
-                        'text-p2 text-grey-500 px-4 py-2.5 whitespace-nowrap',
+                        'text-p2 text-grey-500 h-[54px] px-4 py-2.5 whitespace-nowrap',
                         col.getCellClassName?.(row)
                       )}
                     >

--- a/frontend/src/common/components/DataTable.tsx
+++ b/frontend/src/common/components/DataTable.tsx
@@ -144,7 +144,8 @@ function DataTable<T>({
                       // rather than padding so a taller cell (a date button, a
                       // pill) sets the row height instead of a stack of
                       // padding rules fighting over it.
-                      'text-p1 h-[54px] px-4 py-2.5 text-left font-semibold whitespace-nowrap',
+                      // Headers are the H3 style — Nunito Sans Bold 16/20.
+                      'text-h3 h-[54px] px-4 py-2.5 text-left font-bold whitespace-nowrap',
                       col.headerClassName
                     )}
                   >
@@ -187,7 +188,8 @@ function DataTable<T>({
                     <td
                       key={col.key}
                       className={cn(
-                        'text-p2 text-grey-500 h-[54px] px-4 py-2.5 whitespace-nowrap',
+                        // Every body string in the design is 14/18 SemiBold.
+                        'text-p2 text-grey-500 h-[54px] px-4 py-2.5 font-semibold whitespace-nowrap',
                         col.getCellClassName?.(row)
                       )}
                     >

--- a/frontend/src/common/components/Pagination.tsx
+++ b/frontend/src/common/components/Pagination.tsx
@@ -1,0 +1,120 @@
+import ChevronRightIcon from '@/assets/icons/chevron-right.svg?react';
+import { cn } from '@/lib/utils';
+
+/** Pages either side of the current one that always get their own button. */
+const WINDOW = 1;
+
+export interface PaginationProps {
+  /** Current page, 1-indexed. */
+  page: number;
+  /** Total number of pages; the component renders nothing below 2. */
+  totalPages: number;
+  onPageChange: (page: number) => void;
+  className?: string;
+}
+
+/**
+ * Build the page list, using `null` for a gap.
+ *
+ * The first and last pages are always reachable, plus a window around the
+ * current one — so page 1 of 10 reads "1 2 3 … 10" (what the Figma shows) and a
+ * middle page reads "1 … 5 6 7 … 10". A gap of exactly one page renders as that
+ * page rather than an ellipsis, since "…" standing in for a single number is
+ * both wider and less useful than the number.
+ */
+function pageItems(page: number, totalPages: number): (number | null)[] {
+  const shown = new Set([1, totalPages]);
+  // Anchor the window at the start/end so the row keeps a stable width as you
+  // page through: page 1 shows 1-3, the last page shows the final three.
+  const start = Math.min(
+    Math.max(page - WINDOW, 1),
+    Math.max(totalPages - 2, 1)
+  );
+  for (let p = start; p < start + 1 + WINDOW * 2 && p <= totalPages; p += 1) {
+    shown.add(p);
+  }
+
+  const sorted = [...shown].sort((a, b) => a - b);
+  const items: (number | null)[] = [];
+  for (const [i, p] of sorted.entries()) {
+    const previous = sorted[i - 1];
+    if (previous !== undefined) {
+      if (p - previous === 2) items.push(previous + 1);
+      else if (p - previous > 2) items.push(null);
+    }
+    items.push(p);
+  }
+  return items;
+}
+
+/**
+ * Page switcher for the admin tables. Sits under the table, centred.
+ *
+ * Per the Figma the *current* page is the plain one (no fill, body text
+ * colour) and every page you can navigate to carries a grey pill — the
+ * highlight marks what is clickable, not where you are.
+ */
+export function Pagination({
+  page,
+  totalPages,
+  onPageChange,
+  className,
+}: PaginationProps) {
+  if (totalPages < 2) return null;
+
+  const cell = 'flex size-7 items-center justify-center rounded-full text-p1';
+
+  return (
+    <nav
+      aria-label="Pagination"
+      className={cn('mt-7 flex items-center justify-center gap-6', className)}
+    >
+      {pageItems(page, totalPages).map((item, index) =>
+        item === null ? (
+          <span
+            key={`gap-${index}`}
+            aria-hidden
+            className={cn(cell, 'bg-grey-200 font-medium text-blue-300')}
+          >
+            …
+          </span>
+        ) : (
+          <button
+            key={item}
+            type="button"
+            aria-label={`Page ${item}`}
+            aria-current={item === page ? 'page' : undefined}
+            onClick={() => onPageChange(item)}
+            className={cn(
+              cell,
+              'font-medium transition-colors',
+              item === page
+                ? 'text-grey-500 cursor-default'
+                : 'bg-grey-200 cursor-pointer text-blue-300 hover:bg-blue-50'
+            )}
+          >
+            {item}
+          </button>
+        )
+      )}
+
+      {/* The Figma only draws this on page 1, where it is always available.
+          Disabled rather than hidden on the last page so the row doesn't
+          reflow under the pointer as you reach the end. */}
+      <button
+        type="button"
+        disabled={page >= totalPages}
+        onClick={() => onPageChange(page + 1)}
+        className={cn(
+          'text-p1 ml-3 flex items-center gap-2 font-medium transition-colors',
+          page >= totalPages
+            ? 'text-grey-400 cursor-not-allowed'
+            : 'cursor-pointer text-blue-300 hover:underline'
+        )}
+      >
+        Next
+        <ChevronRightIcon className="size-5" />
+      </button>
+    </nav>
+  );
+}

--- a/frontend/src/common/components/SearchBar.tsx
+++ b/frontend/src/common/components/SearchBar.tsx
@@ -7,7 +7,8 @@ import { cn } from '@/lib/utils';
 const searchBarVariants = cva(
   /* Base styles shared by all variants */
   [
-    'flex min-w-90 items-center gap-2.5 rounded-full px-6 py-3 border border-grey-300 bg-white',
+    // 328x44 with a 24px inset icon, per the admin frames.
+    'flex min-w-82 items-center gap-2.5 rounded-full px-6 py-2.5 border border-grey-300 bg-white',
     'transition-colors',
     'focus-within:ring-1 focus-within:ring-blue-300',
   ],
@@ -50,7 +51,7 @@ const SearchBar = forwardRef<HTMLInputElement, SearchBarProps>(
           type="search"
           className={cn(
             'h-full w-full bg-transparent outline-none',
-            'text-grey-500 placeholder:text-grey-400 text-lg placeholder:text-lg',
+            'text-grey-500 placeholder:text-grey-400 text-m-p2 font-medium',
             // Remove default search input styling (x button, etc.)
             '[&::-webkit-search-cancel-button]:hidden',
             '[&::-webkit-search-decoration]:hidden',

--- a/frontend/src/common/components/Sidebar.tsx
+++ b/frontend/src/common/components/Sidebar.tsx
@@ -15,7 +15,9 @@ function Sidebar({ className, children }: React.ComponentProps<'aside'>) {
   return (
     <aside
       className={cn(
-        'flex w-28 shrink-0 flex-col items-center gap-12 bg-white px-4 py-6',
+        // 120px rail, 24px above the logo and 48px below it — the Web-Nav-Bar
+        // component's own measurements.
+        'flex w-30 shrink-0 flex-col items-center gap-12 bg-white px-4 py-6',
         'shadow-[0px_0px_32px_0px_rgba(0,0,0,0.04)]',
         'z-10 h-full',
         className
@@ -65,7 +67,9 @@ function SidebarFooter({ className, children }: React.ComponentProps<'div'>) {
 
 function SidebarMenu({ className, children }: React.ComponentProps<'nav'>) {
   return (
-    <nav className={cn('flex flex-col items-center gap-2', className)}>
+    // 48px between items, per the design. They sit in a column from the top
+    // rather than spreading to fill the rail.
+    <nav className={cn('flex flex-col items-center gap-12', className)}>
       {children}
     </nav>
   );
@@ -90,8 +94,10 @@ function SidebarMenuItem({
       end={end}
       className={({ isActive }) =>
         cn(
+          // 80x80: 14px padding, a 24px icon, 4px, then a 16/24 label. The
+          // label carries its own size, so the box does not set one.
           'flex w-20 flex-col items-center justify-center gap-1 rounded-xl px-4 py-3.5',
-          'text-base transition-colors',
+          'transition-colors',
           isActive
             ? 'bg-blue-50 text-blue-400 shadow-[0px_4px_24px_0px_rgba(0,0,0,0.08)] outline outline-1 outline-offset-[-1px] outline-blue-100'
             : 'text-grey-500 hover:bg-grey-150'
@@ -99,7 +105,7 @@ function SidebarMenuItem({
       }
     >
       <Icon className="size-6" />
-      <span className="text-center text-sm leading-tight">{label}</span>
+      <span className="text-m-p2 text-center">{label}</span>
     </NavLink>
   );
 }

--- a/frontend/src/common/components/TableToolbar.tsx
+++ b/frontend/src/common/components/TableToolbar.tsx
@@ -41,6 +41,7 @@ export function TableToolbar({
           <Button
             variant="tertiary"
             shape="circular"
+            aria-label="Filters"
             className={hasActiveFilters ? 'bg-blue-50' : 'bg-white'}
             onClick={onFilterClick}
           >

--- a/frontend/src/common/components/TableToolbar.tsx
+++ b/frontend/src/common/components/TableToolbar.tsx
@@ -34,7 +34,7 @@ export function TableToolbar({
   actions,
 }: TableToolbarProps) {
   return (
-    <div className="mb-8 flex items-center justify-between">
+    <div className="mb-7 flex items-center justify-between">
       <div className="flex items-center gap-5">
         <SearchBar placeholder={searchPlaceholder} {...search} />
         {showFilter && (
@@ -45,7 +45,7 @@ export function TableToolbar({
             className={hasActiveFilters ? 'bg-blue-50' : 'bg-white'}
             onClick={onFilterClick}
           >
-            <FilterLinesIcon className="size-4" />
+            <FilterLinesIcon className="size-5" />
           </Button>
         )}
       </div>

--- a/frontend/src/common/components/Tabs.tsx
+++ b/frontend/src/common/components/Tabs.tsx
@@ -15,7 +15,9 @@ function TabsList({
     <div className="flex flex-col gap-0">
       <TabsPrimitive.List
         data-slot="tabs-list"
-        className={cn('flex gap-8', className)}
+        // gap-13 (52px) is the 53px the design leaves between labels, to the
+        // nearest spacing step.
+        className={cn('flex gap-13', className)}
         {...props}
       />
       <hr className="border-grey-300" />
@@ -30,10 +32,14 @@ function TabsTrigger({
   return (
     <TabsPrimitive.Trigger
       data-slot="tabs-trigger"
+      // Per the Figma (measured on the Groups/Routes/Addresses frames, each
+      // showing a different tab active): labels are Nunito Bold 20/28 — the
+      // Desktop/H2 style — and every label is grey-500 whatever its state. The
+      // active tab is marked by its 3px blue underline alone, not by colour.
       className={cn(
-        'text-h3 cursor-pointer pb-2 capitalize transition-colors',
-        'text-grey-400 font-bold',
-        'data-[state=active]:border-b-2 data-[state=active]:border-blue-400 data-[state=active]:text-blue-400',
+        'text-h2 font-nunito cursor-pointer pb-1 font-bold capitalize',
+        'text-grey-500 transition-colors',
+        'data-[state=active]:border-b-[3px] data-[state=active]:border-blue-300',
         className
       )}
       {...props}

--- a/frontend/src/common/components/Tabs.tsx
+++ b/frontend/src/common/components/Tabs.tsx
@@ -12,7 +12,8 @@ function TabsList({
   ...props
 }: React.ComponentProps<typeof TabsPrimitive.List>) {
   return (
-    <div className="flex flex-col gap-0">
+    // 40px between the divider and whatever the tab reveals, per the design.
+    <div className="mb-10 flex flex-col gap-0">
       <TabsPrimitive.List
         data-slot="tabs-list"
         // gap-13 (52px) is the 53px the design leaves between labels, to the

--- a/frontend/src/common/components/index.ts
+++ b/frontend/src/common/components/index.ts
@@ -46,6 +46,7 @@ export {
   ModalTitle,
   ModalTrigger,
 } from './Modal';
+export { Pagination } from './Pagination';
 export {
   Popover,
   PopoverAnchor,

--- a/frontend/src/common/hooks/index.ts
+++ b/frontend/src/common/hooks/index.ts
@@ -1,4 +1,6 @@
 export { useDebouncedValue } from './useDebouncedValue';
+export type { UsePaginationReturn } from './usePagination';
+export { TABLE_PAGE_SIZE, usePagination } from './usePagination';
 export type { UseRowHighlightReturn } from './useRowHighlight';
 export { useRowHighlight } from './useRowHighlight';
 export type { UseSearchReturn } from './useSearch';

--- a/frontend/src/common/hooks/index.ts
+++ b/frontend/src/common/hooks/index.ts
@@ -1,6 +1,6 @@
 export { useDebouncedValue } from './useDebouncedValue';
 export type { UsePaginationReturn } from './usePagination';
-export { TABLE_PAGE_SIZE, usePagination } from './usePagination';
+export { clampPage, TABLE_PAGE_SIZE, usePagination } from './usePagination';
 export type { UseRowHighlightReturn } from './useRowHighlight';
 export { useRowHighlight } from './useRowHighlight';
 export type { UseSearchReturn } from './useSearch';

--- a/frontend/src/common/hooks/usePagination.ts
+++ b/frontend/src/common/hooks/usePagination.ts
@@ -14,6 +14,32 @@ export interface UsePaginationReturn {
 }
 
 /**
+ * Pull `page` back inside range when the result set shrinks under it — delete
+ * the only group on the last page, or assign the last unassigned route while
+ * that filter is on, and the current page stops existing. Left alone the table
+ * renders empty with no page marked current, and the reader has to work out
+ * that they should click back.
+ *
+ * Call it after the list query, since only the response knows how many pages
+ * there are now. Setting state during render is deliberate (the same pattern
+ * usePagination uses for its reset): React re-renders with the corrected page
+ * before committing, so the empty page is never painted.
+ *
+ * `totalPages` of 0 means "not loaded yet", not "no pages", so it never clamps.
+ */
+export function clampPage(
+  page: number,
+  totalPages: number,
+  setPage: (page: number) => void
+): number {
+  if (totalPages >= 1 && page > totalPages) {
+    setPage(totalPages);
+    return totalPages;
+  }
+  return page;
+}
+
+/**
  * Page state for a server-paginated table.
  *
  * `resetKey` is whatever narrows the result set — the serialized search and

--- a/frontend/src/common/hooks/usePagination.ts
+++ b/frontend/src/common/hooks/usePagination.ts
@@ -1,0 +1,35 @@
+import { useState } from 'react';
+
+/**
+ * Rows per page for the admin tables. The Figma draws the table as a fixed box
+ * of fourteen 54px cells — a header plus thirteen rows — with the page
+ * switcher directly beneath it, so a full page fills the frame exactly.
+ */
+export const TABLE_PAGE_SIZE = 13;
+
+export interface UsePaginationReturn {
+  /** Current page, 1-indexed. Feed straight into the list query. */
+  page: number;
+  setPage: (page: number) => void;
+}
+
+/**
+ * Page state for a server-paginated table.
+ *
+ * `resetKey` is whatever narrows the result set — the serialized search and
+ * filter query. When it changes the page snaps back to 1: page 4 of an
+ * unfiltered list is usually past the end of a filtered one, and a table that
+ * renders empty the moment you type is worse than one that starts over.
+ *
+ * The reset is applied to the returned `page` immediately (not just to the
+ * stored state) so the render that first sees the new key already asks for
+ * page 1, rather than firing a throwaway request for the stale page.
+ */
+export function usePagination(resetKey: string): UsePaginationReturn {
+  const [state, setState] = useState({ key: resetKey, page: 1 });
+
+  const page = state.key === resetKey ? state.page : 1;
+  if (state.key !== resetKey) setState({ key: resetKey, page: 1 });
+
+  return { page, setPage: (next) => setState({ key: resetKey, page: next }) };
+}

--- a/frontend/src/common/hooks/useRowHighlight.ts
+++ b/frontend/src/common/hooks/useRowHighlight.ts
@@ -46,6 +46,10 @@ export function useRowHighlight(
     [durationMs]
   );
 
+  // Drop a pending un-highlight when the table goes away, so it can't fire a
+  // setState into an unmounted component.
+  useEffect(() => () => clearTimeout(timer.current), []);
+
   // Runs again as `rows` updates because the row may not exist in the DOM (or
   // may re-sort) until the list refetch lands; scrolledRef keeps it to one
   // scroll per highlight.

--- a/frontend/src/common/utils/index.ts
+++ b/frontend/src/common/utils/index.ts
@@ -4,3 +4,4 @@ export {
   parseDateOnly,
   toNaiveDateString,
 } from './dateUtils';
+export { orDash } from './tableUtils';

--- a/frontend/src/common/utils/tableUtils.ts
+++ b/frontend/src/common/utils/tableUtils.ts
@@ -1,0 +1,12 @@
+/**
+ * Render an empty table cell as the design's hyphen.
+ *
+ * Empty means null/undefined, the empty string, or a zero count — a group with
+ * no routes yet reads "-", not "0", because the routes haven't been generated
+ * rather than counted to nothing. Shared so every admin table uses one
+ * character; the tables previously mixed "-" and "—".
+ */
+export const orDash = (value: string | number | null | undefined): string =>
+  value === null || value === undefined || value === '' || value === 0
+    ? '-'
+    : String(value);

--- a/frontend/src/features/announcements/AnnouncementsBoard.tsx
+++ b/frontend/src/features/announcements/AnnouncementsBoard.tsx
@@ -170,11 +170,11 @@ export function AnnouncementsBoard() {
       <Button
         type="button"
         variant="tertiary"
-        shape="circular"
+        shape="circularLarge"
         aria-label="Open announcements"
         onClick={() => setPanelOpen(true)}
       >
-        <MegaphoneIcon className="size-5 text-blue-300" />
+        <MegaphoneIcon className="size-[22px] text-blue-300" />
       </Button>
 
       <AnnouncementsPanel

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -264,11 +264,14 @@
 
 @layer utilities {
   /* Page-level margins from the F4K design system, ADMIN platform only.
-   * Mobile: 20px · Tablet: 40px · Desktop: 80px left/right, 40px top.
+   * Mobile: 20px · Tablet: 40px · Desktop: 48px left/right, 40px top.
    *
    * Driver pages must not use this: DriverLayout already applies the driver
    * spec (20px / 32px) to the whole platform, so adding this on top of it
-   * doubles the padding rather than replacing it. */
+   * doubles the padding rather than replacing it.
+   *
+   * The desktop inset is measured off the admin frames: content runs 170→1392
+   * inside a 1440 frame whose nav rail is 120 wide, i.e. 48px either side. */
   .admin-page-margins {
     padding-left: 1.25rem; /* 20px */
     padding-right: 1.25rem;
@@ -283,8 +286,8 @@
   }
   @media (width >= theme(--breakpoint-desktop)) {
     .admin-page-margins {
-      padding-left: 5rem; /* 80px */
-      padding-right: 5rem;
+      padding-left: 3rem; /* 48px */
+      padding-right: 3rem;
       padding-top: 2.5rem; /* 40px */
     }
   }

--- a/frontend/src/layouts/AdminLayout.tsx
+++ b/frontend/src/layouts/AdminLayout.tsx
@@ -27,7 +27,7 @@ export const AdminLayout = () => {
     <SidebarProvider>
       <Sidebar>
         <SidebarHeader>
-          <img src={logoImg} alt="Food4Kids" className="w-20 object-contain" />
+          <img src={logoImg} alt="Food4Kids" className="w-22 object-contain" />
         </SidebarHeader>
 
         <SidebarContent>

--- a/frontend/src/pages/admin/routes/AdminRoutesPage.tsx
+++ b/frontend/src/pages/admin/routes/AdminRoutesPage.tsx
@@ -42,12 +42,11 @@ export const AdminRoutesPage = () => {
   };
 
   return (
-    <Tabs
-      value={tab}
-      onValueChange={handleTabChange}
-      className="flex flex-col gap-8"
-    >
-      <div className="flex items-start justify-between">
+    // The design's two vertical gaps differ — 32px under the title row, 40
+    // under the tab divider — so they are set here rather than by one gap on
+    // the column. The title row is 48 tall, not the h1's own 44.
+    <Tabs value={tab} onValueChange={handleTabChange} className="flex flex-col">
+      <div className="mb-8 flex h-12 items-start justify-between">
         <h1>Routes</h1>
         <div className="flex items-center gap-6">
           <AnnouncementsBoard />

--- a/frontend/src/pages/admin/routes/AdminRoutesPage.tsx
+++ b/frontend/src/pages/admin/routes/AdminRoutesPage.tsx
@@ -46,7 +46,7 @@ export const AdminRoutesPage = () => {
     // under the tab divider — so they are set here rather than by one gap on
     // the column. The title row is 48 tall, not the h1's own 44.
     <Tabs value={tab} onValueChange={handleTabChange} className="flex flex-col">
-      <div className="mb-8 flex h-12 items-start justify-between">
+      <div className="mb-8 flex h-12 items-center justify-between">
         <h1>Routes</h1>
         <div className="flex items-center gap-6">
           <AnnouncementsBoard />

--- a/frontend/src/pages/admin/routes/AdminRoutesPage.tsx
+++ b/frontend/src/pages/admin/routes/AdminRoutesPage.tsx
@@ -1,3 +1,5 @@
+import { useSearchParams } from 'react-router-dom';
+
 import {
   Account,
   Tabs,
@@ -14,12 +16,37 @@ import {
 } from './components';
 import { useAddressesTabState, useGroupsTabState } from './hooks';
 
+const TABS = ['groups', 'routes', 'addresses'] as const;
+type RoutesTab = (typeof TABS)[number];
+
+const isTab = (value: string | null): value is RoutesTab =>
+  TABS.includes(value as RoutesTab);
+
 export const AdminRoutesPage = () => {
   const groupsState = useGroupsTabState();
   const addressesState = useAddressesTabState();
 
+  // The tab lives in the URL so a refresh, a bookmark, or a link keeps the
+  // reader where they were. An absent or unrecognised ?tab= falls back to
+  // Groups rather than erroring: the query string is reader input, and the
+  // page has a sensible default. Replaced rather than pushed — Back should
+  // leave the page, not walk back through the tabs you looked at.
+  const [searchParams, setSearchParams] = useSearchParams();
+  const param = searchParams.get('tab');
+  const tab: RoutesTab = isTab(param) ? param : 'groups';
+
+  const handleTabChange = (value: string) => {
+    const next = new URLSearchParams(searchParams);
+    next.set('tab', value);
+    setSearchParams(next, { replace: true });
+  };
+
   return (
-    <Tabs defaultValue="groups" className="flex flex-col gap-8">
+    <Tabs
+      value={tab}
+      onValueChange={handleTabChange}
+      className="flex flex-col gap-8"
+    >
       <div className="flex items-start justify-between">
         <h1>Routes</h1>
         <div className="flex items-center gap-6">

--- a/frontend/src/pages/admin/routes/components/AddressActionsCell.tsx
+++ b/frontend/src/pages/admin/routes/components/AddressActionsCell.tsx
@@ -28,7 +28,7 @@ export function AddressActionsCell({ row }: AddressActionsCellProps) {
               'transition-colors hover:bg-blue-50 data-[state=open]:bg-blue-50'
             )}
           >
-            <MoreVerticalIcon className="text-grey-400 size-5" />
+            <MoreVerticalIcon className="text-grey-400 size-4" />
           </button>
         </PopoverTrigger>
         <PopoverContent

--- a/frontend/src/pages/admin/routes/components/AssignDriverCell.tsx
+++ b/frontend/src/pages/admin/routes/components/AssignDriverCell.tsx
@@ -1,0 +1,36 @@
+import { useState } from 'react';
+
+import type { RouteWithDateRead } from '@/api/generated/types.gen';
+import { Button } from '@/common/components';
+
+import { ReassignDriverModal } from './ReassignDriverModal';
+
+interface AssignDriverCellProps {
+  row: RouteWithDateRead;
+  /** Called once a driver is assigned, e.g. to highlight the row. */
+  onUpdated?: () => void;
+}
+
+/**
+ * The Driver cell for a route nobody is driving yet: a pill that opens the
+ * same driver picker the kebab's "Reassign Driver" opens. Per the design the
+ * gap is an action rather than a warning — the count of unassigned routes is
+ * already called out by the banner above the table.
+ */
+export function AssignDriverCell({ row, onUpdated }: AssignDriverCellProps) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <Button shape="compact" onClick={() => setOpen(true)}>
+        Assign
+      </Button>
+      <ReassignDriverModal
+        open={open}
+        onOpenChange={setOpen}
+        route={row}
+        onUpdated={onUpdated}
+      />
+    </>
+  );
+}

--- a/frontend/src/pages/admin/routes/components/ReassignDriverModal.tsx
+++ b/frontend/src/pages/admin/routes/components/ReassignDriverModal.tsx
@@ -71,11 +71,19 @@ export function ReassignDriverModal({
     );
   };
 
+  // The same dialog serves the kebab's "Reassign Driver" and the Driver
+  // column's "Assign" pill. Reached from the pill there is nobody to reassign
+  // from, so it says Assign — the design's own word for that action — and
+  // drops the "Currently Assigned: Unassigned" line that only restates it.
+  const isReassign = Boolean(route.driver_name);
+
   return (
     <Modal open={open} onOpenChange={handleOpenChange}>
       <ModalContent>
         <ModalHeader>
-          <ModalTitle>Reassign Driver</ModalTitle>
+          <ModalTitle>
+            {isReassign ? 'Reassign Driver' : 'Assign Driver'}
+          </ModalTitle>
           <ModalDescription>
             {route.name} • {route.group_name} •{' '}
             {formatContextDate(route.drive_date)}
@@ -83,14 +91,16 @@ export function ReassignDriverModal({
         </ModalHeader>
 
         <div className="flex flex-col gap-4">
-          <div className="flex flex-col gap-2">
-            <p className="text-p1 text-grey-500 font-semibold">
-              Currently Assigned
-            </p>
-            <p className="border-grey-300 text-p2 text-grey-400 border-l-2 pl-4">
-              {route.driver_name ?? 'Unassigned'}
-            </p>
-          </div>
+          {isReassign && (
+            <div className="flex flex-col gap-2">
+              <p className="text-p1 text-grey-500 font-semibold">
+                Currently Assigned
+              </p>
+              <p className="border-grey-300 text-p2 text-grey-400 border-l-2 pl-4">
+                {route.driver_name}
+              </p>
+            </div>
+          )}
 
           <Field>
             <FieldLabel>New Driver</FieldLabel>
@@ -111,7 +121,8 @@ export function ReassignDriverModal({
 
         {isError && (
           <FieldDescription error>
-            Something went wrong reassigning the driver. Please try again.
+            Something went wrong {isReassign ? 'reassigning' : 'assigning'} the
+            driver. Please try again.
           </FieldDescription>
         )}
         <ModalFooter>
@@ -127,7 +138,7 @@ export function ReassignDriverModal({
             disabled={!driverId || isPending}
             onClick={handleSubmit}
           >
-            Reassign
+            {isReassign ? 'Reassign' : 'Assign'}
           </Button>
         </ModalFooter>
       </ModalContent>

--- a/frontend/src/pages/admin/routes/components/RouteActionsCell.tsx
+++ b/frontend/src/pages/admin/routes/components/RouteActionsCell.tsx
@@ -64,7 +64,7 @@ export function RouteActionsCell({ row, onUpdated }: RouteActionsCellProps) {
               'transition-colors hover:bg-blue-50 data-[state=open]:bg-blue-50'
             )}
           >
-            <MoreVerticalIcon className="text-grey-400 size-5" />
+            <MoreVerticalIcon className="text-grey-400 size-4" />
           </button>
         </PopoverTrigger>
         <PopoverContent

--- a/frontend/src/pages/admin/routes/components/RouteAddressesTab.tsx
+++ b/frontend/src/pages/admin/routes/components/RouteAddressesTab.tsx
@@ -60,7 +60,7 @@ const COLUMNS: Column<LocationRead>[] = [
     sortValue: (row) =>
       row.last_delivery_date ? new Date(row.last_delivery_date) : null,
     render: (row) =>
-      row.last_delivery_date ? formatShortDate(row.last_delivery_date) : '-',
+      orDash(row.last_delivery_date && formatShortDate(row.last_delivery_date)),
   },
   {
     key: 'total_deliveries',

--- a/frontend/src/pages/admin/routes/components/RouteAddressesTab.tsx
+++ b/frontend/src/pages/admin/routes/components/RouteAddressesTab.tsx
@@ -21,7 +21,7 @@ import {
   TableToolbar,
 } from '@/common/components';
 import { useTableSort } from '@/common/hooks';
-import { formatShortDate } from '@/common/utils';
+import { formatShortDate, orDash } from '@/common/utils';
 
 import type { AddressesTabState } from '../hooks';
 import { AddressActionsCell } from './AddressActionsCell';
@@ -29,10 +29,6 @@ import { EmptyState } from './EmptyState';
 import { StatusHeader } from './StatusHeader';
 
 const STATUSES: LocationStatusEnum[] = ['Active', 'Unscheduled', 'Inactive'];
-
-/** Renders a nullable/empty cell value as an em dash. */
-const orDash = (value: string | null | undefined) =>
-  value && value.length > 0 ? value : '—';
 
 const COLUMNS: Column<LocationRead>[] = [
   {
@@ -64,7 +60,7 @@ const COLUMNS: Column<LocationRead>[] = [
     sortValue: (row) =>
       row.last_delivery_date ? new Date(row.last_delivery_date) : null,
     render: (row) =>
-      row.last_delivery_date ? formatShortDate(row.last_delivery_date) : '—',
+      row.last_delivery_date ? formatShortDate(row.last_delivery_date) : '-',
   },
   {
     key: 'total_deliveries',

--- a/frontend/src/pages/admin/routes/components/RouteAddressesTab.tsx
+++ b/frontend/src/pages/admin/routes/components/RouteAddressesTab.tsx
@@ -17,6 +17,7 @@ import {
   ModalFooter,
   ModalHeader,
   ModalTitle,
+  Pagination,
   TableToolbar,
 } from '@/common/components';
 import { useTableSort } from '@/common/hooks';
@@ -114,6 +115,9 @@ type RouteAddressesTabProps = AddressesTabState;
 
 export function RouteAddressesTab({
   rows,
+  page,
+  setPage,
+  totalPages,
   deliveryTypes,
   search,
   searchTerm,
@@ -181,6 +185,8 @@ export function RouteAddressesTab({
           />
         }
       />
+
+      <Pagination page={page} totalPages={totalPages} onPageChange={setPage} />
 
       <Modal open={filterOpen} onOpenChange={setFilterOpen}>
         <ModalContent>

--- a/frontend/src/pages/admin/routes/components/RouteGroupActionsCell.tsx
+++ b/frontend/src/pages/admin/routes/components/RouteGroupActionsCell.tsx
@@ -67,7 +67,7 @@ export function RouteGroupActionsCell({
               'transition-colors hover:bg-blue-50 data-[state=open]:bg-blue-50'
             )}
           >
-            <MoreVerticalIcon className="text-grey-400 size-5" />
+            <MoreVerticalIcon className="text-grey-400 size-4" />
           </button>
         </PopoverTrigger>
         <PopoverContent

--- a/frontend/src/pages/admin/routes/components/RouteGroupsTab.tsx
+++ b/frontend/src/pages/admin/routes/components/RouteGroupsTab.tsx
@@ -11,6 +11,7 @@ import {
   TableToolbar,
 } from '@/common/components';
 import { useRowHighlight, useTableSort } from '@/common/hooks';
+import { orDash } from '@/common/utils';
 
 import type { GroupsTabState } from '../hooks';
 import { DriveDateCell } from './DriveDateCell';
@@ -38,25 +39,26 @@ const COLUMNS: Column<RouteGroupRead>[] = [
     header: 'Delivery Type',
     sortable: true,
     sortValue: (row) => row.delivery_type,
-    render: (row) => row.delivery_type,
+    // Null until the group has stops — its delivery type is whatever they are.
+    render: (row) => orDash(row.delivery_type),
   },
   // Aggregate counts read '-' for groups with no routes yet (just created,
   // ahead of route generation)
   {
     key: 'num_routes',
     header: 'Routes',
-    render: (row) => row.num_routes || '-',
+    render: (row) => orDash(row.num_routes),
   },
   {
     key: 'num_locations',
     header: 'Locations',
-    render: (row) => row.num_locations || '-',
+    render: (row) => orDash(row.num_locations),
   },
-  { key: 'num_boxes', header: 'Boxes', render: (row) => row.num_boxes || '-' },
+  { key: 'num_boxes', header: 'Boxes', render: (row) => orDash(row.num_boxes) },
   {
     key: 'num_drivers_assigned',
     header: 'Drivers',
-    render: (row) => row.num_drivers_assigned || '-',
+    render: (row) => orDash(row.num_drivers_assigned),
   },
   {
     key: 'status',

--- a/frontend/src/pages/admin/routes/components/RouteGroupsTab.tsx
+++ b/frontend/src/pages/admin/routes/components/RouteGroupsTab.tsx
@@ -7,6 +7,7 @@ import {
   Button,
   DataTable,
   HighlightText,
+  Pagination,
   TableToolbar,
 } from '@/common/components';
 import { useRowHighlight, useTableSort } from '@/common/hooks';
@@ -81,6 +82,9 @@ type RouteGroupsTabProps = GroupsTabState;
 
 export function RouteGroupsTab({
   rows,
+  page,
+  setPage,
+  totalPages,
   deliveryTypes,
   search,
   searchTerm,
@@ -179,6 +183,8 @@ export function RouteGroupsTab({
           }
         />
       </div>
+
+      <Pagination page={page} totalPages={totalPages} onPageChange={setPage} />
 
       <RouteFilterModal
         open={filterOpen}

--- a/frontend/src/pages/admin/routes/components/RouteRoutesTab.tsx
+++ b/frontend/src/pages/admin/routes/components/RouteRoutesTab.tsx
@@ -10,10 +10,13 @@ import {
   Button,
   DataTable,
   HighlightText,
+  Pagination,
   TableToolbar,
 } from '@/common/components';
 import {
+  TABLE_PAGE_SIZE,
   useDebouncedValue,
+  usePagination,
   useRowHighlight,
   useSearch,
   useTableSort,
@@ -77,11 +80,14 @@ export function RouteRoutesTab() {
   // Debounced so the driver-name search hits the server once typing pauses.
   const searchTerm = useDebouncedValue(search.value).trim();
   const filters = useRouteFilters();
-  const { data } = useRoutes({
+  const query = {
     search: searchTerm || undefined,
     ...routeFiltersToQuery(filters.appliedFilters),
-  });
+  };
+  const { page, setPage } = usePagination(JSON.stringify(query));
+  const { data } = useRoutes({ ...query, page, page_size: TABLE_PAGE_SIZE });
   const rows = useMemo(() => data?.items ?? [], [data]);
+  const totalPages = data?.total_pages ?? 0;
   const { sort, toggleSort } = useTableSort();
   const [bannerDismissed, setBannerDismissed] = useState(false);
   // Highlight + scroll a row after a date edit (re-sorts it) or a driver
@@ -144,10 +150,18 @@ export function RouteRoutesTab() {
     [handleRowChanged, searchTerm]
   );
 
-  const unassignedCount = useMemo(
-    () => rows.filter((r) => !r.driver_name).length,
-    [rows]
-  );
+  // Counted server-side rather than from `rows`: the banner is about the whole
+  // filtered result set and `rows` is one page of it. page_size 1 because only
+  // the total is wanted — the item itself is thrown away. The driver-assignment
+  // chip is deliberately overridden: the banner answers "how many routes still
+  // need a driver", which is the same question whichever side of that filter
+  // you are currently looking at.
+  const { data: unassigned } = useRoutes({
+    ...query,
+    driver_assignment_status: ['Unassigned'],
+    page_size: 1,
+  });
+  const unassignedCount = unassigned?.total ?? 0;
 
   return (
     <>
@@ -191,6 +205,8 @@ export function RouteRoutesTab() {
           }
         />
       </div>
+
+      <Pagination page={page} totalPages={totalPages} onPageChange={setPage} />
 
       <RouteFilterModal
         open={filters.filterOpen}

--- a/frontend/src/pages/admin/routes/components/RouteRoutesTab.tsx
+++ b/frontend/src/pages/admin/routes/components/RouteRoutesTab.tsx
@@ -13,6 +13,7 @@ import {
   TableToolbar,
 } from '@/common/components';
 import {
+  clampPage,
   TABLE_PAGE_SIZE,
   useDebouncedValue,
   usePagination,
@@ -81,10 +82,15 @@ export function RouteRoutesTab() {
     search: searchTerm || undefined,
     ...routeFiltersToQuery(filters.appliedFilters),
   };
-  const { page, setPage } = usePagination(JSON.stringify(query));
-  const { data } = useRoutes({ ...query, page, page_size: TABLE_PAGE_SIZE });
+  const { page: requestedPage, setPage } = usePagination(JSON.stringify(query));
+  const { data } = useRoutes({
+    ...query,
+    page: requestedPage,
+    page_size: TABLE_PAGE_SIZE,
+  });
   const rows = useMemo(() => data?.items ?? [], [data]);
   const totalPages = data?.total_pages ?? 0;
+  const page = clampPage(requestedPage, totalPages, setPage);
   const { sort, toggleSort } = useTableSort();
   const [bannerDismissed, setBannerDismissed] = useState(false);
   // Highlight + scroll a row after a date edit (re-sorts it) or a driver

--- a/frontend/src/pages/admin/routes/components/RouteRoutesTab.tsx
+++ b/frontend/src/pages/admin/routes/components/RouteRoutesTab.tsx
@@ -3,7 +3,6 @@ import { Link } from 'react-router-dom';
 
 import type { RouteWithDateRead } from '@/api/generated/types.gen';
 import { useRoutes } from '@/api/routes';
-import AlertCircleIcon from '@/assets/icons/alert-circle.svg?react';
 import type { Column } from '@/common/components';
 import {
   Banner,
@@ -23,6 +22,7 @@ import {
 } from '@/common/hooks';
 
 import { routeFiltersToQuery, useRouteFilters } from '../hooks';
+import { AssignDriverCell } from './AssignDriverCell';
 import { DriveDateCell } from './DriveDateCell';
 import { EmptyState } from './EmptyState';
 import { RouteActionsCell } from './RouteActionsCell';
@@ -42,18 +42,14 @@ const COLUMNS: Column<RouteWithDateRead>[] = [
   {
     key: 'length',
     header: 'Distance (km)',
-    render: (row) => row.length,
+    // One decimal on every row, as the design shows — a bare integer next to
+    // "23.4" reads as a different quantity rather than a rounder one.
+    render: (row) => row.length.toFixed(1),
   },
   {
     key: 'driver_name',
     header: 'Driver',
-    render: (row) =>
-      row.driver_name ?? (
-        <span className="flex items-center gap-2">
-          <AlertCircleIcon className="text-red size-4 shrink-0" />
-          Unassigned
-        </span>
-      ),
+    render: (row) => row.driver_name ?? <AssignDriverCell row={row} />,
   },
   {
     key: 'status',
@@ -121,10 +117,10 @@ export function RouteRoutesTab() {
               row.driver_name ? (
                 <HighlightText text={row.driver_name} query={searchTerm} />
               ) : (
-                <span className="flex items-center gap-2">
-                  <AlertCircleIcon className="text-red size-4 shrink-0" />
-                  Unassigned
-                </span>
+                <AssignDriverCell
+                  row={row}
+                  onUpdated={() => handleRowChanged(row.route_id)}
+                />
               ),
           };
         }

--- a/frontend/src/pages/admin/routes/components/RouteRoutesTab.tsx
+++ b/frontend/src/pages/admin/routes/components/RouteRoutesTab.tsx
@@ -20,6 +20,7 @@ import {
   useSearch,
   useTableSort,
 } from '@/common/hooks';
+import { orDash } from '@/common/utils';
 
 import { routeFiltersToQuery, useRouteFilters } from '../hooks';
 import { AssignDriverCell } from './AssignDriverCell';
@@ -35,7 +36,7 @@ const COLUMNS: Column<RouteWithDateRead>[] = [
     header: 'Delivery Type',
     sortable: true,
     sortValue: (row) => row.delivery_type,
-    render: (row) => row.delivery_type ?? '—',
+    render: (row) => orDash(row.delivery_type),
   },
   { key: 'num_stops', header: 'Stops', render: (row) => row.num_stops },
   { key: 'box_total', header: 'Boxes', render: (row) => row.box_total },

--- a/frontend/src/pages/admin/routes/hooks/useAddressesTabState.ts
+++ b/frontend/src/pages/admin/routes/hooks/useAddressesTabState.ts
@@ -11,6 +11,7 @@ import {
 } from '@/api/system-settings';
 import type { UsePaginationReturn, UseSearchReturn } from '@/common/hooks';
 import {
+  clampPage,
   TABLE_PAGE_SIZE,
   useDebouncedValue,
   usePagination,
@@ -125,12 +126,14 @@ export function useAddressesTabState(): AddressesTabState {
     setFilterOpen(false);
   };
 
+  const totalPages = data?.total_pages ?? 0;
+
   return {
     rows: data?.items ?? [],
     isLoading,
-    page,
+    page: clampPage(page, totalPages, setPage),
     setPage,
-    totalPages: data?.total_pages ?? 0,
+    totalPages,
     deliveryTypes,
     search,
     searchTerm: debouncedSearch.trim(),

--- a/frontend/src/pages/admin/routes/hooks/useAddressesTabState.ts
+++ b/frontend/src/pages/admin/routes/hooks/useAddressesTabState.ts
@@ -9,8 +9,13 @@ import {
   getConfiguredDeliveryTypes,
   useSystemSettings,
 } from '@/api/system-settings';
-import type { UseSearchReturn } from '@/common/hooks';
-import { useDebouncedValue, useSearch } from '@/common/hooks';
+import type { UsePaginationReturn, UseSearchReturn } from '@/common/hooks';
+import {
+  TABLE_PAGE_SIZE,
+  useDebouncedValue,
+  usePagination,
+  useSearch,
+} from '@/common/hooks';
 
 export interface AddressesFilterState {
   statuses: Set<LocationStatusEnum>;
@@ -29,9 +34,10 @@ const copyFilters = (f: AddressesFilterState): AddressesFilterState => ({
   deliveryTypes: new Set(f.deliveryTypes),
 });
 
-export interface AddressesTabState {
+export interface AddressesTabState extends UsePaginationReturn {
   rows: LocationRead[];
   isLoading: boolean;
+  totalPages: number;
   deliveryTypes: string[];
   search: UseSearchReturn;
   /** Debounced search term the rows were filtered by, for highlighting. */
@@ -72,7 +78,7 @@ export function useAddressesTabState(): AddressesTabState {
   // the query fires once typing pauses.
   const debouncedSearch = useDebouncedValue(search.value);
 
-  const { data, isLoading } = useAddresses({
+  const query = {
     search: debouncedSearch.trim() || undefined,
     status:
       appliedFilters.statuses.size > 0
@@ -82,10 +88,14 @@ export function useAddressesTabState(): AddressesTabState {
       appliedFilters.deliveryTypes.size > 0
         ? [...appliedFilters.deliveryTypes]
         : undefined,
+  };
+  const { page, setPage } = usePagination(JSON.stringify(query));
+
+  const { data, isLoading } = useAddresses({
+    ...query,
+    page,
+    page_size: TABLE_PAGE_SIZE,
   });
-  // GET /locations is paginated; we currently surface only the first page.
-  // Pagination controls (and a total count) are future work.
-  const rows = data?.items ?? [];
 
   const openFilters = () => {
     setDraftFilters(copyFilters(appliedFilters));
@@ -116,8 +126,11 @@ export function useAddressesTabState(): AddressesTabState {
   };
 
   return {
-    rows,
+    rows: data?.items ?? [],
     isLoading,
+    page,
+    setPage,
+    totalPages: data?.total_pages ?? 0,
     deliveryTypes,
     search,
     searchTerm: debouncedSearch.trim(),

--- a/frontend/src/pages/admin/routes/hooks/useGroupsTabState.ts
+++ b/frontend/src/pages/admin/routes/hooks/useGroupsTabState.ts
@@ -1,14 +1,21 @@
 import type { RouteGroupRead } from '@/api/generated/types.gen';
 import { useRouteGroups } from '@/api/route-groups';
-import type { UseSearchReturn } from '@/common/hooks';
-import { useDebouncedValue, useSearch } from '@/common/hooks';
+import type { UsePaginationReturn, UseSearchReturn } from '@/common/hooks';
+import {
+  TABLE_PAGE_SIZE,
+  useDebouncedValue,
+  usePagination,
+  useSearch,
+} from '@/common/hooks';
 
 import type { UseRouteFiltersReturn } from './useRouteFilters';
 import { routeFiltersToQuery, useRouteFilters } from './useRouteFilters';
 
-export interface GroupsTabState extends UseRouteFiltersReturn {
+export interface GroupsTabState
+  extends UseRouteFiltersReturn, UsePaginationReturn {
   rows: RouteGroupRead[];
   isLoading: boolean;
+  totalPages: number;
   search: UseSearchReturn;
   /** Debounced search term the rows were filtered by, for highlighting. */
   searchTerm: string;
@@ -22,15 +29,25 @@ export function useGroupsTabState(): GroupsTabState {
   // group name (GET /route-groups?search); the chips narrow server-side too.
   const debouncedSearch = useDebouncedValue(search.value);
 
-  const { data: rows = [], isLoading } = useRouteGroups({
+  const query = {
     search: debouncedSearch.trim() || undefined,
     ...routeFiltersToQuery(filters.appliedFilters),
+  };
+  const { page, setPage } = usePagination(JSON.stringify(query));
+
+  const { data, isLoading } = useRouteGroups({
+    ...query,
+    page,
+    page_size: TABLE_PAGE_SIZE,
   });
 
   return {
     ...filters,
-    rows,
+    rows: data?.items ?? [],
     isLoading,
+    page,
+    setPage,
+    totalPages: data?.total_pages ?? 0,
     search,
     searchTerm: debouncedSearch.trim(),
   };

--- a/frontend/src/pages/admin/routes/hooks/useGroupsTabState.ts
+++ b/frontend/src/pages/admin/routes/hooks/useGroupsTabState.ts
@@ -2,6 +2,7 @@ import type { RouteGroupRead } from '@/api/generated/types.gen';
 import { useRouteGroups } from '@/api/route-groups';
 import type { UsePaginationReturn, UseSearchReturn } from '@/common/hooks';
 import {
+  clampPage,
   TABLE_PAGE_SIZE,
   useDebouncedValue,
   usePagination,
@@ -41,13 +42,15 @@ export function useGroupsTabState(): GroupsTabState {
     page_size: TABLE_PAGE_SIZE,
   });
 
+  const totalPages = data?.total_pages ?? 0;
+
   return {
     ...filters,
     rows: data?.items ?? [],
     isLoading,
-    page,
+    page: clampPage(page, totalPages, setPage),
     setPage,
-    totalPages: data?.total_pages ?? 0,
+    totalPages,
     search,
     searchTerm: debouncedSearch.trim(),
   };


### PR DESCRIPTION
Follow-ups to #219, plus a pass aligning the admin Routes page with the Figma frames.

## Backend

- **A route group's delivery type is derived, not stored.** The column added in `b8e2a4c6d9f1` only ever acted as a fallback for a group with no stops, and the one UI that could have written it was never built — so it was always NULL while reads derived the real value from the group's locations. Two sources for one value, one of them always empty, is worse than one. Migration `c1f4a80b7e35` drops the column; groups with no stops now report `delivery_type: null`.
- **`GET /route-groups` is paginated**, returning `PaginatedResponse[RouteGroupRead]` like the other list endpoints.
- **`RouteWithDateRead.status` is typed as `RouteStatusEnum`** rather than a bare string.

## Frontend behaviour

- **All three tables paginate** (13 rows — the fixed-height table the design draws), via a shared `usePagination` hook that resets to page 1 when the search or filters change, applying the reset immediately so no throwaway request fires.
- **The active tab lives in the URL** (`?tab=`), so a refresh, bookmark, or shared link lands where you were. Unrecognised values fall back to Groups; the change is `replace`d, so Back leaves the page instead of walking the tabs.
- **Unassigned routes get an Assign pill** that opens the existing driver modal in an "assign" mode (no "Currently Assigned" block, different title and CTA). The unassigned count now comes from the server rather than the current page.
- Nits: the filter button has an accessible name, distances show one decimal, empty cells use the design's single dash, and a leaked timer is cleaned up.

## Design alignment

The app shell was systematically off, so every value here is measured off the Figma frames rather than eyeballed: 120px nav rail, 88px logo, 48px nav gaps, 48px page margins, 54px table cells, and the tab bar's type and spacing. A full sweep of the frames' text styles also caught two mismatches that are invisible by eye — table body cells are SemiBold (not Regular) and headers are Bold 16/20 (not SemiBold 16/24).

The kebab is the last of these: the design gives it a 30px column flush to the card's inner edge with a 16px glyph, where we drew a 20px glyph inside a padded cell, putting it ~17px short.

**One deliberate departure from `main`:** #226 set `.admin-page-margins` to 80px on desktop. The admin frames put content at 170→1392 inside a 1440 frame whose rail is 120 wide, i.e. **48px** either side — at 80px the content lands at 200 instead of 170. This PR sets 48px. Driver pages are untouched (`DriverLayout` has its own spec, as #226 documented). Flagging it since it reverses a recent decision.

Verified against the frames with the local overlay harness: title 42, tabs 120, toolbar 196, table 268, header 54, rows 54, rail 120, content 168..1392, avatar cluster right edge 1392 — all within ~1–2px.

Some inconsistencies were on the design side and were fixed in Figma rather than in code — most visibly the pagination block, which was absolutely positioned inside its own centre-aligned row and had drifted to five different x values across 38 frames (596 / 602 / 638 / 639 / 525). All 38 are now centred at 613.5, which is where the code already put it.

## Testing

`test_routes.py` is **165/165 green** on this branch (164/164 on `main`) — the new cases cover the derived delivery type and pagination-after-filtering. Frontend `tsc`, `eslint src` and `prettier` are clean; backend `ruff check`, `ruff format --check` and `mypy` all pass.

Note for anyone running the suite locally: without `GOOGLE_MAPS_API_KEY` set, ~70 tests fail with `Must provide API key or enterprise credentials` and it looks like a pre-existing baseline. It isn't — set the key and the suite is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
