### PR TITLE
Match the route-generation wizard to the finalized frames

### DIFF
--- a/backend/python/app/models/location.py
+++ b/backend/python/app/models/location.py
@@ -163,6 +163,10 @@ class StaleEntry(SQLModel):
     delivery_group: str | None = None
     phone_primary: str
     phone_secondary: str | None = None
+    # Carried so the review step can show what is being taken off the roster in
+    # the same columns as the changed rows. Always known — it is stored on the
+    # Location, not read from the import.
+    num_children: int = 0
 
 
 class ChangedFieldStr(SQLModel):

--- a/backend/python/app/models/location.py
+++ b/backend/python/app/models/location.py
@@ -22,6 +22,11 @@ class LocationBase(SQLModel):
     )
     name: str
     contact_name: str
+    # Guardian's name, for Family deliveries. Distinct from contact_name, which
+    # holds the school name or the family's last name — a Family row has both.
+    # Nullable: School rows have no guardian, and rows imported before this
+    # column existed have nothing to backfill from.
+    guardian_name: str | None = None
     address: str
     phone_primary: str
     phone_secondary: str | None = None
@@ -102,6 +107,7 @@ class LocationImportEntry(SQLModel):
     """Parsed row from import file; all fields optional until validated."""
 
     contact_name: str | None = None
+    guardian_name: str | None = None
     address: str | None = None
     delivery_group: str | None = None
     phone_primary: str | None = None
@@ -144,6 +150,7 @@ class NetNewEntry(SQLModel):
 
     row: int
     contact_name: str
+    guardian_name: str | None = None
     address: str
     delivery_group: str | None = None
     phone_primary: str
@@ -194,6 +201,10 @@ class ChangedEntry(SQLModel):
     row: int
     location_id: UUID
     contact_name: str
+    # Diffed like the rest. The frames' Changed table has no Guardian Name
+    # column, but leaving it undiffed would mean a row whose only edit is the
+    # guardian's name never surfaces and the edit is dropped on ingest.
+    guardian_name: str | ChangedFieldOptStr | None = None
     address: str | ChangedFieldStr
     delivery_group: str | ChangedFieldOptStr | None = None
     phone_primary: str | ChangedFieldStr
@@ -261,6 +272,7 @@ class LocationUpdate(SQLModel):
     location_group_id: UUID | None = None
     name: str | None = None
     contact_name: str | None = None
+    guardian_name: str | None = None
     address: str | None = None
     phone_primary: str | None = None
     phone_secondary: str | None = None

--- a/backend/python/app/models/system_settings.py
+++ b/backend/python/app/models/system_settings.py
@@ -92,8 +92,11 @@ class SystemSettingsBase(SQLModel):
     # The default lives here and nowhere else: it applies only when a settings
     # row is created. Every other code path must read the configured list off
     # the (always-present) row rather than reaching for a fallback constant.
+    # Family first, per the import frames. This is display order everywhere the
+    # list is rendered, and it only applies to a settings row being created —
+    # an existing row keeps whatever order it was configured with.
     delivery_types: list[str] = Field(
-        default_factory=lambda: ["School", "Family"],
+        default_factory=lambda: ["Family", "School"],
         sa_column=Column(JSON, nullable=False),
     )
 

--- a/backend/python/app/services/implementations/location_service.py
+++ b/backend/python/app/services/implementations/location_service.py
@@ -873,6 +873,7 @@ class LocationService:
             delivery_group=location.location_group.name,
             phone_primary=location.phone_primary,
             phone_secondary=location.phone_secondary,
