### PR TITLE
Rebuild the stepper on the autolayout design

### DIFF
--- a/frontend/src/pages/admin/routes/components/ProgressStepper.tsx
+++ b/frontend/src/pages/admin/routes/components/ProgressStepper.tsx
@@ -21,73 +21,46 @@ interface ProgressStepperProps {
   className?: string;
 }
 
-/** A 3px segment of the track, sitting on the 24px circle's centre line. */
-function Track({ done, className }: { done: boolean; className?: string }) {
-  return (
-    <div
-      className={cn(
-        'absolute top-[10.5px] h-[3px]',
-        done ? 'bg-blue-300' : 'bg-grey-300',
-        className
-      )}
-    />
-  );
-}
-
 function ProgressStepper({ currentStep, className }: ProgressStepperProps) {
-  const last = STEPS.length - 1;
-
   return (
-    // Each step is as wide as its own label, and the spans between them share
-    // what is left over — which is what the frames do: the five labels sit at
-    // an even 180.25px pitch across the content column, with each circle
-    // centred on its own label.
-    //
-    // That leaves the circles unevenly spaced, so a span can't be one element:
-    // it runs from a circle's edge, across the rest of that label's box, over
-    // the gap, and into the next label's box. Hence three pieces — two drawn
-    // inside the step columns and one filling the gap — which join up into an
-    // unbroken line without anyone having to measure a label.
-    <div className={cn('flex w-full items-start', className)}>
+    // The circles are evenly spaced and the labels hang off them: each label is
+    // centred on its circle and taken out of the flow, so a label as wide as
+    // "Edit Route Groups" doesn't push its circle around. That leaves the row as
+    // fixed-size circles with the connectors splitting whatever is left over.
+    // `pb-6` reserves the 4px gap + 20px line the labels occupy, and `px-14`
+    // the half-label that the first and last circles' labels hang off the row —
+    // without it they escape the page's side padding and cause a horizontal
+    // scroll. 56px clears the widest end label ("Generate Routes", 50.5px of
+    // overhang); bump it if the end labels get longer.
+    <div className={cn('flex w-full items-center px-14 pb-6', className)}>
       {STEPS.map((step, i) => (
         <Fragment key={step.path}>
-          <div className="relative flex shrink-0 flex-col items-center gap-1">
-            {i > 0 && (
-              <Track
-                done={i - 1 < currentStep}
-                className="right-[calc(50%+12px)] left-0"
-              />
-            )}
-            {i < last && (
-              <Track
-                done={i < currentStep}
-                className="right-0 left-[calc(50%+12px)]"
-              />
-            )}
+          {i > 0 && (
             <div
               className={cn(
-                'relative flex size-6 items-center justify-center rounded-full border-2',
-                i < currentStep && 'border-blue-300 bg-blue-300',
-                i === currentStep && 'border-blue-300',
-                i > currentStep && 'border-grey-400'
+                'h-[3px] flex-1',
+                i <= currentStep ? 'bg-blue-300' : 'bg-grey-300'
               )}
-            >
-              {i < currentStep && <CheckIcon className="size-3.5 text-white" />}
-            </div>
+            />
+          )}
+          <div
+            className={cn(
+              'relative flex size-6 shrink-0 items-center justify-center rounded-full border-2',
+              i < currentStep && 'border-blue-300 bg-blue-300',
+              i === currentStep && 'border-blue-300',
+              i > currentStep && 'border-grey-400'
+            )}
+          >
+            {i < currentStep && <CheckIcon className="size-3.5 text-white" />}
             <span
               className={cn(
-                'text-h3 text-center font-bold whitespace-nowrap',
+                'text-h3 absolute top-full left-1/2 mt-1 -translate-x-1/2 font-bold whitespace-nowrap',
                 i <= currentStep ? 'text-blue-300' : 'text-grey-400'
               )}
             >
               {step.label}
             </span>
           </div>
-          {i < last && (
-            <div className="relative flex-1">
-              <Track done={i < currentStep} className="inset-x-0" />
-            </div>
-          )}
         </Fragment>
       ))}
     </div>


### PR DESCRIPTION
The designer's new [autolayout stepper](https://www.figma.com/design/aoBkDdARkmaUc9Cc2OMicR/F4K-Designs?node-id=7782-32202) makes a different choice about who owns the horizontal space, and it's one we can build with a plain flex row.

**Before:** each step column was as wide as its own label, so the labels sat at an even pitch and the circles landed wherever their labels put them — unevenly spaced. A connector therefore couldn't be a single element: it ran from one circle's edge, across the rest of that label's box, over the gap, and into the next label's box. That's the three-piece `Track` helper.

**After:** the circles are evenly spaced (every connector in the frames is exactly 241.8px, and 144.25px in the narrow variant) and each label is centred on its circle and taken out of the flow. Once labels stop influencing layout, the row is just fixed-size circles with `flex-1` connectors between them.

Net −52/+25 lines, and `Track` is gone.

### One deviation from the frames

Taking the labels out of the flow means the end labels hang off the row — "Generate Routes" overhangs the last circle by ~50px. In Figma that bleeds harmlessly into the canvas, but the real content column has 48px of side padding, so it produced an actual horizontal scroll: measured `scrollWidth` 1472 vs viewport 1470 at desktop, and it'd be ~30px at mobile padding.

Pinning the two end labels flush to the row edges fixes the overflow but pulls "Generate Routes" left into "Edit Route Groups" at tablet width. So the row instead carries `px-14`: the circles inset 56px from the content edge, everything stays centred, and there's no collision or overflow at any width. That's the one magic number in the file (it clears the widest end label) and it's commented as such.

If we'd rather the circles sit flush to the content edge as drawn, the alternative is widening the page gutter instead.

### Verification

Rendered all five `currentStep` values plus a 700px-wide variant against the Figma frames and confirmed they match; measured `document.documentElement.scrollWidth` to verify the overflow fix. `tsc`, `eslint src`, and `prettier --check` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)