### PR TITLE
Stop reporting unreachable-server failures as bad credentials

### DIFF
--- a/frontend/src/api/errors.ts
+++ b/frontend/src/api/errors.ts
@@ -11,15 +11,15 @@ import { isAxiosError } from 'axios';
  * password that was never wrong.
  */
 type ApiFailureKind =
-  /** 401 or 403 — the server rejected the credentials, token, or link. */
+  /** 401 or 403, meaning the server rejected the credentials, token, or link. */
   | 'unauthorized'
-  /** Another 4xx — the server understood the request and declined it. */
+  /** Another 4xx: the server understood the request and declined it. */
   | 'rejected'
-  /** 5xx — the request was fine; the server broke while handling it. */
+  /** 5xx. The request was fine; the server broke while handling it. */
   | 'server'
   /** No response at all: offline, DNS failure, reset connection, timeout, CORS. */
   | 'unreachable'
-  /** Not an HTTP failure — a bug in our own success/error handling. */
+  /** Not an HTTP failure, so a bug in our own success/error handling. */
   | 'unknown';
 
 function classifyApiFailure(error: unknown): ApiFailureKind {
@@ -45,8 +45,8 @@ function classifyApiFailure(error: unknown): ApiFailureKind {
 
 /**
  * The message to show for a failed request, or `null` when the server
- * explicitly refused what the user supplied — the caller words that case
- * itself, because only it knows what was being refused.
+ * explicitly refused what the user supplied. The caller words that case itself,
+ * because only it knows what was being refused.
  *
  * Never surfaces the underlying error: backend detail belongs in the console,
  * not in front of a driver.
@@ -59,7 +59,7 @@ export function describeApiFailure(error: unknown): string | null {
     case 'rejected':
       return null;
     case 'unreachable':
-      return "Can't reach the server — check your connection and try again.";
+      return "Can't reach the server. Check your connection and try again.";
     case 'server':
     case 'unknown':
       return 'Something went wrong on our end. Please try again in a moment.';

--- a/frontend/src/api/errors.ts
+++ b/frontend/src/api/errors.ts
@@ -1,0 +1,67 @@
+import { isAxiosError } from 'axios';
+
+/**
+ * Why a request failed, at the granularity a form needs in order to word its
+ * message.
+ *
+ * The distinction that matters is `unauthorized`/`rejected` versus everything
+ * else: only those two mean the server looked at what the user supplied and
+ * refused it. A dropped connection or a 500 says nothing about the input, and
+ * reporting one as "incorrect email or password" sends people off to reset a
+ * password that was never wrong.
+ */
+type ApiFailureKind =
+  /** 401 or 403 — the server rejected the credentials, token, or link. */
+  | 'unauthorized'
+  /** Another 4xx — the server understood the request and declined it. */
+  | 'rejected'
+  /** 5xx — the request was fine; the server broke while handling it. */
+  | 'server'
+  /** No response at all: offline, DNS failure, reset connection, timeout, CORS. */
+  | 'unreachable'
+  /** Not an HTTP failure — a bug in our own success/error handling. */
+  | 'unknown';
+
+function classifyApiFailure(error: unknown): ApiFailureKind {
+  if (!isAxiosError(error)) {
+    return 'unknown';
+  }
+
+  const status = error.response?.status;
+
+  // Axios only omits `response` when the request never got an answer, which is
+  // exactly the case we must not blame on the user's input.
+  if (status === undefined) {
+    return 'unreachable';
+  }
+  if (status === 401 || status === 403) {
+    return 'unauthorized';
+  }
+  if (status >= 500) {
+    return 'server';
+  }
+  return 'rejected';
+}
+
+/**
+ * The message to show for a failed request, or `null` when the server
+ * explicitly refused what the user supplied — the caller words that case
+ * itself, because only it knows what was being refused.
+ *
+ * Never surfaces the underlying error: backend detail belongs in the console,
+ * not in front of a driver.
+ */
+export function describeApiFailure(error: unknown): string | null {
+  const kind = classifyApiFailure(error);
+
+  switch (kind) {
+    case 'unauthorized':
+    case 'rejected':
+      return null;
+    case 'unreachable':
+      return "Can't reach the server — check your connection and try again.";
+    case 'server':
+    case 'unknown':
+      return 'Something went wrong on our end. Please try again in a moment.';
+  }
+}

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -1,5 +1,6 @@
 export { useAddresses } from './addresses';
 export { useForgotPassword, useLogin } from './auth';
+export { describeApiFailure } from './errors';
 export { useReviewLocations } from './locations';
 export { useRouteGroups } from './route-groups';
 export { useSystemSettings } from './system-settings';

--- a/frontend/src/pages/auth/CreatePassword.tsx
+++ b/frontend/src/pages/auth/CreatePassword.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 
 import { useRegisterDriver } from '@/api/auth';
+import { describeApiFailure } from '@/api/errors';
 import { Button, NotFoundPage } from '@/common/components';
 import { cn } from '@/lib/utils';
 
@@ -12,6 +13,7 @@ type Step = 'FORM' | 'CONFIRMATION';
 
 export const CreatePassword = () => {
   const [step, setStep] = useState<Step>('FORM');
+  const [submitError, setSubmitError] = useState<string | null>(null);
   const headerTitle = step === 'FORM' ? 'Create a password' : 'Account created';
   const subheaderTitle =
     step === 'FORM'
@@ -32,6 +34,7 @@ export const CreatePassword = () => {
   const handleRegister = (password: string) => {
     if (!token) return;
 
+    setSubmitError(null);
     mutate(
       {
         user_invite_id: token,
@@ -39,6 +42,14 @@ export const CreatePassword = () => {
       },
       {
         onSuccess: () => setStep('CONFIRMATION'),
+        onError: (error) => {
+          // A refusal here is the invite link, never the password: the backend
+          // answers 403 for a link that's already used or expired.
+          setSubmitError(
+            describeApiFailure(error) ??
+              'This registration link is no longer valid. Ask your admin for a new one.'
+          );
+        },
       }
     );
   };
@@ -59,6 +70,7 @@ export const CreatePassword = () => {
           onSubmit={handleRegister}
           isPending={isPending}
           submitButtonText="Create account"
+          submitError={submitError}
         />
       ) : (
         <AccountCreationConfirmation />

--- a/frontend/src/pages/auth/CreatePasswordForm.tsx
+++ b/frontend/src/pages/auth/CreatePasswordForm.tsx
@@ -1,22 +1,26 @@
-import { AlertTriangleIcon, CheckIcon, EyeOffIcon } from 'lucide-react';
+import { CheckIcon, EyeOffIcon } from 'lucide-react';
 import { type FormEvent, useState } from 'react';
 
 import EyeIcon from '@/assets/icons/eye.svg?react';
 import { Button, Field, FieldLabel, Input } from '@/common/components';
 import { cn } from '@/lib/utils';
 
+import { ErrorNote } from './ErrorNote';
 import { fieldNote } from './styles';
 
 interface CreatePasswordFormProps {
   onSubmit: (password: string) => void;
   isPending: boolean;
   submitButtonText: string;
+  /** Why the last submission failed, if it did. Nothing to do with the fields. */
+  submitError?: string | null;
 }
 
 export const CreatePasswordForm = ({
   onSubmit,
   isPending,
   submitButtonText,
+  submitError,
 }: CreatePasswordFormProps) => {
   const [password, setPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
@@ -110,16 +114,11 @@ export const CreatePasswordForm = ({
               </button>
             </div>
             {passwordError && (
-              <div
-                className={cn(fieldNote, 'text-red flex items-center gap-1')}
-              >
-                <AlertTriangleIcon className="h-4 w-4 shrink-0" />
-                <span>
-                  {password
-                    ? 'Please make sure all criteria is met'
-                    : 'Please enter a password'}
-                </span>
-              </div>
+              <ErrorNote>
+                {password
+                  ? 'Please make sure all criteria is met'
+                  : 'Please enter a password'}
+              </ErrorNote>
             )}
           </Field>
 
@@ -161,16 +160,11 @@ export const CreatePasswordForm = ({
                 </button>
               </div>
               {confirmPasswordError && (
-                <div
-                  className={cn(fieldNote, 'text-red flex items-center gap-1')}
-                >
-                  <AlertTriangleIcon className="h-4 w-4 shrink-0" />
-                  <span>
-                    {confirmPassword
-                      ? 'Please make sure both passwords match'
-                      : 'Please enter a password'}
-                  </span>
-                </div>
+                <ErrorNote>
+                  {confirmPassword
+                    ? 'Please make sure both passwords match'
+                    : 'Please enter a password'}
+                </ErrorNote>
               )}
             </Field>
           </div>
@@ -192,12 +186,16 @@ export const CreatePasswordForm = ({
 
         {/* Create Account Button */}
         <div className="flex flex-col">
+          {submitError && <ErrorNote className="mt-6">{submitError}</ErrorNote>}
           <Button
             form="register-form"
             type="submit"
             variant="primary"
             shape="default"
-            className="desktop:mt-12 mt-10 w-full py-3"
+            className={cn(
+              'w-full py-3',
+              submitError ? 'mt-4' : 'desktop:mt-12 mt-10'
+            )}
             disabled={isPending}
           >
             {submitButtonText}

--- a/frontend/src/pages/auth/ErrorNote.tsx
+++ b/frontend/src/pages/auth/ErrorNote.tsx
@@ -11,8 +11,8 @@ interface ErrorNoteProps {
 }
 
 /**
- * The red note the auth screens put under a field — or under the form as a
- * whole, when the failure isn't any one field's fault.
+ * The red note the auth screens put under a field, or under the form as a
+ * whole when the failure isn't any one field's fault.
  */
 export const ErrorNote = ({ children, className }: ErrorNoteProps) => (
   <div className={cn(fieldNote, 'text-red flex items-center gap-1', className)}>

--- a/frontend/src/pages/auth/ErrorNote.tsx
+++ b/frontend/src/pages/auth/ErrorNote.tsx
@@ -1,0 +1,22 @@
+import { type ReactNode } from 'react';
+
+import AlertTriangleIcon from '@/assets/icons/alert-triangle.svg?react';
+import { cn } from '@/lib/utils';
+
+import { fieldNote } from './styles';
+
+interface ErrorNoteProps {
+  children: ReactNode;
+  className?: string;
+}
+
+/**
+ * The red note the auth screens put under a field — or under the form as a
+ * whole, when the failure isn't any one field's fault.
+ */
+export const ErrorNote = ({ children, className }: ErrorNoteProps) => (
+  <div className={cn(fieldNote, 'text-red flex items-center gap-1', className)}>
+    <AlertTriangleIcon className="h-4 w-4 shrink-0" />
+    <span>{children}</span>
+  </div>
+);

--- a/frontend/src/pages/auth/ForgotPassword.tsx
+++ b/frontend/src/pages/auth/ForgotPassword.tsx
@@ -1,10 +1,20 @@
 import { type FormEvent, useEffect, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 
-import { useForgotPassword } from '@/api';
+import { describeApiFailure, useForgotPassword } from '@/api';
 import { Button, Field, FieldLabel, Input } from '@/common/components';
 
+import { ErrorNote } from './ErrorNote';
 import { WrapperWithLogo } from './Wrapper';
+
+/**
+ * The endpoint answers 204 whether or not the address exists — that's the
+ * anti-enumeration design — so a failure here is never about the email the user
+ * typed, and is never worth implying it was.
+ */
+const sendFailureMessage = (error: unknown) =>
+  describeApiFailure(error) ??
+  'We couldn’t send the reset link. Please try again in a moment.';
 
 type Step = 'FORM' | 'CONFIRMATION';
 
@@ -55,14 +65,20 @@ const ForgotPasswordForm = ({
   mutation,
   onSuccess,
 }: ForgotPasswordFormProps) => {
+  const [sendError, setSendError] = useState<string | null>(null);
+
   const handleForgotPassword = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
+    setSendError(null);
     mutation.mutate(
       { email },
       {
         onSuccess: () => {
           onSuccess();
+        },
+        onError: (error) => {
+          setSendError(sendFailureMessage(error));
         },
       }
     );
@@ -85,10 +101,13 @@ const ForgotPasswordForm = ({
               value={email}
               onChange={(e) => {
                 setEmail(e.target.value);
+                setSendError(null);
               }}
               required
             />
           </Field>
+
+          {sendError && <ErrorNote className="-mb-2">{sendError}</ErrorNote>}
 
           {/* Send Link Button */}
           <Button
@@ -124,6 +143,7 @@ const ResetLinkConfirmation = ({
 }: ResetLinkConfirmationProps) => {
   const navigate = useNavigate();
   const [countdown, setCountdown] = useState(60);
+  const [resendError, setResendError] = useState<string | null>(null);
 
   useEffect(() => {
     if (countdown === 0) return;
@@ -136,7 +156,17 @@ const ResetLinkConfirmation = ({
   }, [countdown]);
 
   const handleResendClick = () => {
-    mutation.mutate({ email });
+    setResendError(null);
+    mutation.mutate(
+      { email },
+      {
+        onError: (error) => {
+          // Nothing was sent, so don't make them wait out a countdown for it.
+          setResendError(sendFailureMessage(error));
+          setCountdown(0);
+        },
+      }
+    );
     setCountdown(60);
   };
 
@@ -171,6 +201,11 @@ const ResetLinkConfirmation = ({
               : 'Send link again'}
           </button>
         </p>
+        {resendError && (
+          <ErrorNote className="justify-center text-center">
+            {resendError}
+          </ErrorNote>
+        )}
       </div>
     </>
   );

--- a/frontend/src/pages/auth/ForgotPassword.tsx
+++ b/frontend/src/pages/auth/ForgotPassword.tsx
@@ -8,9 +8,9 @@ import { ErrorNote } from './ErrorNote';
 import { WrapperWithLogo } from './Wrapper';
 
 /**
- * The endpoint answers 204 whether or not the address exists — that's the
- * anti-enumeration design — so a failure here is never about the email the user
- * typed, and is never worth implying it was.
+ * The endpoint answers 204 whether or not the address exists, which is the
+ * anti-enumeration design. A failure here is therefore never about the email the
+ * user typed, and is never worth implying it was.
  */
 const sendFailureMessage = (error: unknown) =>
   describeApiFailure(error) ??

--- a/frontend/src/pages/auth/LoginPage.tsx
+++ b/frontend/src/pages/auth/LoginPage.tsx
@@ -1,14 +1,13 @@
 import { type FormEvent, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 
-import { useLogin } from '@/api';
-import AlertTriangleIcon from '@/assets/icons/alert-triangle.svg?react';
+import { describeApiFailure, useLogin } from '@/api';
 import EyeIcon from '@/assets/icons/eye.svg?react';
 import EyeOffIcon from '@/assets/icons/eye-off.svg?react';
 import { Button, Field, FieldLabel, Input } from '@/common/components';
 import { cn } from '@/lib/utils';
 
-import { fieldNote } from './styles';
+import { ErrorNote } from './ErrorNote';
 import { WrapperWithLogo } from './Wrapper';
 
 export const LoginPage = () => {
@@ -22,27 +21,47 @@ export const LoginPage = () => {
   );
 };
 
+/**
+ * `credentials` is the only failure the fields are guilty of, so it is the only
+ * one that reddens them. A login the server never answered gets a single
+ * form-level note instead — the email and password may well be correct.
+ */
+type LoginError = {
+  scope: 'credentials' | 'form';
+  message: string;
+};
+
 const LoginForm = () => {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [showPassword, setShowPassword] = useState(false);
   const [rememberMe, setRememberMe] = useState(false);
-  const [loginError, setLoginError] = useState(false);
+  const [error, setError] = useState<LoginError | null>(null);
+
+  const credentialsError = error?.scope === 'credentials';
 
   const loginMutation = useLogin();
   const navigate = useNavigate();
 
   const handleLogin = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    setLoginError(false);
+    setError(null);
     loginMutation.mutate(
       { email, password },
       {
         onSuccess: () => {
           navigate('/'); // 3. Navigate to base route on success
         },
-        onError: () => {
-          setLoginError(true);
+        onError: (failure) => {
+          const connectionMessage = describeApiFailure(failure);
+          setError(
+            connectionMessage
+              ? { scope: 'form', message: connectionMessage }
+              : {
+                  scope: 'credentials',
+                  message: 'Incorrect email or password',
+                }
+          );
         },
       }
     );
@@ -60,7 +79,7 @@ const LoginForm = () => {
               id="email"
               className={cn(
                 'px-6',
-                loginError && 'outline-red focus:outline-red'
+                credentialsError && 'outline-red focus:outline-red'
               )}
               type="email"
               autoComplete="email"
@@ -68,18 +87,11 @@ const LoginForm = () => {
               value={email}
               onChange={(e) => {
                 setEmail(e.target.value);
-                setLoginError(false);
+                setError(null);
               }}
               required
             />
-            {loginError && (
-              <div
-                className={cn(fieldNote, 'text-red flex items-center gap-1')}
-              >
-                <AlertTriangleIcon className="h-4 w-4 shrink-0" />
-                <span>Incorrect email or password</span>
-              </div>
-            )}
+            {credentialsError && <ErrorNote>{error.message}</ErrorNote>}
           </Field>
 
           <div className="flex flex-col gap-4">
@@ -94,12 +106,12 @@ const LoginForm = () => {
                   placeholder="Enter your password"
                   className={cn(
                     'px-6',
-                    loginError && 'outline-red focus:outline-red'
+                    credentialsError && 'outline-red focus:outline-red'
                   )}
                   value={password}
                   onChange={(e) => {
                     setPassword(e.target.value);
-                    setLoginError(false);
+                    setError(null);
                   }}
                   required
                 />
@@ -116,14 +128,7 @@ const LoginForm = () => {
                   )}
                 </button>
               </div>
-              {loginError && (
-                <div
-                  className={cn(fieldNote, 'text-red flex items-center gap-1')}
-                >
-                  <AlertTriangleIcon className="h-4 w-4 shrink-0" />
-                  <span>Incorrect email or password</span>
-                </div>
-              )}
+              {credentialsError && <ErrorNote>{error.message}</ErrorNote>}
             </Field>
 
             {/* Remember Me & Forgot Password */}
@@ -145,6 +150,12 @@ const LoginForm = () => {
               </Link>
             </div>
           </div>
+
+          {/* Failures that aren't the credentials' fault get one note for the
+              whole form, not a red outline on fields that may be perfectly fine. */}
+          {error?.scope === 'form' && (
+            <ErrorNote className="-mb-4">{error.message}</ErrorNote>
+          )}
 
           {/* Log In Button */}
           <Button

--- a/frontend/src/pages/auth/LoginPage.tsx
+++ b/frontend/src/pages/auth/LoginPage.tsx
@@ -24,7 +24,7 @@ export const LoginPage = () => {
 /**
  * `credentials` is the only failure the fields are guilty of, so it is the only
  * one that reddens them. A login the server never answered gets a single
- * form-level note instead — the email and password may well be correct.
+ * form-level note instead, because the email and password may well be correct.
  */
 type LoginError = {
   scope: 'credentials' | 'form';

--- a/frontend/src/pages/auth/ResetPassword.tsx
+++ b/frontend/src/pages/auth/ResetPassword.tsx
@@ -60,7 +60,7 @@ const ResetPasswordContent = ({ token }: ResetPasswordContentProps) => {
   }
 
   if (didValidationFail) {
-    // A link we couldn't check is not a link we can call dead — the backend
+    // A link we couldn't check is not a link we can call dead. The backend
     // answers 400 for a token that's really expired, and nothing at all when
     // it's the connection that's gone.
     return describeApiFailure(validationError) ? (

--- a/frontend/src/pages/auth/ResetPassword.tsx
+++ b/frontend/src/pages/auth/ResetPassword.tsx
@@ -2,7 +2,12 @@ import { useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 
 import { useUpdatePassword, useValidateResetToken } from '@/api/auth';
-import { CatchAllErrorPage, NotFoundPage } from '@/common/components';
+import { describeApiFailure } from '@/api/errors';
+import {
+  CatchAllErrorPage,
+  NotFoundPage,
+  ServiceUnavailablePage,
+} from '@/common/components';
 
 import { CreatePasswordForm } from './CreatePasswordForm';
 import { WrapperWithLogo } from './Wrapper';
@@ -26,10 +31,17 @@ const ResetPasswordContent = ({ token }: ResetPasswordContentProps) => {
   const subheaderTitle = 'Create a password to access the app';
 
   const navigate = useNavigate();
+  // A message means the reset never reached the server, so the form (and the
+  // password already typed into it) stays put and the user can retry. Only a
+  // refusal from the server itself is worth throwing the whole screen away.
+  const [connectionError, setConnectionError] = useState<string | null>(null);
   const [hasSubmitError, setHasSubmitError] = useState(false);
 
-  const { isLoading: isValidatingToken, isError: isTokenInvalid } =
-    useValidateResetToken({ password_reset_token: token });
+  const {
+    isLoading: isValidatingToken,
+    isError: didValidationFail,
+    error: validationError,
+  } = useValidateResetToken({ password_reset_token: token });
 
   const { mutate, isPending } = useUpdatePassword();
 
@@ -47,8 +59,15 @@ const ResetPasswordContent = ({ token }: ResetPasswordContentProps) => {
     );
   }
 
-  if (isTokenInvalid) {
-    return <NotFoundPage />;
+  if (didValidationFail) {
+    // A link we couldn't check is not a link we can call dead — the backend
+    // answers 400 for a token that's really expired, and nothing at all when
+    // it's the connection that's gone.
+    return describeApiFailure(validationError) ? (
+      <ServiceUnavailablePage />
+    ) : (
+      <NotFoundPage />
+    );
   }
 
   if (hasSubmitError) {
@@ -56,6 +75,7 @@ const ResetPasswordContent = ({ token }: ResetPasswordContentProps) => {
   }
 
   const handleResetPassword = (password: string) => {
+    setConnectionError(null);
     mutate(
       {
         password_reset_token: token,
@@ -65,8 +85,13 @@ const ResetPasswordContent = ({ token }: ResetPasswordContentProps) => {
         onSuccess: () => {
           navigate('/login', { replace: true });
         },
-        onError: () => {
-          setHasSubmitError(true);
+        onError: (error) => {
+          const message = describeApiFailure(error);
+          if (message) {
+            setConnectionError(message);
+          } else {
+            setHasSubmitError(true);
+          }
         },
       }
     );
@@ -83,6 +108,7 @@ const ResetPasswordContent = ({ token }: ResetPasswordContentProps) => {
         onSubmit={handleResetPassword}
         isPending={isPending}
         submitButtonText="Create account"
+        submitError={connectionError}
       />
     </WrapperWithLogo>
   );


### PR DESCRIPTION
## Problem

With the backend stopped, submitting **valid** credentials produced `POST /auth/login [FAILED: net::ERR_CONNECTION_RESET]` and the login page rendered *"Incorrect email or password"* under both fields. A driver in that situation goes and resets a password that was never wrong.

The same catch-all shape ran through the rest of the auth flows. Forgot-password and create-password swallowed failures entirely, so the button just did nothing, and reset-password mapped every failure, including a dropped connection, onto a full error page.

## Fix

`frontend/src/api/errors.ts` classifies the failure. `describeApiFailure()` returns wording for the failures the user's input had nothing to do with (no response at all, or a 5xx) and `null` when the server actively refused what was supplied. Each form words that second case itself. No backend detail reaches the screen; the raw error still goes to the console.

| Flow | Server refused (401/403/4xx) | Couldn't reach the server / 5xx |
|---|---|---|
| Login | "Incorrect email or password", per-field, unchanged | one form-level note, no red field outlines |
| Forgot password | n/a, since the endpoint answers 204 either way | "Can't reach the server. Check your connection and try again." (previously silent) |
| Create password | "This registration link is no longer valid. Ask your admin for a new one." (403) | same connection message (previously silent) |
| Reset password, submit | `CatchAllErrorPage`, unchanged | inline note, form and typed password kept |
| Reset password, link check | "Page not found", unchanged | `ServiceUnavailablePage` instead of claiming the link is dead |

A failed *resend* on forgot-password also no longer starts a 60-second countdown for a link that was never sent.

`get-login-link` is still an unimplemented TODO on the login page, so there was nothing to fix there.

`ErrorNote` factors out the red inline note these screens repeat. That also settles create-password's icon on the design-system asset the rest of the flow uses.

## Verification

Screenshots of all seven states were captured from this branch against the running backend.

- **Wrong password (real 401).** Red outlines and "Incorrect email or password" under both fields, exactly as before.
- **Backend unreachable.** "Can't reach the server. Check your connection and try again." as a single form-level note, fields untouched. The console confirms `AxiosError: Network Error`, where the 401 case logs `status code 401`.
- Same two branches checked on forgot-password and create-password, plus both link-check outcomes on reset-password (400 gives Page not found, unreachable gives Service Unavailable).

The unreachable case was reproduced by pointing the app at a port with no listener (`ERR_CONNECTION_REFUSED`) rather than stopping the shared `f4k_backend` container another worktree is using.

`pnpm exec tsc --noEmit && pnpm exec eslint src && pnpm exec prettier --check src` all pass.

There is no test framework in `frontend/`, so this carries no unit tests. Worth adding Vitest for `describeApiFailure`, which is pure and exhaustively testable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)