+            num_children=location.num_children,
         )
 
     def _to_changed_entry(

--- a/backend/python/app/services/implementations/location_service.py
+++ b/backend/python/app/services/implementations/location_service.py
@@ -73,18 +73,6 @@ ALLOWED_EXTENSIONS = {".csv", ".xlsx"}
 
 MAX_FILE_SIZE = 10 * 1024 * 1024  # 10MB
 
-# Default CSV column names
-DEFAULT_COLUMN_MAP = {
-    "contact_name": "Guardian Name",
-    "address": "Address",
-    "delivery_group": "Delivery Day",
-    "phone_primary": "Primary Phone",
-    "phone_secondary": "Secondary Phone",
-    "num_children": "Number of Children",
-    "halal": "Halal?",
-    "dietary_restrictions": "Specific Food Restrictions",
-}
-
 
 class InvalidDeliveryTypeError(ValueError):
     """Raised when a delivery type is not configured in system settings."""
@@ -855,6 +843,7 @@ class LocationService:
         return NetNewEntry(
             row=row_num,
             contact_name=entry.contact_name,
+            guardian_name=entry.guardian_name,
             address=entry.address,
             delivery_group=entry.delivery_group,
             phone_primary=entry.phone_primary,
@@ -889,6 +878,9 @@ class LocationService:
         phone_secondary_changed = (entry.phone_secondary or None) != (
             location.phone_secondary or None
         )
+        guardian_name_changed = (entry.guardian_name or None) != (
+            location.guardian_name or None
+        )
         num_children_changed = (
             entry.num_children is not None
             and entry.num_children != location.num_children
@@ -898,6 +890,7 @@ class LocationService:
         if not any(
             [
                 contact_name_changed,
+                guardian_name_changed,
                 address_changed,
                 delivery_group_changed,
                 phone_primary_changed,
@@ -912,6 +905,11 @@ class LocationService:
             row=row_num,
             location_id=location.location_id,
             contact_name=entry.contact_name,
+            guardian_name=ChangedFieldOptStr(
+                new_value=entry.guardian_name, old_value=location.guardian_name
+            )
+            if guardian_name_changed
+            else entry.guardian_name,
             address=ChangedFieldStr(new_value=entry.address, old_value=location.address)
             if address_changed
             else entry.address,
@@ -996,6 +994,7 @@ class LocationService:
 
         return LocationImportEntry(
             contact_name=get_value("contact_name"),
+            guardian_name=get_value("guardian_name"),
             address=get_value("address"),
             delivery_group=get_value("delivery_group"),
             phone_primary=get_value("phone_primary"),
@@ -1036,6 +1035,7 @@ class LocationService:
             location_group_id=location_data.location_group_id,
             name=location_data.name,
             contact_name=location_data.contact_name,
+            guardian_name=location_data.guardian_name,
             address=location_data.address,
             phone_primary=location_data.phone_primary,
             phone_secondary=location_data.phone_secondary,
@@ -1114,6 +1114,7 @@ class LocationService:
                     Location(
                         name=entry.contact_name,
                         contact_name=entry.contact_name,
+                        guardian_name=entry.guardian_name,
                         address=geocode_result.formatted_address,
                         phone_primary=entry.phone_primary,
                         phone_secondary=entry.phone_secondary,
@@ -1180,6 +1181,9 @@ class LocationService:
                         Location(
                             name=changed_entry.contact_name,
                             contact_name=changed_entry.contact_name,
+                            guardian_name=self._changed_optional_str_value(
+                                changed_entry.guardian_name
+                            ),
                             address=geocode_result.formatted_address,
                             phone_primary=self._changed_str_value(
                                 changed_entry.phone_primary
@@ -1209,6 +1213,9 @@ class LocationService:
                 location.in_roster = True
                 location.name = changed_entry.contact_name
                 location.contact_name = changed_entry.contact_name
+                location.guardian_name = self._changed_optional_str_value(
+                    changed_entry.guardian_name
+                )
                 location.phone_primary = self._changed_str_value(
                     changed_entry.phone_primary
                 )

--- a/backend/python/migrations/versions/d2e91c47ab08_add_location_guardian_name.py
+++ b/backend/python/migrations/versions/d2e91c47ab08_add_location_guardian_name.py
@@ -1,0 +1,32 @@
+"""Add guardian_name to locations
+
+The Apricot import maps a Guardian Name column separately from School Name /
+Last Name, so a Family location carries both. Nullable with no backfill:
+School rows have no guardian, and rows imported before this column existed
+have nothing to derive one from.
+
+Revision ID: d2e91c47ab08
+Revises: c1f4a80b7e35
+Create Date: 2026-07-29 17:10:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "d2e91c47ab08"
+down_revision = "c1f4a80b7e35"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "locations",
+        sa.Column("guardian_name", sa.String(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("locations", "guardian_name")

--- a/backend/python/tests/test_models.py
+++ b/backend/python/tests/test_models.py
@@ -834,7 +834,7 @@ class TestModelValidation:
         assert system_settings.boxes_per_car == 10
         assert system_settings.dropoff_minutes == 3
         assert system_settings.children_per_box == 2
-        assert system_settings.delivery_types == ["School", "Family"]
+        assert system_settings.delivery_types == ["Family", "School"]
         assert system_settings.email_reminders == [
             EmailReminder(days_before=1, time=time(9, 0))
         ]

--- a/backend/python/tests/test_routes.py
+++ b/backend/python/tests/test_routes.py
@@ -1891,6 +1891,9 @@ class TestLocationImportRoutes:
             "Net New Family"
         ]
         assert [entry["contact_name"] for entry in body["stale"]] == ["Stale Family"]
+        # Carried off the existing Location, not the import — the review step
+        # shows what is being taken off the roster.
+        assert body["stale"][0]["num_children"] == 4
         changed_by_name = {entry["contact_name"]: entry for entry in body["changed"]}
         assert set(changed_by_name) == {
             "Address Change Family",

--- a/backend/python/tests/test_routes.py
+++ b/backend/python/tests/test_routes.py
@@ -34,6 +34,7 @@ from app.utilities.google_maps_client import GeocodeResult
 
 IMPORT_COLUMN_MAP = {
     "contact_name": "Name",
+    "guardian_name": "Guardian",
     "address": "Address",
     "delivery_group": "Delivery Group",
     "phone_primary": "Phone",
@@ -66,6 +67,7 @@ def import_review_request(
 ) -> dict[str, Any]:
     headers = [
         "Name",
+        "Guardian",
         "Address",
         "Delivery Group",
         "Phone",
@@ -2007,6 +2009,121 @@ class TestLocationImportRoutes:
         assert school_same_identity.phone_primary == "+14164164168"
         assert stale_family.in_roster is False
         assert untouched_school.in_roster is True
+
+    @pytest.mark.asyncio
+    async def test_guardian_name_round_trips_through_review_and_ingest(
+        self,
+        client_with_overrides: Any,
+        test_session: AsyncSession,
+        test_location_group: Any,
+    ) -> None:
+        """A Family row carries a guardian distinct from its School / Last Name.
+
+        Covers all three write paths: a net-new row, a row whose guardian
+        changed in place, and a row whose address changed (which replaces the
+        Location rather than updating it).
+        """
+        fake_maps = FakeGoogleMapsClient()
+        async_client = await client_with_overrides(
+            {get_google_maps_client: lambda: fake_maps}
+        )
+        renamed_guardian = Location(
+            location_group_id=test_location_group.location_group_id,
+            name="Nguyen",
+            contact_name="Nguyen",
+            guardian_name="Old Guardian",
+            address="Formatted 30 Main St",
+            phone_primary="+14164164180",
+            num_children=2,
+            delivery_type="Family",
+        )
+        moved_house = Location(
+            location_group_id=test_location_group.location_group_id,
+            name="Okafor",
+            contact_name="Okafor",
+            guardian_name="Stale Guardian",
+            address="Formatted 31 Main St",
+            phone_primary="+14164164181",
+            num_children=1,
+            delivery_type="Family",
+        )
+        test_session.add_all([renamed_guardian, moved_house])
+        await test_session.commit()
+
+        request = import_review_request(
+            [
+                {
+                    "Name": "Nguyen",
+                    "Guardian": "New Guardian",
+                    "Address": "30 Main St",
+                    "Delivery Group": test_location_group.name,
+                    "Phone": "+14164164180",
+                    "Children": "2",
+                },
+                {
+                    "Name": "Okafor",
+                    "Guardian": "Moved Guardian",
+                    "Address": "99 Elsewhere Rd",
+                    "Delivery Group": test_location_group.name,
+                    "Phone": "+14164164181",
+                    "Children": "1",
+                },
+                {
+                    "Name": "Brand New",
+                    "Guardian": "Fresh Guardian",
+                    "Address": "32 Main St",
+                    "Delivery Group": test_location_group.name,
+                    "Phone": "+14164164182",
+                    "Children": "3",
+                },
+            ]
+        )
+
+        review = await async_client.post("/locations/review", **request)
+        assert review.status_code == 200
+        review_body = review.json()
+        assert review_body["success"] is True
+
+        # Net-new carries the guardian straight through.
+        assert [entry["guardian_name"] for entry in review_body["net_new"]] == [
+            "Fresh Guardian"
+        ]
+
+        # A guardian-only edit is diffed, so the row surfaces for review at all.
+        changed_by_name = {
+            entry["contact_name"]: entry for entry in review_body["changed"]
+        }
+        assert changed_by_name["Nguyen"]["guardian_name"] == {
+            "new_value": "New Guardian",
+            "old_value": "Old Guardian",
+        }
+        assert changed_by_name["Okafor"]["guardian_name"] == {
+            "new_value": "Moved Guardian",
+            "old_value": "Stale Guardian",
+        }
+
+        ingest = await async_client.post(
+            "/locations/ingest",
+            json={
+                "delivery_type": "Family",
+                "net_new": review_body["net_new"],
+                "stale": review_body["stale"],
+                "changed": review_body["changed"],
+            },
+        )
+        assert ingest.status_code == 200
+        created = {row["contact_name"]: row for row in ingest.json()["created"]}
+
+        # Updated in place — the address did not move.
+        await test_session.refresh(renamed_guardian)
+        assert renamed_guardian.guardian_name == "New Guardian"
+
+        # Replaced — the address moved, so the guardian lands on the new row
+        # and the old one goes off the roster.
+        await test_session.refresh(moved_house)
+        assert moved_house.in_roster is False
+        assert created["Okafor"]["guardian_name"] == "Moved Guardian"
+        assert created["Brand New"]["guardian_name"] == "Fresh Guardian"
 
     @pytest.mark.asyncio
     async def test_review_locations_blank_children_does_not_mark_changed(

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -3374,6 +3374,11 @@
             "title": "Location Id",
             "type": "string"
           },
+          "num_children": {
+            "default": 0,
+            "title": "Num Children",
+            "type": "integer"
+          },
           "phone_primary": {
             "title": "Phone Primary",
             "type": "string"

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -340,6 +340,20 @@
             ],
             "title": "Delivery Group"
           },
+          "guardian_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "$ref": "#/components/schemas/ChangedFieldOptStr"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Guardian Name"
+          },
           "location_id": {
             "format": "uuid",
             "title": "Location Id",
@@ -1098,6 +1112,17 @@
             "title": "Dietary Restrictions",
             "type": "string"
           },
+          "guardian_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Guardian Name"
+          },
           "halal": {
             "default": false,
             "title": "Halal",
@@ -1411,6 +1436,17 @@
             ],
             "title": "Dietary Restrictions"
           },
+          "guardian_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Guardian Name"
+          },
           "halal": {
             "anyOf": [
               {
@@ -1640,6 +1676,17 @@
             "title": "Dietary Restrictions",
             "type": "string"
           },
+          "guardian_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Guardian Name"
+          },
           "halal": {
             "default": false,
             "title": "Halal",
@@ -1844,6 +1891,17 @@
               }
             ],
             "title": "Dietary Restrictions"
+          },
+          "guardian_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Guardian Name"
           },
           "halal": {
             "anyOf": [
@@ -2052,6 +2110,17 @@
               }
             ],
             "title": "Dietary Restrictions"
+          },
+          "guardian_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Guardian Name"
           },
           "halal": {
             "anyOf": [
@@ -3943,6 +4012,17 @@
               }
             ],
             "title": "Dietary Restrictions"
+          },
+          "guardian_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Guardian Name"
           },
           "halal": {
             "anyOf": [

--- a/frontend/src/api/generated/types.gen.ts
+++ b/frontend/src/api/generated/types.gen.ts
@@ -229,6 +229,10 @@ export type ChangedEntry = {
    */
   delivery_group?: string | ChangedFieldOptStr | null;
   /**
+   * Guardian Name
+   */
+  guardian_name?: string | ChangedFieldOptStr | null;
+  /**
    * Location Id
    */
   location_id: string;
@@ -681,6 +685,10 @@ export type LocationCreate = {
    */
   dietary_restrictions?: string;
   /**
+   * Guardian Name
+   */
+  guardian_name?: string | null;
+  /**
    * Halal
    */
   halal?: boolean;
@@ -853,6 +861,10 @@ export type LocationImportEntry = {
    */
   dietary_restrictions?: string | null;
   /**
+   * Guardian Name
+   */
+  guardian_name?: string | null;
+  /**
    * Halal
    */
   halal?: boolean | null;
@@ -995,6 +1007,10 @@ export type LocationRead = {
    */
   dietary_restrictions?: string;
   /**
+   * Guardian Name
+   */
+  guardian_name?: string | null;
+  /**
    * Halal
    */
   halal?: boolean;
@@ -1097,6 +1113,10 @@ export type LocationUpdate = {
    * Dietary Restrictions
    */
   dietary_restrictions?: string | null;
+  /**
+   * Guardian Name
+   */
+  guardian_name?: string | null;
   /**
    * Halal
    */
@@ -1203,6 +1223,10 @@ export type NetNewEntry = {
    * Dietary Restrictions
    */
   dietary_restrictions?: string | null;
+  /**
+   * Guardian Name
+   */
+  guardian_name?: string | null;
   /**
    * Halal
    */
@@ -2246,6 +2270,10 @@ export type ValidatedLocationImportEntry = {
    */
   dietary_restrictions?: string | null;
   /**
+   * Guardian Name
+   */
+  guardian_name?: string | null;
+  /**
    * Halal
    */
   halal?: boolean | null;
@@ -2443,6 +2471,10 @@ export type LocationReadWritable = {
    * Dietary Restrictions
    */
   dietary_restrictions?: string;
+  /**
+   * Guardian Name
+   */
+  guardian_name?: string | null;
   /**
    * Halal
    */

--- a/frontend/src/api/generated/types.gen.ts
+++ b/frontend/src/api/generated/types.gen.ts
@@ -1987,6 +1987,10 @@ export type StaleEntry = {
    */
   location_id: string;
   /**
+   * Num Children
+   */
+  num_children?: number;
+  /**
    * Phone Primary
    */
   phone_primary: string;

--- a/frontend/src/common/components/DataTable.tsx
+++ b/frontend/src/common/components/DataTable.tsx
@@ -140,15 +140,15 @@ function DataTable<T>({
                         : undefined
                     }
                     className={cn(
-                      // 54px per the design, header and body alike. A height
+                      // 40px per the design, header and body alike. A height
                       // rather than padding so a taller cell (a date button, a
-                      // pill) sets the row height instead of a stack of
-                      // padding rules fighting over it.
+                      // pill, a two-line alert) sets the row height instead of
+                      // a stack of padding rules fighting over it.
                       // Headers are the H3 style — Nunito Sans Bold 16/20.
                       // The design runs its columns edge to edge inside the
                       // card's 24px padding, so the last one has no trailing
                       // gap of its own — that is what puts the kebab flush.
-                      'text-h3 h-[54px] px-4 py-2.5 text-left font-bold whitespace-nowrap last:pr-0',
+                      'text-h3 h-10 px-4 py-2.5 text-left font-bold whitespace-nowrap last:pr-0',
                       col.headerClassName
                     )}
                   >
@@ -192,7 +192,7 @@ function DataTable<T>({
                       key={col.key}
                       className={cn(
                         // Every body string in the design is 14/18 SemiBold.
-                        'text-p2 text-grey-500 h-[54px] px-4 py-2.5 font-semibold whitespace-nowrap last:pr-0',
+                        'text-p2 text-grey-500 h-10 px-4 py-2.5 font-semibold whitespace-nowrap last:pr-0',
                         col.getCellClassName?.(row)
                       )}
                     >

--- a/frontend/src/common/components/DataTable.tsx
+++ b/frontend/src/common/components/DataTable.tsx
@@ -23,6 +23,8 @@ export interface Column<T> {
   getCellClassName?: (row: T) => string | undefined;
   /** Static className applied to the header <th> cell. */
   headerClassName?: string;
+  /** Static className applied to every body <td> in this column. */
+  cellClassName?: string;
   /** When set, the header is a sort toggle and rows sort by `sortValue`. */
   sortable?: boolean;
   /** Comparable value for sorting; required for the sort to do anything. */
@@ -67,18 +69,20 @@ function AlertCell({ type, label }: AlertCellProps) {
   const isError = type === 'error';
   const labels = typeof label === 'string' ? [label] : [...label];
   return (
+    // Only the icon carries the alert colour — the label is ordinary body
+    // text, same as every other cell in the row.
     <span
       className={cn(
-        'flex items-center gap-1.5',
-        isError ? 'text-red' : 'text-dark-yellow'
+        'text-grey-500 flex items-center gap-2',
+        isError ? '[&>svg]:text-red' : '[&>svg]:text-dark-yellow'
       )}
     >
       {isError ? (
-        <AlertCircle className="h-4 w-4 shrink-0" />
+        <AlertCircle className="size-[18px] shrink-0" />
       ) : (
-        <AlertTriangle className="h-4 w-4 shrink-0" />
+        <AlertTriangle className="size-[18px] shrink-0" />
       )}
-      <span className="text-p2 flex flex-col font-medium">
+      <span className="text-p2 flex flex-col font-semibold">
         {labels.map((text, index) => (
           <span key={`${text}-${index}`}>
             {text}
@@ -175,7 +179,9 @@ function DataTable<T>({
             </tr>
           </thead>
 
-          <tbody className="divide-grey-300 divide-y">
+          {/* Row rules are the lighter grey-200; only the header's is
+              grey-300, so the head reads as separate from the body. */}
+          <tbody className="divide-grey-200 divide-y">
             {sortedRows.length === 0 ? (
               <tr>
                 <td colSpan={columns.length}>{emptyState}</td>
@@ -193,6 +199,7 @@ function DataTable<T>({
                       className={cn(
                         // Every body string in the design is 14/18 SemiBold.
                         'text-p2 text-grey-500 h-10 px-4 py-2.5 font-semibold whitespace-nowrap last:pr-0',
+                        col.cellClassName,
                         col.getCellClassName?.(row)
                       )}
                     >

--- a/frontend/src/common/components/Dropdown.tsx
+++ b/frontend/src/common/components/Dropdown.tsx
@@ -15,7 +15,10 @@ function DropdownTrigger({
   return (
     <SelectPrimitive.Trigger
       className={cn(
-        'inline-flex w-full cursor-pointer items-center justify-between rounded-full px-6 py-3',
+        // 34px tall, r16, 12px side padding — measured off the Map Columns
+        // frame. `rounded-full` on a 34px box reads the same as r16, but the
+        // token is what the design states.
+        'inline-flex w-full cursor-pointer items-center justify-between rounded-xl px-3 py-2',
         // No `outline-none` here: it would set --tw-outline-style to `none`,
         // which the outline-1 below inherits, making the outline invisible
         'text-p2 text-grey-500 transition-colors',

--- a/frontend/src/common/components/FileInput.tsx
+++ b/frontend/src/common/components/FileInput.tsx
@@ -41,7 +41,7 @@ function FileInput({
     return (
       <div
         className={cn(
-          'border-grey-300 flex h-16 items-center rounded-sm border bg-white px-7',
+          'border-grey-300 flex h-16 items-center rounded-sm border bg-white px-6',
           className
         )}
       >
@@ -49,8 +49,8 @@ function FileInput({
           XLS
         </div>
         <div className="min-w-0 flex-1">
-          <p className="text-p1 truncate font-semibold">{selectedFile.name}</p>
-          <p className="text-p2 text-grey-400">{displaySize}</p>
+          <p className="text-p1 truncate font-bold">{selectedFile.name}</p>
+          <p className="text-p2 text-grey-400 font-semibold">{displaySize}</p>
         </div>
         {onClearFile && (
           <button

--- a/frontend/src/common/components/FileInput.tsx
+++ b/frontend/src/common/components/FileInput.tsx
@@ -41,7 +41,7 @@ function FileInput({
     return (
       <div
         className={cn(
-          'border-grey-300 flex h-16 items-center rounded-lg border bg-white px-7',
+          'border-grey-300 flex h-16 items-center rounded-sm border bg-white px-7',
           className
         )}
       >

--- a/frontend/src/common/hooks/usePagination.ts
+++ b/frontend/src/common/hooks/usePagination.ts
@@ -1,9 +1,14 @@
 import { useState } from 'react';
 
 /**
- * Rows per page for the admin tables. The Figma draws the table as a fixed box
- * of fourteen 54px cells — a header plus thirteen rows — with the page
- * switcher directly beneath it, so a full page fills the frame exactly.
+ * Rows per page for the admin tables. This came from a Figma frame that draws
+ * the table as a fixed box of fourteen 54px cells — a header plus thirteen
+ * rows — with the page switcher directly beneath it.
+ *
+ * The route-generation frames draw the same table at 40px, and DataTable now
+ * follows them, so thirteen rows no longer fill that box. The count is left
+ * alone until the designer resolves which height is right; whatever it lands
+ * on, this number is (boxHeight / rowHeight) - 1.
  */
 export const TABLE_PAGE_SIZE = 13;
 

--- a/frontend/src/pages/StyleGuide/sections/BannersSection.tsx
+++ b/frontend/src/pages/StyleGuide/sections/BannersSection.tsx
@@ -17,7 +17,7 @@ const BANNER_SUCCESS_CODE = `import { Banner } from '@/common/components';
 const BANNER_ERROR_CODE = `import { Banner } from '@/common/components';
 
 <Banner variant="error">
-  Unsupported format — please upload an Excel (.xlsx) file
+  Unsupported format. Please upload an Excel (.xlsx) file.
 </Banner>`;
 
 const BANNER_WARNING_CODE = `import { Banner } from '@/common/components';
@@ -64,7 +64,7 @@ export function BannersSection() {
         >
           <div className="w-full max-w-2xl">
             <Banner variant="error">
-              Unsupported format — please upload an Excel (.xlsx) file
+              Unsupported format. Please upload an Excel (.xlsx) file.
             </Banner>
           </div>
         </ComponentPreview>

--- a/frontend/src/pages/admin/routes/components/EmptyState.tsx
+++ b/frontend/src/pages/admin/routes/components/EmptyState.tsx
@@ -1,24 +1,25 @@
 import boyEdgeCaseNoQuestionMark from '@/assets/illustrations/boy-edge-case-no-question-mark.png';
 import boyEdgeCaseWithQuestions from '@/assets/illustrations/boy-edge-case-with-questions.png';
 import girlConfused from '@/assets/illustrations/girl-confused.png';
+import girlSearching from '@/assets/illustrations/girl-searching.png';
 import { cn } from '@/lib/utils';
 
 const IMAGES = {
   'girl-confused': girlConfused,
+  'girl-searching': girlSearching,
   'boy-edge-case-with-questions': boyEdgeCaseWithQuestions,
   'boy-edge-case-no-question-mark': boyEdgeCaseNoQuestionMark,
 };
 
 interface EmptyStateProps {
-  image?:
-    | 'girl-confused'
-    | 'boy-edge-case-with-questions'
-    | 'boy-edge-case-no-question-mark';
+  image?: keyof typeof IMAGES;
   title: string;
   description: string;
   /**
-   * Tighter illustration and padding, for a table that shares a screen with
-   * others (the route-generation steps) rather than owning the page.
+   * The route-generation variant: the illustration is cropped into a 106px
+   * blue disc rather than standing free, and both lines drop to the table's
+   * own 14/600. Used where a table shares a screen with others rather than
+   * owning the page.
    *
    * This is a prop rather than a `[&_td>div]` arbitrary variant on the
    * DataTable wrapper: that selector also matched the populated cells' own
@@ -37,17 +38,36 @@ export function EmptyState({
     <div
       className={cn(
         'flex flex-col items-center justify-center text-center',
-        compact ? 'gap-1 py-8' : 'gap-3 py-16'
+        compact ? 'gap-2 py-6' : 'gap-3 py-16'
       )}
     >
-      <img
-        src={IMAGES[image]}
-        alt=""
-        className={cn('w-auto', compact ? 'h-28' : 'h-48')}
-      />
+      {compact ? (
+        // The source PNGs are 1000×1000 with a wide transparent margin, so
+        // filling the disc means scaling past it and pulling the figure up
+        // until the head sits inside — hence the offsets rather than a plain
+        // object-cover.
+        <div className="size-[106px] shrink-0 overflow-hidden rounded-full bg-blue-50">
+          <img
+            src={IMAGES[image]}
+            alt=""
+            className="-mt-[55px] -ml-[62px] w-[246px] max-w-none"
+          />
+        </div>
+      ) : (
+        <img src={IMAGES[image]} alt="" className="h-48 w-auto" />
+      )}
       <div>
-        <p className="text-p1 text-grey-500 font-medium">{title}</p>
-        <p className="text-p2 text-grey-400">{description}</p>
+        <p
+          className={cn(
+            'text-grey-500',
+            compact ? 'text-p2 font-semibold' : 'text-p1 font-medium'
+          )}
+        >
+          {title}
+        </p>
+        <p className={cn('text-p2 text-grey-400', compact && 'font-semibold')}>
+          {description}
+        </p>
       </div>
     </div>
   );

--- a/frontend/src/pages/admin/routes/components/EmptyState.tsx
+++ b/frontend/src/pages/admin/routes/components/EmptyState.tsx
@@ -1,6 +1,7 @@
 import boyEdgeCaseNoQuestionMark from '@/assets/illustrations/boy-edge-case-no-question-mark.png';
 import boyEdgeCaseWithQuestions from '@/assets/illustrations/boy-edge-case-with-questions.png';
 import girlConfused from '@/assets/illustrations/girl-confused.png';
+import { cn } from '@/lib/utils';
 
 const IMAGES = {
   'girl-confused': girlConfused,
@@ -15,16 +16,35 @@ interface EmptyStateProps {
     | 'boy-edge-case-no-question-mark';
   title: string;
   description: string;
+  /**
+   * Tighter illustration and padding, for a table that shares a screen with
+   * others (the route-generation steps) rather than owning the page.
+   *
+   * This is a prop rather than a `[&_td>div]` arbitrary variant on the
+   * DataTable wrapper: that selector also matched the populated cells' own
+   * wrapper divs, which nearly doubled the height of every changed row.
+   */
+  compact?: boolean;
 }
 
 export function EmptyState({
   title,
   description,
   image = 'girl-confused',
+  compact = false,
 }: EmptyStateProps) {
   return (
-    <div className="flex flex-col items-center justify-center gap-3 py-16 text-center">
-      <img src={IMAGES[image]} alt="" className="h-48 w-auto" />
+    <div
+      className={cn(
+        'flex flex-col items-center justify-center text-center',
+        compact ? 'gap-1 py-8' : 'gap-3 py-16'
+      )}
+    >
+      <img
+        src={IMAGES[image]}
+        alt=""
+        className={cn('w-auto', compact ? 'h-28' : 'h-48')}
+      />
       <div>
         <p className="text-p1 text-grey-500 font-medium">{title}</p>
         <p className="text-p2 text-grey-400">{description}</p>

--- a/frontend/src/pages/admin/routes/components/ProgressStepper.tsx
+++ b/frontend/src/pages/admin/routes/components/ProgressStepper.tsx
@@ -23,10 +23,17 @@ interface ProgressStepperProps {
 
 function ProgressStepper({ currentStep, className }: ProgressStepperProps) {
   return (
-    <div className={cn('flex w-full items-start pb-6', className)}>
+    // Each step is as wide as its own label, with the connectors sharing what
+    // is left over — so the labels sit centred on their circles and the track
+    // stops where the last label ends. Absolutely positioning the labels over
+    // fixed 24px columns instead spread the circles edge to edge, which pushed
+    // every label right of where the frames put it (up to 86px by the middle).
+    // 24px circle + 4px + 20px label is the frame's 48px stepper exactly, so
+    // no bottom padding: the 40px to the next section is the parent's gap.
+    <div className={cn('flex w-full items-start gap-8', className)}>
       {STEPS.map((step, i) => (
         <Fragment key={step.path}>
-          <div className="relative z-10 m-0 flex w-6 shrink-0 justify-center">
+          <div className="relative z-10 flex shrink-0 flex-col items-center gap-1">
             <div
               className={cn(
                 'flex size-6 items-center justify-center rounded-full border-2 bg-white',
@@ -39,7 +46,7 @@ function ProgressStepper({ currentStep, className }: ProgressStepperProps) {
             </div>
             <span
               className={cn(
-                'text-h3 absolute top-8 left-1/2 -translate-x-1/2 text-center font-bold whitespace-nowrap',
+                'text-h3 text-center font-bold whitespace-nowrap',
                 i <= currentStep ? 'text-blue-300' : 'text-grey-400'
               )}
             >

--- a/frontend/src/pages/admin/routes/components/ProgressStepper.tsx
+++ b/frontend/src/pages/admin/routes/components/ProgressStepper.tsx
@@ -12,7 +12,7 @@ const STEPS: Step[] = [
   { label: 'Import', path: '/admin/routes/generation/import' },
   { label: 'Validate', path: '/admin/routes/generation/validate' },
   { label: 'Review Changes', path: '/admin/routes/generation/review' },
-  { label: 'Configure Routes', path: '/admin/routes/generation/configure' },
+  { label: 'Edit Route Groups', path: '/admin/routes/generation/configure' },
   { label: 'Generate Routes', path: '/admin/routes/generation/generate' },
 ];
 

--- a/frontend/src/pages/admin/routes/components/ProgressStepper.tsx
+++ b/frontend/src/pages/admin/routes/components/ProgressStepper.tsx
@@ -1,4 +1,4 @@
-import { Fragment } from 'react';
+import { Fragment, useLayoutEffect, useRef, useState } from 'react';
 
 import CheckIcon from '@/assets/icons/check.svg?react';
 import { cn } from '@/lib/utils';
@@ -16,37 +16,74 @@ const STEPS: Step[] = [
   { label: 'Generate Routes', path: '/admin/routes/generation/generate' },
 ];
 
+const CIRCLE_SIZE = 24;
+
 interface ProgressStepperProps {
   currentStep: number;
   className?: string;
 }
 
+/**
+ * How far the first and last labels stick out past their own circle. The track
+ * is inset by exactly that much, so evenly-spaced circles can still carry
+ * centred labels without the two end ones spilling over the page margins.
+ * Measured rather than hardcoded because it depends on the rendered text —
+ * a ResizeObserver so a late-loading webfont re-runs it.
+ */
+function useEndLabelOverhang() {
+  const first = useRef<HTMLSpanElement>(null);
+  const last = useRef<HTMLSpanElement>(null);
+  const [overhang, setOverhang] = useState<[number, number]>([0, 0]);
+
+  useLayoutEffect(() => {
+    const measure = () => {
+      if (!first.current || !last.current) return;
+      setOverhang([
+        Math.max(0, (first.current.offsetWidth - CIRCLE_SIZE) / 2),
+        Math.max(0, (last.current.offsetWidth - CIRCLE_SIZE) / 2),
+      ]);
+    };
+    measure();
+    const observer = new ResizeObserver(measure);
+    if (first.current) observer.observe(first.current);
+    if (last.current) observer.observe(last.current);
+    return () => observer.disconnect();
+  }, []);
+
+  return { first, last, overhang };
+}
+
 function ProgressStepper({ currentStep, className }: ProgressStepperProps) {
+  const { first, last, overhang } = useEndLabelOverhang();
+
   return (
-    // Each step is as wide as its own label, with the connectors sharing what
-    // is left over — so the labels sit centred on their circles and the track
-    // stops where the last label ends. Absolutely positioning the labels over
-    // fixed 24px columns instead spread the circles edge to edge, which pushed
-    // every label right of where the frames put it (up to 86px by the middle).
-    // 24px circle + 4px + 20px label is the frame's 48px stepper exactly, so
-    // no bottom padding: the 40px to the next section is the parent's gap.
-    <div className={cn('flex w-full items-start gap-8', className)}>
+    // Circles are spaced evenly along the track with the connectors running
+    // circle-edge to circle-edge between them, so the line is unbroken. Labels
+    // are absolutely positioned and centred on their circle — in the flow they
+    // would widen a step and push the circles around.
+    // 24px circle + 4px + 20px label is the frame's 48px stepper, so the 24px
+    // of bottom padding is what reserves room for the absolute labels.
+    <div
+      className={cn('flex w-full items-start pb-6', className)}
+      style={{ paddingLeft: overhang[0], paddingRight: overhang[1] }}
+    >
       {STEPS.map((step, i) => (
         <Fragment key={step.path}>
-          <div className="relative z-10 flex shrink-0 flex-col items-center gap-1">
+          <div className="relative shrink-0">
             <div
               className={cn(
-                'flex size-6 items-center justify-center rounded-full border-2 bg-white',
+                'flex size-6 items-center justify-center rounded-full border-2',
                 i < currentStep && 'border-blue-300 bg-blue-300',
-                i === currentStep && 'border-blue-300 bg-white',
-                i > currentStep && 'border-grey-300 bg-white'
+                i === currentStep && 'border-blue-300',
+                i > currentStep && 'border-grey-400'
               )}
             >
               {i < currentStep && <CheckIcon className="size-3.5 text-white" />}
             </div>
             <span
+              ref={i === 0 ? first : i === STEPS.length - 1 ? last : undefined}
               className={cn(
-                'text-h3 text-center font-bold whitespace-nowrap',
+                'text-h3 absolute top-full left-1/2 mt-1 -translate-x-1/2 font-bold whitespace-nowrap',
                 i <= currentStep ? 'text-blue-300' : 'text-grey-400'
               )}
             >
@@ -56,7 +93,8 @@ function ProgressStepper({ currentStep, className }: ProgressStepperProps) {
           {i + 1 < STEPS.length && (
             <div
               className={cn(
-                'mt-3 h-0.5 flex-1 -translate-y-1/2',
+                // 3px, centred on the 24px circle.
+                'mt-[10.5px] h-[3px] flex-1',
                 i < currentStep ? 'bg-blue-300' : 'bg-grey-300'
               )}
             />

--- a/frontend/src/pages/admin/routes/components/ProgressStepper.tsx
+++ b/frontend/src/pages/admin/routes/components/ProgressStepper.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useLayoutEffect, useRef, useState } from 'react';
+import { Fragment } from 'react';
 
 import CheckIcon from '@/assets/icons/check.svg?react';
 import { cn } from '@/lib/utils';
@@ -16,63 +16,57 @@ const STEPS: Step[] = [
   { label: 'Generate Routes', path: '/admin/routes/generation/generate' },
 ];
 
-const CIRCLE_SIZE = 24;
-
 interface ProgressStepperProps {
   currentStep: number;
   className?: string;
 }
 
-/**
- * How far the first and last labels stick out past their own circle. The track
- * is inset by exactly that much, so evenly-spaced circles can still carry
- * centred labels without the two end ones spilling over the page margins.
- * Measured rather than hardcoded because it depends on the rendered text —
- * a ResizeObserver so a late-loading webfont re-runs it.
- */
-function useEndLabelOverhang() {
-  const first = useRef<HTMLSpanElement>(null);
-  const last = useRef<HTMLSpanElement>(null);
-  const [overhang, setOverhang] = useState<[number, number]>([0, 0]);
-
-  useLayoutEffect(() => {
-    const measure = () => {
-      if (!first.current || !last.current) return;
-      setOverhang([
-        Math.max(0, (first.current.offsetWidth - CIRCLE_SIZE) / 2),
-        Math.max(0, (last.current.offsetWidth - CIRCLE_SIZE) / 2),
-      ]);
-    };
-    measure();
-    const observer = new ResizeObserver(measure);
-    if (first.current) observer.observe(first.current);
-    if (last.current) observer.observe(last.current);
-    return () => observer.disconnect();
-  }, []);
-
-  return { first, last, overhang };
+/** A 3px segment of the track, sitting on the 24px circle's centre line. */
+function Track({ done, className }: { done: boolean; className?: string }) {
+  return (
+    <div
+      className={cn(
+        'absolute top-[10.5px] h-[3px]',
+        done ? 'bg-blue-300' : 'bg-grey-300',
+        className
+      )}
+    />
+  );
 }
 
 function ProgressStepper({ currentStep, className }: ProgressStepperProps) {
-  const { first, last, overhang } = useEndLabelOverhang();
+  const last = STEPS.length - 1;
 
   return (
-    // Circles are spaced evenly along the track with the connectors running
-    // circle-edge to circle-edge between them, so the line is unbroken. Labels
-    // are absolutely positioned and centred on their circle — in the flow they
-    // would widen a step and push the circles around.
-    // 24px circle + 4px + 20px label is the frame's 48px stepper, so the 24px
-    // of bottom padding is what reserves room for the absolute labels.
-    <div
-      className={cn('flex w-full items-start pb-6', className)}
-      style={{ paddingLeft: overhang[0], paddingRight: overhang[1] }}
-    >
+    // Each step is as wide as its own label, and the spans between them share
+    // what is left over — which is what the frames do: the five labels sit at
+    // an even 180.25px pitch across the content column, with each circle
+    // centred on its own label.
+    //
+    // That leaves the circles unevenly spaced, so a span can't be one element:
+    // it runs from a circle's edge, across the rest of that label's box, over
+    // the gap, and into the next label's box. Hence three pieces — two drawn
+    // inside the step columns and one filling the gap — which join up into an
+    // unbroken line without anyone having to measure a label.
+    <div className={cn('flex w-full items-start', className)}>
       {STEPS.map((step, i) => (
         <Fragment key={step.path}>
-          <div className="relative shrink-0">
+          <div className="relative flex shrink-0 flex-col items-center gap-1">
+            {i > 0 && (
+              <Track
+                done={i - 1 < currentStep}
+                className="right-[calc(50%+12px)] left-0"
+              />
+            )}
+            {i < last && (
+              <Track
+                done={i < currentStep}
+                className="right-0 left-[calc(50%+12px)]"
+              />
+            )}
             <div
               className={cn(
-                'flex size-6 items-center justify-center rounded-full border-2',
+                'relative flex size-6 items-center justify-center rounded-full border-2',
                 i < currentStep && 'border-blue-300 bg-blue-300',
                 i === currentStep && 'border-blue-300',
                 i > currentStep && 'border-grey-400'
@@ -81,23 +75,18 @@ function ProgressStepper({ currentStep, className }: ProgressStepperProps) {
               {i < currentStep && <CheckIcon className="size-3.5 text-white" />}
             </div>
             <span
-              ref={i === 0 ? first : i === STEPS.length - 1 ? last : undefined}
               className={cn(
-                'text-h3 absolute top-full left-1/2 mt-1 -translate-x-1/2 font-bold whitespace-nowrap',
+                'text-h3 text-center font-bold whitespace-nowrap',
                 i <= currentStep ? 'text-blue-300' : 'text-grey-400'
               )}
             >
               {step.label}
             </span>
           </div>
-          {i + 1 < STEPS.length && (
-            <div
-              className={cn(
-                // 3px, centred on the 24px circle.
-                'mt-[10.5px] h-[3px] flex-1',
-                i < currentStep ? 'bg-blue-300' : 'bg-grey-300'
-              )}
-            />
+          {i < last && (
+            <div className="relative flex-1">
+              <Track done={i < currentStep} className="inset-x-0" />
+            </div>
           )}
         </Fragment>
       ))}

--- a/frontend/src/pages/admin/routes/generation/AdminRoutesGenerationLayout.tsx
+++ b/frontend/src/pages/admin/routes/generation/AdminRoutesGenerationLayout.tsx
@@ -69,8 +69,9 @@ export function AdminRoutesGenerationLayout() {
 
   return (
     <div className="flex flex-col gap-10">
-      {/* Breadcrumb + subtitle */}
-      <div className="flex flex-col gap-2">
+      {/* Breadcrumb + subtitle. 4px, not 8: the frames make this block 72 tall
+          (44 + 4 + 24), and the extra 4 pushed every section below it down. */}
+      <div className="flex flex-col gap-1">
         <div className="flex items-center gap-1">
           <Link
             to="/admin/routes"

--- a/frontend/src/pages/admin/routes/generation/AdminRoutesGenerationLayout.tsx
+++ b/frontend/src/pages/admin/routes/generation/AdminRoutesGenerationLayout.tsx
@@ -84,7 +84,7 @@ export function AdminRoutesGenerationLayout() {
           </span>
         </div>
         <p className="text-p1 text-grey-500">
-          Import family data and generate delivery routes
+          Import data and generate delivery routes
         </p>
       </div>
 

--- a/frontend/src/pages/admin/routes/generation/AdminRoutesGenerationLayout.tsx
+++ b/frontend/src/pages/admin/routes/generation/AdminRoutesGenerationLayout.tsx
@@ -68,7 +68,10 @@ export function AdminRoutesGenerationLayout() {
   };
 
   return (
-    <div className="flex flex-col gap-10">
+    // Tall enough to fill the viewport minus the page margins, so the sticky
+    // footer's `mt-auto` still puts it at the bottom of the screen on a step
+    // whose content doesn't reach that far.
+    <div className="desktop:min-h-[calc(100dvh-4rem)] flex min-h-[calc(100dvh-2.75rem)] flex-col gap-10">
       {/* Breadcrumb + subtitle. 4px, not 8: the frames make this block 72 tall
           (44 + 4 + 24), and the extra 4 pushed every section below it down. */}
       <div className="flex flex-col gap-1">

--- a/frontend/src/pages/admin/routes/generation/ConfigureStep.tsx
+++ b/frontend/src/pages/admin/routes/generation/ConfigureStep.tsx
@@ -23,6 +23,7 @@ import {
 } from '@/common/components';
 
 import type { GenerationOutletContext } from './AdminRoutesGenerationLayout';
+import { GenerationFooter } from './GenerationFooter';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -236,15 +237,14 @@ export function ConfigureStep() {
         />
       </div>
 
-      {/* Actions */}
-      <div className="flex items-center justify-between">
+      <GenerationFooter>
         <Button variant="tertiary" onClick={() => setLeaveOpen(true)}>
           Back to review changes
         </Button>
         <Button variant="primary" onClick={() => setConfirmOpen(true)}>
           Continue to generate routes
         </Button>
-      </div>
+      </GenerationFooter>
 
       {/* Leave without saving dialog */}
       <Modal open={leaveOpen} onOpenChange={setLeaveOpen}>

--- a/frontend/src/pages/admin/routes/generation/GenerationFooter.tsx
+++ b/frontend/src/pages/admin/routes/generation/GenerationFooter.tsx
@@ -1,0 +1,18 @@
+import type { ReactNode } from 'react';
+
+/**
+ * The wizard's sticky action bar: an 84px full-bleed strip pinned to the
+ * bottom of the viewport, holding the back/continue pair.
+ *
+ * Full-bleed means it has to cancel the page margins that wrap every admin
+ * route — hence the negative insets, which are the `.admin-page-margins`
+ * values inverted. Its own padding then puts the buttons back on the content
+ * grid, so they line up with the tables above.
+ */
+export function GenerationFooter({ children }: { children: ReactNode }) {
+  return (
+    <div className="border-grey-300 bg-grey-200 tablet:-mx-10 tablet:px-10 desktop:-mx-12 desktop:px-12 sticky bottom-0 z-20 -mx-5 mt-auto -mb-6 flex h-21 items-center justify-between gap-4 border-t px-5 py-5">
+      {children}
+    </div>
+  );
+}

--- a/frontend/src/pages/admin/routes/generation/ImportStep.tsx
+++ b/frontend/src/pages/admin/routes/generation/ImportStep.tsx
@@ -124,6 +124,10 @@ export function ImportStep() {
     {
       key: 'label',
       header: 'System Column',
+      // 56px rows, header included — the frames give this table more air than
+      // the others because every row holds a control.
+      headerClassName: 'h-14',
+      getCellClassName: () => 'h-14',
       render: (row) => (
         // P1, not the table's usual P2 — these are field labels rather than
         // imported data, and the frames set them 16/500.
@@ -136,6 +140,8 @@ export function ImportStep() {
     {
       key: 'value',
       header: 'Your File Column',
+      headerClassName: 'h-14',
+      getCellClassName: () => 'h-14',
       render: (row) => (
         <Dropdown
           value={columnMap[row.key] ?? ''}
@@ -194,7 +200,8 @@ export function ImportStep() {
             Choose the type of spreadsheet you'll be uploading:
           </p>
         </div>
-        <div className="flex flex-col gap-2">
+        {/* 28px pitch: a 24px-tall row per the frames, 4px apart. */}
+        <div className="flex flex-col gap-1">
           {deliveryTypes.map((deliveryType) => (
             <label
               key={deliveryType}
@@ -212,7 +219,7 @@ export function ImportStep() {
                   setReviewResult(null);
                   setFormatError(null);
                 }}
-                className="size-4 cursor-pointer accent-blue-300"
+                className="size-5 cursor-pointer accent-blue-300"
               />
               {deliveryType}
             </label>

--- a/frontend/src/pages/admin/routes/generation/ImportStep.tsx
+++ b/frontend/src/pages/admin/routes/generation/ImportStep.tsx
@@ -124,7 +124,9 @@ export function ImportStep() {
       key: 'label',
       header: 'System Column',
       render: (row) => (
-        <span className="text-p2 text-grey-500">
+        // P1, not the table's usual P2 — these are field labels rather than
+        // imported data, and the frames set them 16/500.
+        <span className="text-p1 text-grey-500">
           {row.label}
           {row.required && <span className="text-red ml-0.5">*</span>}
         </span>
@@ -260,7 +262,7 @@ export function ImportStep() {
             rows={SYSTEM_FIELDS}
             getRowKey={(row) => row.key}
           />
-          <p className="text-p2 text-grey-400 text-right">
+          <p className="text-p2 text-grey-400 text-right font-semibold">
             Columns can be customized from the{' '}
             <Link to="/admin/settings" className="text-blue-300">
               Settings

--- a/frontend/src/pages/admin/routes/generation/ImportStep.tsx
+++ b/frontend/src/pages/admin/routes/generation/ImportStep.tsx
@@ -21,6 +21,7 @@ import {
 } from '@/common/components';
 
 import type { GenerationOutletContext } from './AdminRoutesGenerationLayout';
+import { GenerationFooter } from './GenerationFooter';
 
 const ACCEPTED_EXTENSIONS = new Set(['.xlsx']);
 
@@ -199,7 +200,7 @@ export function ImportStep() {
       <section className="flex flex-col gap-4">
         <div className="flex flex-col gap-1">
           <h2 className="text-grey-500">Select Delivery Type</h2>
-          <p className="text-p1 text-grey-500">
+          <p className="text-p1 text-grey-500 font-normal">
             Choose the type of spreadsheet you'll be uploading:
           </p>
         </div>
@@ -234,7 +235,7 @@ export function ImportStep() {
         <section className="flex max-w-[700px] flex-col gap-4">
           <div className="flex flex-col gap-1">
             <h2 className="text-grey-500">Import Data</h2>
-            <p className="text-p1 text-grey-500">
+            <p className="text-p1 text-grey-500 font-normal">
               Upload an Excel file (.xlsx) with delivery information
             </p>
           </div>
@@ -264,7 +265,7 @@ export function ImportStep() {
         <div className="flex flex-col gap-4">
           <div className="flex flex-col gap-1">
             <h2 className="text-grey-500">Map Columns</h2>
-            <p className="text-p1 text-grey-500">
+            <p className="text-p1 text-grey-500 font-normal">
               Match columns in your file to the fields in our database
             </p>
           </div>
@@ -284,8 +285,7 @@ export function ImportStep() {
         </div>
       )}
 
-      {/* Actions */}
-      <div className="flex items-center justify-between">
+      <GenerationFooter>
         <Button variant="tertiary" asChild>
           <Link to="/admin/routes">Back to routes</Link>
         </Button>
@@ -296,7 +296,7 @@ export function ImportStep() {
         >
           {isReviewing ? 'Validating…' : 'Continue to validate'}
         </Button>
-      </div>
+      </GenerationFooter>
     </>
   );
 }

--- a/frontend/src/pages/admin/routes/generation/ImportStep.tsx
+++ b/frontend/src/pages/admin/routes/generation/ImportStep.tsx
@@ -200,7 +200,7 @@ export function ImportStep() {
       <section className="flex flex-col gap-4">
         <div className="flex flex-col gap-1">
           <h2 className="text-grey-500">Select Delivery Type</h2>
-          <p className="text-p1 text-grey-500 font-normal">
+          <p className="text-p1 text-grey-500">
             Choose the type of spreadsheet you'll be uploading:
           </p>
         </div>
@@ -235,7 +235,7 @@ export function ImportStep() {
         <section className="flex max-w-[700px] flex-col gap-4">
           <div className="flex flex-col gap-1">
             <h2 className="text-grey-500">Import Data</h2>
-            <p className="text-p1 text-grey-500 font-normal">
+            <p className="text-p1 text-grey-500">
               Upload an Excel file (.xlsx) with delivery information
             </p>
           </div>
@@ -265,7 +265,7 @@ export function ImportStep() {
         <div className="flex flex-col gap-4">
           <div className="flex flex-col gap-1">
             <h2 className="text-grey-500">Map Columns</h2>
-            <p className="text-p1 text-grey-500 font-normal">
+            <p className="text-p1 text-grey-500">
               Match columns in your file to the fields in our database
             </p>
           </div>

--- a/frontend/src/pages/admin/routes/generation/ImportStep.tsx
+++ b/frontend/src/pages/admin/routes/generation/ImportStep.tsx
@@ -124,9 +124,12 @@ export function ImportStep() {
     {
       key: 'label',
       header: 'System Column',
-      // 56px rows, header included — the frames give this table more air than
-      // the others because every row holds a control.
-      headerClassName: 'h-14',
+      // 56px rows — the frames give this table more air than the others
+      // because every row holds a control. The header is 48 and top-aligned:
+      // the frames draw it as a 40px box with 16px of air beneath, which a
+      // borderless table row can only approximate, and this is the split that
+      // lands both the header text and all eight rows on their frame y.
+      headerClassName: 'h-12 align-top',
       getCellClassName: () => 'h-14',
       render: (row) => (
         // P1, not the table's usual P2 — these are field labels rather than
@@ -140,7 +143,7 @@ export function ImportStep() {
     {
       key: 'value',
       header: 'Your File Column',
-      headerClassName: 'h-14',
+      headerClassName: 'h-12 align-top',
       getCellClassName: () => 'h-14',
       render: (row) => (
         <Dropdown
@@ -193,8 +196,8 @@ export function ImportStep() {
         </Banner>
       )}
 
-      <section className="flex flex-col gap-3">
-        <div>
+      <section className="flex flex-col gap-4">
+        <div className="flex flex-col gap-1">
           <h2 className="text-grey-500">Select Delivery Type</h2>
           <p className="text-p1 text-grey-500">
             Choose the type of spreadsheet you'll be uploading:
@@ -229,7 +232,7 @@ export function ImportStep() {
 
       {selectedDeliveryType && (
         <section className="flex max-w-[700px] flex-col gap-4">
-          <div>
+          <div className="flex flex-col gap-1">
             <h2 className="text-grey-500">Import Data</h2>
             <p className="text-p1 text-grey-500">
               Upload an Excel file (.xlsx) with delivery information
@@ -270,7 +273,8 @@ export function ImportStep() {
             rows={SYSTEM_FIELDS}
             getRowKey={(row) => row.key}
           />
-          <p className="text-p2 text-grey-400 text-right font-semibold">
+          {/* 8px under the card, not the section's 16. */}
+          <p className="text-p2 text-grey-400 -mt-2 text-right font-semibold">
             Columns can be customized from the{' '}
             <Link to="/admin/settings" className="text-blue-300">
               Settings

--- a/frontend/src/pages/admin/routes/generation/ImportStep.tsx
+++ b/frontend/src/pages/admin/routes/generation/ImportStep.tsx
@@ -32,6 +32,7 @@ interface SystemField {
 
 const SYSTEM_FIELDS: SystemField[] = [
   { key: 'contact_name', label: 'School Name / Last Name', required: true },
+  { key: 'guardian_name', label: 'Guardian Name', required: true },
   { key: 'address', label: 'Address', required: true },
   { key: 'delivery_group', label: 'Delivery Group', required: true },
   { key: 'phone_primary', label: 'Phone Number', required: true },

--- a/frontend/src/pages/admin/routes/generation/ReviewStep.tsx
+++ b/frontend/src/pages/admin/routes/generation/ReviewStep.tsx
@@ -29,6 +29,7 @@ import { cn } from '@/lib/utils';
 
 import { EmptyState } from '../components';
 import type { GenerationOutletContext } from './AdminRoutesGenerationLayout';
+import { GenerationFooter } from './GenerationFooter';
 
 type ChangedField<T> = { new_value: T; old_value: T };
 
@@ -60,7 +61,7 @@ function ChangedCell({
   // 40px the frames call for and a changed row totals 80.
   return (
     <div className="-mx-4 -my-2.5 flex flex-col">
-      <span className="bg-grey-150 flex min-h-10 items-center gap-2 px-4">
+      <span className="border-grey-300 bg-grey-150 flex min-h-10 items-center gap-2 border-b-2 px-4">
         <span className="text-grey-400 text-base">−</span>
         {value.old_value ?? '—'}
       </span>
@@ -189,14 +190,17 @@ export function ReviewStep() {
     {
       key: 'reviewed',
       header: '',
+      // 32px column: the frames give the checkbox 8px either side, not the
+      // 16px the data columns use.
       headerClassName: 'w-8 px-2',
+      cellClassName: 'w-8 px-2',
       render: (row) => (
         <input
           type="checkbox"
           checked={reviewedChanged.has(row._index)}
           onChange={() => toggleChanged(row._index)}
           aria-label={`Review changes for ${row.contact_name}`}
-          className="border-grey-300 size-4 cursor-pointer rounded accent-blue-300"
+          className="border-grey-300 size-4 cursor-pointer rounded-[4px] accent-blue-300"
         />
       ),
     },
@@ -239,14 +243,17 @@ export function ReviewStep() {
     {
       key: 'reviewed',
       header: '',
+      // 32px column: the frames give the checkbox 8px either side, not the
+      // 16px the data columns use.
       headerClassName: 'w-8 px-2',
+      cellClassName: 'w-8 px-2',
       render: (row) => (
         <input
           type="checkbox"
           checked={reviewedRemoved.has(row.location_id)}
           onChange={() => toggleRemoved(row.location_id)}
           aria-label={`Review removal of ${row.contact_name}`}
-          className="border-grey-300 size-4 cursor-pointer rounded accent-blue-300"
+          className="border-grey-300 size-4 cursor-pointer rounded-[4px] accent-blue-300"
         />
       ),
     },
@@ -296,7 +303,7 @@ export function ReviewStep() {
                 total={changedEntries.length}
               />
             </div>
-            <p className="text-p1 text-grey-500">
+            <p className="text-p1 text-grey-500 font-normal">
               Check off entries that have changed since the previous upload to
               confirm you have reviewed them
             </p>
@@ -317,6 +324,7 @@ export function ReviewStep() {
           emptyState={
             <EmptyState
               compact
+              image="girl-searching"
               title="No entries found"
               description="No action required at this time"
             />
@@ -333,7 +341,7 @@ export function ReviewStep() {
               total={staleRows.length}
             />
           </div>
-          <p className="text-p1 text-grey-500">
+          <p className="text-p1 text-grey-500 font-normal">
             Check off entries that were removed since the previous upload to
             confirm you have reviewed them
           </p>
@@ -345,6 +353,7 @@ export function ReviewStep() {
           emptyState={
             <EmptyState
               compact
+              image="girl-searching"
               title="No entries found"
               description="No action required at this time"
             />
@@ -352,7 +361,7 @@ export function ReviewStep() {
         />
       </section>
 
-      <div className="flex items-center justify-between">
+      <GenerationFooter>
         <Button variant="tertiary" asChild>
           <Link to="/admin/routes/generation/validate">Back to validate</Link>
         </Button>
@@ -363,7 +372,7 @@ export function ReviewStep() {
         >
           Continue to edit route groups
         </Button>
-      </div>
+      </GenerationFooter>
 
       <Modal open={confirmOpen} onOpenChange={setConfirmOpen}>
         <ModalContent>

--- a/frontend/src/pages/admin/routes/generation/ReviewStep.tsx
+++ b/frontend/src/pages/admin/routes/generation/ReviewStep.tsx
@@ -303,7 +303,7 @@ export function ReviewStep() {
                 total={changedEntries.length}
               />
             </div>
-            <p className="text-p1 text-grey-500 font-normal">
+            <p className="text-p1 text-grey-500">
               Check off entries that have changed since the previous upload to
               confirm you have reviewed them
             </p>
@@ -341,7 +341,7 @@ export function ReviewStep() {
               total={staleRows.length}
             />
           </div>
-          <p className="text-p1 text-grey-500 font-normal">
+          <p className="text-p1 text-grey-500">
             Check off entries that were removed since the previous upload to
             confirm you have reviewed them
           </p>

--- a/frontend/src/pages/admin/routes/generation/ReviewStep.tsx
+++ b/frontend/src/pages/admin/routes/generation/ReviewStep.tsx
@@ -25,6 +25,7 @@ import {
   ModalHeader,
   ModalTitle,
 } from '@/common/components';
+import { cn } from '@/lib/utils';
 
 import { EmptyState } from '../components';
 import type { GenerationOutletContext } from './AdminRoutesGenerationLayout';
@@ -55,13 +56,15 @@ function ChangedCell({
     return <span>{value ?? '—'}</span>;
   }
 
+  // No vertical padding: `min-h-10` is border-box, so each half is exactly the
+  // 40px the frames call for and a changed row totals 80.
   return (
     <div className="-mx-4 -my-2.5 flex flex-col">
-      <span className="bg-grey-150 flex min-h-10 items-center gap-2 px-4 py-2.5">
+      <span className="bg-grey-150 flex min-h-10 items-center gap-2 px-4">
         <span className="text-grey-400 text-base">−</span>
         {value.old_value ?? '—'}
       </span>
-      <span className="flex min-h-10 items-center gap-2 border-b-2 border-blue-100 bg-blue-50 px-4 py-2.5">
+      <span className="flex min-h-10 items-center gap-2 border-b-2 border-blue-100 bg-blue-50 px-4">
         <span className="text-grey-400 text-base">+</span>
         {value.new_value ?? '—'}
       </span>
@@ -93,11 +96,14 @@ function ReviewStatus({
 
   return (
     <span
-      className={
+      className={cn(
+        // Tag: 127×26, r40, 16px side padding, 14/600. Neutral until every row
+        // in the section is checked off — 0 / 0 stays neutral.
+        'inline-flex h-[26px] items-center rounded-full px-4 text-sm font-semibold',
         complete
-          ? 'bg-success-fill text-success-stroke rounded-full px-3 py-1 text-sm'
-          : 'bg-grey-300 rounded-full px-3 py-1 text-sm'
-      }
+          ? 'bg-success-fill text-success-stroke'
+          : 'bg-grey-300 text-grey-500'
+      )}
     >
       {reviewed} / {total} Reviewed
     </span>
@@ -159,17 +165,21 @@ export function ReviewStep() {
   const handleConfirm = async () => {
     setIngestError(null);
     try {
+      // Every change is applied. The checkboxes only attest that an admin has
+      // looked at each row — they are not a per-row include/exclude.
       await ingestLocations({
         delivery_type: selectedDeliveryType,
         net_new: netNewRows.map(toIngestNetNew),
         stale: staleRows,
-        changed: changedEntries.filter((_, index) =>
-          reviewedChanged.has(index)
-        ),
+        changed: changedEntries,
       });
       setConfirmOpen(false);
       navigate('/admin/routes/generation/configure');
     } catch {
+      // Close first: Radix marks the rest of the page aria-hidden and locks
+      // body scroll while the modal is open, so a banner set behind it is
+      // unreachable both visually and to screen readers.
+      setConfirmOpen(false);
       setIngestError('Could not apply the import changes — please try again.');
     }
   };
@@ -258,7 +268,6 @@ export function ReviewStep() {
     ...entry,
     _index: index,
   }));
-  const compactEmptyState = '[&_td>div]:gap-1 [&_td>div]:py-8 [&_td_img]:h-28';
 
   return (
     <>
@@ -268,10 +277,10 @@ export function ReviewStep() {
         </Banner>
       )}
 
-      <section className="flex flex-col gap-3">
+      <section className="flex flex-col gap-4">
         <div className="flex items-end justify-between">
           <div>
-            <div className="flex items-center gap-3">
+            <div className="flex items-center gap-2">
               <h2 className="text-grey-500">Changed Data</h2>
               <ReviewStatus
                 reviewed={reviewedChanged.size}
@@ -284,10 +293,10 @@ export function ReviewStep() {
             </p>
           </div>
           <div className="flex items-center gap-2">
-            <span className="border-grey-300 rounded-full border bg-white px-4 py-1 text-sm">
+            <span className="border-grey-300 bg-grey-150 inline-flex h-[26px] items-center rounded-full border px-4 text-sm font-semibold">
               Old
             </span>
-            <span className="rounded-full border border-blue-100 bg-blue-50 px-4 py-1 text-sm">
+            <span className="inline-flex h-[26px] items-center rounded-full border border-blue-100 bg-blue-50 px-4 text-sm font-semibold">
               New
             </span>
           </div>
@@ -296,9 +305,9 @@ export function ReviewStep() {
           columns={changedColumns}
           rows={changedRows}
           getRowKey={(row) => row._index}
-          className={compactEmptyState}
           emptyState={
             <EmptyState
+              compact
               title="No entries found"
               description="No action required at this time"
             />
@@ -306,9 +315,9 @@ export function ReviewStep() {
         />
       </section>
 
-      <section className="flex flex-col gap-3">
+      <section className="flex flex-col gap-4">
         <div>
-          <div className="flex items-center gap-3">
+          <div className="flex items-center gap-2">
             <h2 className="text-grey-500">Removed</h2>
             <ReviewStatus
               reviewed={reviewedRemoved.size}
@@ -324,9 +333,9 @@ export function ReviewStep() {
           columns={staleColumns}
           rows={staleRows}
           getRowKey={(row) => row.location_id}
-          className={compactEmptyState}
           emptyState={
             <EmptyState
+              compact
               title="No entries found"
               description="No action required at this time"
             />

--- a/frontend/src/pages/admin/routes/generation/ReviewStep.tsx
+++ b/frontend/src/pages/admin/routes/generation/ReviewStep.tsx
@@ -75,6 +75,7 @@ function ChangedCell({
 function toIngestNetNew(entry: NetNewEntry): ValidatedLocationImportEntry {
   return {
     contact_name: entry.contact_name,
+    guardian_name: entry.guardian_name,
     address: entry.address,
     delivery_group: entry.delivery_group ?? '',
     phone_primary: entry.phone_primary,
@@ -203,6 +204,14 @@ export function ReviewStep() {
       key: 'contact_name',
       header: 'School / Last Name',
       render: (row) => row.contact_name,
+    },
+    // Not in the frames' Changed table. Without it, a row whose only edit is
+    // the guardian's name shows no visible difference, and there is nothing
+    // for the admin to check off — flag to the designer.
+    {
+      key: 'guardian_name',
+      header: 'Guardian Name',
+      render: (row) => <ChangedCell value={row.guardian_name} />,
     },
     {
       key: 'address',

--- a/frontend/src/pages/admin/routes/generation/ReviewStep.tsx
+++ b/frontend/src/pages/admin/routes/generation/ReviewStep.tsx
@@ -288,7 +288,7 @@ export function ReviewStep() {
 
       <section className="flex flex-col gap-4">
         <div className="flex items-end justify-between">
-          <div>
+          <div className="flex flex-col gap-1">
             <div className="flex items-center gap-2">
               <h2 className="text-grey-500">Changed Data</h2>
               <ReviewStatus
@@ -325,7 +325,7 @@ export function ReviewStep() {
       </section>
 
       <section className="flex flex-col gap-4">
-        <div>
+        <div className="flex flex-col gap-1">
           <div className="flex items-center gap-2">
             <h2 className="text-grey-500">Removed</h2>
             <ReviewStatus

--- a/frontend/src/pages/admin/routes/generation/ReviewStep.tsx
+++ b/frontend/src/pages/admin/routes/generation/ReviewStep.tsx
@@ -260,7 +260,7 @@ export function ReviewStep() {
     {
       key: 'num_children',
       header: 'Number of Children',
-      render: () => '—',
+      render: (row) => row.num_children ?? '—',
     },
   ];
 

--- a/frontend/src/pages/admin/routes/generation/ValidateStep.tsx
+++ b/frontend/src/pages/admin/routes/generation/ValidateStep.tsx
@@ -63,6 +63,9 @@ const hasPhoneAlert = (alerts: AlertCode[]) =>
   alerts.includes('MISSING_PHONE_NUMBER') ||
   alerts.includes('INVALID_PHONE_NUMBER');
 
+const hasInvalidOrMissingAlert = (row: { alerts: AlertCode[] }) =>
+  row.alerts.some((code) => code !== 'LOCAL_DUPLICATE');
+
 // Returns the cell highlight class for non-alert data columns
 function getCellClass(
   hasFieldError: boolean,
@@ -112,74 +115,103 @@ export function ValidateStep() {
   const errorCount = errorRows.length;
   const canContinue = data.success === true;
 
+  // The frames split validation into two tables because the two problems have
+  // different remedies. A row can land in both — a duplicate that is also
+  // missing a delivery group needs fixing twice — and each table shows only
+  // the alerts it is responsible for.
+  const invalidRows = errorRows.filter((r) => hasInvalidOrMissingAlert(r));
+  const duplicateRows = errorRows.filter((r) =>
+    r.alerts.includes('LOCAL_DUPLICATE')
+  );
+
   const handleContinue = () => {
     navigate('/admin/routes/generation/review');
   };
 
-  const columns: Column<LocationImportRow>[] = [
-    {
-      key: 'alerts',
-      header: 'Error',
-      render: (row) => {
-        if (row.alerts.length === 0) return null;
-        return (
-          <AlertCell
-            type="error"
-            label={row.alerts.map((code) => getAlertDisplay(code).label)}
-          />
-        );
+  const alertColumn = (
+    scope: 'invalid' | 'duplicate'
+  ): Column<LocationImportRow> => ({
+    key: 'alerts',
+    header: 'Error',
+    render: (row) => {
+      const codes = row.alerts.filter((code) =>
+        scope === 'duplicate'
+          ? code === 'LOCAL_DUPLICATE'
+          : code !== 'LOCAL_DUPLICATE'
+      );
+      if (codes.length === 0) return null;
+      return (
+        <AlertCell
+          type="error"
+          label={codes.map((code) => getAlertDisplay(code).label)}
+        />
+      );
+    },
+  });
+
+  // Each table highlights only the cells it is about: the invalid/missing
+  // table marks the fields that failed validation, the duplicate table marks
+  // the fields that matched another row. A row in both tables therefore shows
+  // a different set of red cells in each.
+  const dataColumns = (
+    scope: 'invalid' | 'duplicate'
+  ): Column<LocationImportRow>[] => {
+    const invalid = scope === 'invalid';
+    const duplicateFields = (row: LocationImportRow) =>
+      invalid ? undefined : duplicateFieldsByRow.get(row.row);
+
+    return [
+      {
+        key: 'row',
+        header: 'Row',
+        render: (row) => String(row.row),
       },
-    },
-    {
-      key: 'row',
-      header: 'Row',
-      render: (row) => String(row.row),
-      getCellClassName: () => getCellClass(false),
-    },
-    {
-      key: 'contact_name',
-      header: 'School / Last Name',
-      render: (row) => row.location.contact_name ?? '',
-      getCellClassName: (row) =>
-        getCellClass(
-          hasContactNameAlert(row.alerts),
-          'contact_name',
-          duplicateFieldsByRow.get(row.row)
-        ),
-    },
-    {
-      key: 'address',
-      header: 'Address',
-      render: (row) => row.location.address ?? '',
-      getCellClassName: (row) =>
-        getCellClass(
-          hasAddressAlert(row.alerts),
-          'address',
-          duplicateFieldsByRow.get(row.row)
-        ),
-    },
-    {
-      key: 'delivery_group',
-      header: 'Delivery Group',
-      render: (row) => row.location.delivery_group ?? '',
-      getCellClassName: (row) =>
-        getCellClass(
-          row.alerts.includes('MISSING_DELIVERY_GROUP') &&
-            !row.location.delivery_group
-        ),
-    },
-    {
-      key: 'phone_primary',
-      header: 'Phone Number',
-      render: (row) => row.location.phone_primary ?? '',
-      getCellClassName: (row) =>
-        getCellClass(
-          hasPhoneAlert(row.alerts),
-          'phone_primary',
-          duplicateFieldsByRow.get(row.row)
-        ),
-    },
-  ];
+      {
+        key: 'contact_name',
+        header: 'School / Last Name',
+        render: (row) => row.location.contact_name ?? '',
+        getCellClassName: (row) =>
+          getCellClass(
+            invalid && hasContactNameAlert(row.alerts),
+            'contact_name',
+            duplicateFields(row)
+          ),
+      },
+      {
+        key: 'address',
+        header: 'Address',
+        render: (row) => row.location.address ?? '',
+        getCellClassName: (row) =>
+          getCellClass(
+            invalid && hasAddressAlert(row.alerts),
+            'address',
+            duplicateFields(row)
+          ),
+      },
+      {
+        key: 'delivery_group',
+        header: 'Delivery Group',
+        render: (row) => row.location.delivery_group ?? '',
+        getCellClassName: (row) =>
+          getCellClass(
+            invalid &&
+              row.alerts.includes('MISSING_DELIVERY_GROUP') &&
+              !row.location.delivery_group
+          ),
+      },
+      {
+        key: 'phone_primary',
+        header: 'Phone Number',
+        render: (row) => row.location.phone_primary ?? '',
+        getCellClassName: (row) =>
+          getCellClass(
+            invalid && hasPhoneAlert(row.alerts),
+            'phone_primary',
+            duplicateFields(row)
+          ),
+      },
+    ];
+  };
 
   return (
     <>
@@ -200,18 +232,16 @@ export function ValidateStep() {
         </Banner>
       )}
 
-      {/* Validation card */}
-      <div className="flex flex-col gap-4">
+      <section className="flex flex-col gap-4">
         <div className="flex flex-col gap-1">
-          <h2 className="text-grey-500">Validation</h2>
+          <h2 className="text-grey-500">Invalid / Missing Entries</h2>
           <p className="text-p1 text-grey-500">
-            Below are all the records from your imported file with alerts to
-            resolve
+            Resolve all errors, then go back to Import to upload a new file
           </p>
         </div>
         <DataTable
-          columns={columns}
-          rows={errorRows}
+          columns={[alertColumn('invalid'), ...dataColumns('invalid')]}
+          rows={invalidRows}
           getRowKey={(row) => row.row}
           emptyState={
             <EmptyState
@@ -221,7 +251,29 @@ export function ValidateStep() {
             />
           }
         />
-      </div>
+      </section>
+
+      <section className="flex flex-col gap-4">
+        <div className="flex flex-col gap-1">
+          <h2 className="text-grey-500">Duplicate Entries</h2>
+          <p className="text-p1 text-grey-500">
+            Correct all duplicate entries, then go back to Import to upload a
+            new file
+          </p>
+        </div>
+        <DataTable
+          columns={[alertColumn('duplicate'), ...dataColumns('duplicate')]}
+          rows={duplicateRows}
+          getRowKey={(row) => row.row}
+          emptyState={
+            <EmptyState
+              compact
+              title="No entries found"
+              description="No action required at this time"
+            />
+          }
+        />
+      </section>
 
       {/* Actions */}
       <div className="flex items-center justify-between">

--- a/frontend/src/pages/admin/routes/generation/ValidateStep.tsx
+++ b/frontend/src/pages/admin/routes/generation/ValidateStep.tsx
@@ -119,7 +119,7 @@ export function ValidateStep() {
   const columns: Column<LocationImportRow>[] = [
     {
       key: 'alerts',
-      header: 'Alert',
+      header: 'Error',
       render: (row) => {
         if (row.alerts.length === 0) return null;
         return (
@@ -170,7 +170,7 @@ export function ValidateStep() {
     },
     {
       key: 'phone_primary',
-      header: 'Primary Phone',
+      header: 'Phone Number',
       render: (row) => row.location.phone_primary ?? '',
       getCellClassName: (row) =>
         getCellClass(
@@ -215,8 +215,9 @@ export function ValidateStep() {
           getRowKey={(row) => row.row}
           emptyState={
             <EmptyState
-              title="No new entries found in the spreadsheet"
-              description="It's feeling quite empty here"
+              compact
+              title="No entries found"
+              description="No action required at this time"
             />
           }
         />
@@ -232,7 +233,7 @@ export function ValidateStep() {
           disabled={!canContinue}
           onClick={handleContinue}
         >
-          Continue to review
+          Continue to review changes
         </Button>
       </div>
     </>

--- a/frontend/src/pages/admin/routes/generation/ValidateStep.tsx
+++ b/frontend/src/pages/admin/routes/generation/ValidateStep.tsx
@@ -210,7 +210,7 @@ export function ValidateStep() {
       <section className="flex flex-col gap-4">
         <div className="flex flex-col gap-1">
           <h2 className="text-grey-500">Invalid / Missing Entries</h2>
-          <p className="text-p1 text-grey-500 font-normal">
+          <p className="text-p1 text-grey-500">
             Resolve all errors, then go back to Import to upload a new file
           </p>
         </div>
@@ -232,7 +232,7 @@ export function ValidateStep() {
       <section className="flex flex-col gap-4">
         <div className="flex flex-col gap-1">
           <h2 className="text-grey-500">Duplicate Entries</h2>
-          <p className="text-p1 text-grey-500 font-normal">
+          <p className="text-p1 text-grey-500">
             Correct all duplicate entries, then go back to Import to upload a
             new file
           </p>

--- a/frontend/src/pages/admin/routes/generation/ValidateStep.tsx
+++ b/frontend/src/pages/admin/routes/generation/ValidateStep.tsx
@@ -215,13 +215,14 @@ export function ValidateStep() {
 
   return (
     <>
-      {/* Error banner */}
+      {/* Error banner — just the count. Each table below carries its own
+          instruction, so repeating "go back to Import" here said it three
+          times on the same screen. */}
       {!bannerDismissed && !data.success && (
         <Banner variant="error" onDismiss={() => setDismissedFor(data)}>
           Please correct these{' '}
           <span className="text-red font-bold">{errorCount}</span>{' '}
-          {errorCount === 1 ? 'error' : 'errors'} before continuing, then go
-          back to import to reupload the file.
+          {errorCount === 1 ? 'error' : 'errors'} before continuing.
         </Banner>
       )}
 

--- a/frontend/src/pages/admin/routes/generation/ValidateStep.tsx
+++ b/frontend/src/pages/admin/routes/generation/ValidateStep.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useMemo } from 'react';
 import {
   Link,
   Navigate,
@@ -9,17 +9,17 @@ import {
 import type {
   AlertCode,
   DuplicateMatchField,
-  LocationImportResponse,
   LocationImportRow,
 } from '@/api/generated/types.gen';
 import type { Column } from '@/common/components';
-import { AlertCell, Banner, Button, DataTable } from '@/common/components';
+import { AlertCell, Button, DataTable } from '@/common/components';
 
 import { EmptyState } from '../components';
 import type { GenerationOutletContext } from './AdminRoutesGenerationLayout';
+import { GenerationFooter } from './GenerationFooter';
 
 // Styling for error cells — all alerts are blocking and use the same red error.
-const ERROR_CELL_CLASS = 'border-b-2 border-red bg-light-red';
+const ERROR_CELL_CLASS = 'border-b border-red bg-light-red';
 
 // ---------------------------------------------------------------------------
 // Alert display helpers
@@ -98,21 +98,13 @@ export function ValidateStep() {
     return byRow;
   }, [reviewResult?.duplicate_groups]);
 
-  // Track which data the user dismissed the banner for. The banner is shown
-  // again automatically when a new response comes in (different reference).
-  const [dismissedFor, setDismissedFor] = useState<
-    LocationImportResponse | undefined
-  >(undefined);
-
   // Review runs on the Import step; without a result there's nothing to show.
   if (!file || !reviewResult) {
     return <Navigate to="/admin/routes/generation/import" replace />;
   }
 
   const data = reviewResult;
-  const bannerDismissed = dismissedFor === data;
   const errorRows = data.rows.filter((r) => r.alerts.length > 0);
-  const errorCount = errorRows.length;
   const canContinue = data.success === true;
 
   // The frames split validation into two tables because the two problems have
@@ -215,28 +207,10 @@ export function ValidateStep() {
 
   return (
     <>
-      {/* Error banner — just the count. Each table below carries its own
-          instruction, so repeating "go back to Import" here said it three
-          times on the same screen. */}
-      {!bannerDismissed && !data.success && (
-        <Banner variant="error" onDismiss={() => setDismissedFor(data)}>
-          Please correct these{' '}
-          <span className="text-red font-bold">{errorCount}</span>{' '}
-          {errorCount === 1 ? 'error' : 'errors'} before continuing.
-        </Banner>
-      )}
-
-      {/* Success banner */}
-      {!bannerDismissed && data.success && (
-        <Banner variant="success" onDismiss={() => setDismissedFor(data)}>
-          No errors. You may proceed to the next step.
-        </Banner>
-      )}
-
       <section className="flex flex-col gap-4">
         <div className="flex flex-col gap-1">
           <h2 className="text-grey-500">Invalid / Missing Entries</h2>
-          <p className="text-p1 text-grey-500">
+          <p className="text-p1 text-grey-500 font-normal">
             Resolve all errors, then go back to Import to upload a new file
           </p>
         </div>
@@ -247,6 +221,7 @@ export function ValidateStep() {
           emptyState={
             <EmptyState
               compact
+              image="girl-searching"
               title="No entries found"
               description="No action required at this time"
             />
@@ -257,7 +232,7 @@ export function ValidateStep() {
       <section className="flex flex-col gap-4">
         <div className="flex flex-col gap-1">
           <h2 className="text-grey-500">Duplicate Entries</h2>
-          <p className="text-p1 text-grey-500">
+          <p className="text-p1 text-grey-500 font-normal">
             Correct all duplicate entries, then go back to Import to upload a
             new file
           </p>
@@ -269,6 +244,7 @@ export function ValidateStep() {
           emptyState={
             <EmptyState
               compact
+              image="girl-searching"
               title="No entries found"
               description="No action required at this time"
             />
@@ -276,8 +252,7 @@ export function ValidateStep() {
         />
       </section>
 
-      {/* Actions */}
-      <div className="flex items-center justify-between">
+      <GenerationFooter>
         <Button variant="tertiary" asChild>
           <Link to="/admin/routes/generation/import">Back to import</Link>
         </Button>
@@ -288,7 +263,7 @@ export function ValidateStep() {
         >
           Continue to review changes
         </Button>
-      </div>
+      </GenerationFooter>
     </>
   );
 }

--- a/frontend/src/pages/admin/routes/generation/index.ts
+++ b/frontend/src/pages/admin/routes/generation/index.ts
@@ -1,6 +1,7 @@
 export { AdminRoutesGenerationLayout } from './AdminRoutesGenerationLayout';
 export { ConfigureStep } from './ConfigureStep';
 export { GenerateStep } from './GenerateStep';
+export { GenerationFooter } from './GenerationFooter';
 export { ImportStep } from './ImportStep';
 export { ReviewStep } from './ReviewStep';
 export { ValidateStep } from './ValidateStep';


### PR DESCRIPTION
Follow-up to #209, which merged close to the designs but with a set of
small mismatches across the first three steps. Every number below was
measured against the finalized Figma frames at a 1440 viewport rather
than eyeballed.

## Shell

The **stepper** is spaced by its labels, not its circles. The frames put
the five labels at an even 180.25px pitch across the content column —
their widths sum to 503, the column is 1224, and `(1224 - 503) / 4`
lands on every gap — so it is the labels that are evenly spaced and the
circles that ride on top. That leaves the circles unevenly spaced, so a
span between two of them is drawn as three pieces (one at each end
inside the step columns, one filling the gap) which join into an
unbroken line without measuring anything at runtime. Circles are now
2px inside strokes with no fill, `grey-400` ahead of the current step.

The **action buttons** moved into a shared sticky footer: an 84px
full-bleed bar with a 1px top border, matching the frames' Sticky
Footer. It cancels the page margins with negative insets and puts them
back as its own padding, so the buttons stay on the content grid.

## Validate

- Both banners are gone — the frames have no summary alert, and each
  table already carries its own instruction beneath the heading.
- Error-column labels are `grey-500` 14/600; only the icon is red.
- The error underline is 1px, not 2.
- The empty state is `girl-searching` cropped into a 106px `blue-50`
  disc, with both lines at 14/600.
- Row rules are `grey-200`; only the header rule is `grey-300`.

## Review

- The checkbox column's cells now match its header padding, via a new
  static `cellClassName` on `Column` — previously the header was `px-2`
  and the body `px-4`.

## Backend

`guardian_name` is imported alongside the school / last name and diffed
like any other field (migration `d2e91c47ab08`, nullable — schools have
no guardian and existing rows have nothing to backfill from), and
`num_children` is carried on stale entries so the Removed table can show
it in the same columns as the changed rows.

## Designs

The frames themselves had drifted: 46 section descriptions across the
route-generation flow carried no text style at all, several on a `Gray/800`
fill from an unrelated remote library. Those are now on
`Desktop/Paragraph/P1` (or `P2`) with `Grey/500` bound, done in Figma
with the designer's sign-off, so the code and the frames agree.

## Left alone deliberately

Auto-sized table columns, rather than the frames' fixed widths — the
widths look arbitrary and autosizing reads fine.

`TABLE_PAGE_SIZE` stays at 13. It comes from an admin table frame drawn
as a fixed box of fourteen 54px cells, but the route-generation frames
draw rows at 40px and `DataTable` now follows them, so the two frames
disagree. Documented in place rather than guessed at — it needs a
design answer, and whatever height wins, the count is
`(boxHeight / rowHeight) - 1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)