### PR TITLE
F4KRP-255: Configure route groups before generation

### DIFF
--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -1,6 +1,7 @@
 export { useAddresses } from './addresses';
 export { useForgotPassword, useLogin } from './auth';
 export { describeApiFailure } from './errors';
+export { useLocationGroups } from './location-groups';
 export { useApplyLocationImport, usePreviewLocationImport } from './locations';
 export { useRouteGroups } from './route-groups';
 export {

--- a/frontend/src/api/location-groups.ts
+++ b/frontend/src/api/location-groups.ts
@@ -1,0 +1,7 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { getLocationGroupsOptions } from './generated/@tanstack/react-query.gen';
+
+export function useLocationGroups() {
+  return useQuery(getLocationGroupsOptions());
+}

--- a/frontend/src/common/components/Modal.tsx
+++ b/frontend/src/common/components/Modal.tsx
@@ -29,8 +29,11 @@ function ModalOverlay({
 function ModalContent({
   className,
   children,
+  showCloseButton = true,
   ...props
-}: React.ComponentProps<typeof DialogPrimitive.Content>) {
+}: React.ComponentProps<typeof DialogPrimitive.Content> & {
+  showCloseButton?: boolean;
+}) {
   return (
     <ModalPortal>
       <ModalOverlay />
@@ -48,12 +51,14 @@ function ModalContent({
         {...props}
       >
         {children}
-        <DialogPrimitive.Close
-          aria-label="Close"
-          className="shadow-light text-grey-400 hover:text-grey-500 absolute top-4 right-4 flex size-11 items-center justify-center rounded-full bg-white transition-colors"
-        >
-          <XIcon className="size-5" />
-        </DialogPrimitive.Close>
+        {showCloseButton && (
+          <DialogPrimitive.Close
+            aria-label="Close"
+            className="shadow-light text-grey-400 hover:text-grey-500 absolute top-4 right-4 flex size-11 items-center justify-center rounded-full bg-white transition-colors"
+          >
+            <XIcon className="size-5" />
+          </DialogPrimitive.Close>
+        )}
       </DialogPrimitive.Content>
     </ModalPortal>
   );

--- a/frontend/src/pages/admin/routes/generation/AdminRoutesGenerationLayout.tsx
+++ b/frontend/src/pages/admin/routes/generation/AdminRoutesGenerationLayout.tsx
@@ -2,7 +2,10 @@ import { useState } from 'react';
 import { Link, Outlet, useLocation } from 'react-router-dom';
 
 import { useSystemSettings } from '@/api';
-import type { LocationImportPreview } from '@/api/generated/types.gen';
+import type {
+  LocationImportPreview,
+  RouteGenerationGroupInput,
+} from '@/api/generated/types.gen';
 import ChevronRightIcon from '@/assets/icons/chevron-right.svg?react';
 
 import { ProgressStepper } from '../components';
@@ -32,6 +35,8 @@ export interface GenerationOutletContext {
   setSelectedDeliveryType: (deliveryType: string) => void;
   reviewResult: LocationImportPreview | null;
   setReviewResult: (r: LocationImportPreview | null) => void;
+  routeGenerationInputs: RouteGenerationGroupInput[];
+  setRouteGenerationInputs: (inputs: RouteGenerationGroupInput[]) => void;
 }
 
 export function AdminRoutesGenerationLayout() {
@@ -48,6 +53,9 @@ export function AdminRoutesGenerationLayout() {
   const [hasSeededColumnMap, setHasSeededColumnMap] = useState(false);
   const [reviewResult, setReviewResult] =
     useState<LocationImportPreview | null>(null);
+  const [routeGenerationInputs, setRouteGenerationInputs] = useState<
+    RouteGenerationGroupInput[]
+  >([]);
 
   if (!hasSeededColumnMap && settingsLoaded) {
     setHasSeededColumnMap(true);
@@ -65,6 +73,8 @@ export function AdminRoutesGenerationLayout() {
     setSelectedDeliveryType,
     reviewResult,
     setReviewResult,
+    routeGenerationInputs,
+    setRouteGenerationInputs,
   };
 
   return (

--- a/frontend/src/pages/admin/routes/generation/ConfigureStep.tsx
+++ b/frontend/src/pages/admin/routes/generation/ConfigureStep.tsx
@@ -1,17 +1,14 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { Navigate, useNavigate, useOutletContext } from 'react-router-dom';
 
+import { useLocationGroups, useSystemSettings } from '@/api';
 import EditIcon from '@/assets/icons/edit.svg?react';
 import type { Column } from '@/common/components';
 import {
+  Banner,
   Button,
   DataTable,
   DatePicker,
-  Dropdown,
-  DropdownContent,
-  DropdownItem,
-  DropdownTrigger,
-  DropdownValue,
   Input,
   Modal,
   ModalContent,
@@ -19,141 +16,284 @@ import {
   ModalFooter,
   ModalHeader,
   ModalTitle,
+  Spinner,
   TimePicker,
 } from '@/common/components';
+import { cn } from '@/lib/utils';
 
 import type { GenerationOutletContext } from './AdminRoutesGenerationLayout';
 import { GenerationFooter } from './GenerationFooter';
 
-// ---------------------------------------------------------------------------
-// Types
-// ---------------------------------------------------------------------------
-
-// Read-only — derived from POST /locations/review response
-interface RouteGroup {
-  delivery_group: string;
-  delivery_type: string;
-  stops: number;
-}
-
-// User-controlled — sent to the generation API
 interface RouteFormEntry {
-  route_date: Date | undefined;
-  start_time: string | undefined;
-  route_count: number | undefined;
-  end_location: string;
+  routeDate: Date | undefined;
+  startTime: string;
+  routeCount: number | undefined;
+  returnToWarehouse: boolean;
 }
 
 type FormState = Record<string, RouteFormEntry>;
 
-// Combined shape for the DataTable row
-interface RouteRow extends RouteGroup {
+interface RouteRow {
+  deliveryGroup: string;
+  deliveryType: string;
+  stops: number;
   form: RouteFormEntry;
 }
 
-// ---------------------------------------------------------------------------
-// Mock API data — replace with real response from backend
-// ---------------------------------------------------------------------------
-
-const MOCK_ROUTE_GROUPS: RouteGroup[] = [
-  { delivery_group: 'Tuesday A', delivery_type: 'Family', stops: 9 },
-  { delivery_group: 'Wednesday B', delivery_type: 'Family', stops: 6 },
-  { delivery_group: 'Thursday A', delivery_type: 'Family', stops: 8 },
-];
-
-const INITIAL_FORM_STATE: FormState = {
-  'Tuesday A': {
-    route_date: undefined,
-    start_time: undefined,
-    route_count: 4,
-    end_location: 'Warehouse',
-  },
-  'Wednesday B': {
-    route_date: undefined,
-    start_time: undefined,
-    route_count: 4,
-    end_location: 'Warehouse',
-  },
-  'Thursday A': {
-    route_date: undefined,
-    start_time: undefined,
-    route_count: 8,
-    end_location: 'Warehouse',
-  },
+const WEEKDAYS: Record<string, number> = {
+  sunday: 0,
+  monday: 1,
+  tuesday: 2,
+  wednesday: 3,
+  thursday: 4,
+  friday: 5,
+  saturday: 6,
 };
 
-const END_LOCATION_OPTIONS = [
-  { label: 'Warehouse', value: 'Warehouse' },
-  { label: 'School', value: 'School' },
-] as const;
+function nextRouteDate(groupName: string, today = new Date()): Date {
+  const weekdayName = groupName.trim().split(/\s+/)[0]?.toLowerCase();
+  const targetDay = WEEKDAYS[weekdayName];
+  const result = new Date(today);
+  result.setHours(0, 0, 0, 0);
 
-// ---------------------------------------------------------------------------
-// Component
-// ---------------------------------------------------------------------------
+  if (targetDay === undefined) {
+    result.setDate(result.getDate() + 1);
+    return result;
+  }
+
+  let daysUntil = (targetDay - result.getDay() + 7) % 7;
+  if (daysUntil === 0) daysUntil = 7;
+  result.setDate(result.getDate() + daysUntil);
+  return result;
+}
+
+function normalizeTime(value: string | null | undefined): string {
+  return value?.slice(0, 5) || '09:00';
+}
+
+function routeStartDateTime(date: Date, time: string): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}T${time}:00`;
+}
+
+function ReturnToggle({
+  checked,
+  disabled = false,
+  onChange,
+}: {
+  checked: boolean;
+  disabled?: boolean;
+  onChange: (checked: boolean) => void;
+}) {
+  return (
+    <div
+      className={cn(
+        'flex items-center gap-2',
+        disabled ? 'cursor-not-allowed opacity-50' : 'cursor-pointer'
+      )}
+    >
+      <button
+        type="button"
+        role="switch"
+        aria-checked={checked}
+        disabled={disabled}
+        onClick={() => onChange(!checked)}
+        className={cn(
+          'relative h-5 w-9 rounded-full transition-colors',
+          checked ? 'bg-blue-300' : 'bg-grey-300'
+        )}
+      >
+        <span
+          className={cn(
+            'absolute top-0.5 size-4 rounded-full bg-white transition-transform',
+            checked ? 'translate-x-[18px]' : 'translate-x-0.5'
+          )}
+        />
+      </button>
+      <span className="text-p2">{checked ? 'Yes' : 'No'}</span>
+    </div>
+  );
+}
 
 export function ConfigureStep() {
   const navigate = useNavigate();
-  const { file } = useOutletContext<GenerationOutletContext>();
-  const [formData, setFormData] = useState<FormState>(INITIAL_FORM_STATE);
+  const { file, reviewResult, selectedDeliveryType, setRouteGenerationInputs } =
+    useOutletContext<GenerationOutletContext>();
+  const { data: systemSettings } = useSystemSettings();
+  const {
+    data: locationGroups,
+    isPending: groupsPending,
+    isError: groupsError,
+  } = useLocationGroups();
+
+  const [formData, setFormData] = useState<FormState>({});
+  const [deselectedGroups, setDeselectedGroups] = useState<Set<string>>(
+    new Set()
+  );
   const [confirmOpen, setConfirmOpen] = useState(false);
   const [leaveOpen, setLeaveOpen] = useState(false);
 
-  if (!file) {
+  const importedGroupCounts = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const row of reviewResult?.rows ?? []) {
+      const groupName = row.location.delivery_group?.trim();
+      if (!groupName || row.alerts.length > 0) continue;
+      counts.set(groupName, (counts.get(groupName) ?? 0) + 1);
+    }
+    return counts;
+  }, [reviewResult]);
+
+  const importedGroups = useMemo(
+    () =>
+      (locationGroups ?? []).filter((group) =>
+        importedGroupCounts.has(group.name)
+      ),
+    [importedGroupCounts, locationGroups]
+  );
+
+  if (!file || !reviewResult || !selectedDeliveryType) {
     return <Navigate to="/admin/routes/generation/import" replace />;
   }
 
-  const updateEntry = (key: string, updates: Partial<RouteFormEntry>) => {
-    setFormData((prev) => ({
-      ...prev,
-      [key]: { ...prev[key], ...updates },
+  const defaultEntry = (groupName: string): RouteFormEntry => {
+    const stops = importedGroupCounts.get(groupName) ?? 0;
+    const defaultCap = systemSettings?.default_cap;
+    return {
+      routeDate: nextRouteDate(groupName),
+      startTime: normalizeTime(systemSettings?.route_start_time),
+      routeCount:
+        defaultCap && defaultCap > 0
+          ? Math.max(1, Math.ceil(stops / defaultCap))
+          : 1,
+      returnToWarehouse: selectedDeliveryType.toLowerCase().includes('school'),
+    };
+  };
+
+  const getEntry = (groupName: string) =>
+    formData[groupName] ?? defaultEntry(groupName);
+
+  const updateEntry = (groupName: string, updates: Partial<RouteFormEntry>) => {
+    setFormData((previous) => ({
+      ...previous,
+      [groupName]: {
+        ...(previous[groupName] ?? defaultEntry(groupName)),
+        ...updates,
+      },
     }));
   };
 
-  // Merged payload ready to POST to the generation API
-  const buildPayload = () =>
-    MOCK_ROUTE_GROUPS.map((group) => ({
-      ...group,
-      ...formData[group.delivery_group],
-    }));
+  const toggleGroup = (groupName: string) => {
+    setDeselectedGroups((previous) => {
+      const next = new Set(previous);
+      if (next.has(groupName)) next.delete(groupName);
+      else next.add(groupName);
+      return next;
+    });
+  };
+
+  const rows: RouteRow[] = importedGroups.map((group) => ({
+    deliveryGroup: group.name,
+    deliveryType: selectedDeliveryType,
+    stops: importedGroupCounts.get(group.name) ?? group.num_locations,
+    form: getEntry(group.name),
+  }));
+
+  const selectedRows = rows.filter(
+    (row) => !deselectedGroups.has(row.deliveryGroup)
+  );
+  const missingGroups = [...importedGroupCounts.keys()].filter(
+    (name) => !importedGroups.some((group) => group.name === name)
+  );
+  const canContinue =
+    selectedRows.length > 0 &&
+    missingGroups.length === 0 &&
+    selectedRows.every(
+      (row) =>
+        row.form.routeDate &&
+        row.form.startTime &&
+        row.form.routeCount !== undefined &&
+        row.form.routeCount > 0 &&
+        row.form.routeCount <= row.stops
+    );
 
   const handleConfirm = () => {
-    // TODO: pass buildPayload() to the generation API call
-    void buildPayload();
+    if (!canContinue) return;
+
+    setRouteGenerationInputs(
+      selectedRows.map((row) => {
+        const group = importedGroups.find(
+          (candidate) => candidate.name === row.deliveryGroup
+        );
+        if (!group || !row.form.routeDate || !row.form.routeCount) {
+          throw new Error('Selected route group is missing required settings');
+        }
+
+        return {
+          location_group: {
+            location_group_id: group.location_group_id,
+            name: group.name,
+            color: group.color,
+            notes: group.notes,
+          },
+          settings: {
+            route_start_time: routeStartDateTime(
+              row.form.routeDate,
+              row.form.startTime
+            ),
+            num_routes: row.form.routeCount,
+            return_to_warehouse: row.form.returnToWarehouse,
+            max_stops_per_route: systemSettings?.default_cap ?? null,
+            max_boxes_per_driver: systemSettings?.boxes_per_car ?? 10,
+            children_per_box: systemSettings?.children_per_box ?? 2,
+            service_time_minutes: systemSettings?.dropoff_minutes ?? 3,
+          },
+        };
+      })
+    );
     setConfirmOpen(false);
     navigate('/admin/routes/generation/generate');
   };
 
-  // Flatten API data + form state into table rows
-  const rows: RouteRow[] = MOCK_ROUTE_GROUPS.map((group) => ({
-    ...group,
-    form: formData[group.delivery_group],
-  }));
-
   const columns: Column<RouteRow>[] = [
+    {
+      key: 'selected',
+      header: '',
+      headerClassName: 'w-8 px-2',
+      cellClassName: 'w-8 px-2',
+      render: (row) => (
+        <input
+          type="checkbox"
+          checked={!deselectedGroups.has(row.deliveryGroup)}
+          onChange={() => toggleGroup(row.deliveryGroup)}
+          aria-label={`Generate routes for ${row.deliveryGroup}`}
+          className="size-4 cursor-pointer rounded-[4px] accent-blue-300"
+        />
+      ),
+    },
     {
       key: 'delivery_type',
       header: 'Delivery Type',
-      render: (row) => row.delivery_type,
+      render: (row) => row.deliveryType,
     },
     {
       key: 'delivery_group',
       header: 'Delivery Group',
-      render: (row) => row.delivery_group,
+      render: (row) => row.deliveryGroup,
     },
-    {
-      key: 'stops',
-      header: 'Stops',
-      render: (row) => String(row.stops),
-    },
+    { key: 'stops', header: 'Stops', render: (row) => String(row.stops) },
     {
       key: 'route_date',
       header: 'Route Date',
       render: (row) => (
         <DatePicker
-          value={row.form.route_date}
-          onChange={(date) =>
-            updateEntry(row.delivery_group, { route_date: date })
+          value={row.form.routeDate}
+          onChange={(routeDate) =>
+            updateEntry(row.deliveryGroup, { routeDate })
           }
+          disabled={deselectedGroups.has(row.deliveryGroup)}
+          className="w-36"
         />
       ),
     },
@@ -162,10 +302,12 @@ export function ConfigureStep() {
       header: 'Start Time',
       render: (row) => (
         <TimePicker
-          value={row.form.start_time}
-          onChange={(time) =>
-            updateEntry(row.delivery_group, { start_time: time })
+          value={row.form.startTime}
+          onChange={(startTime) =>
+            updateEntry(row.deliveryGroup, { startTime })
           }
+          disabled={deselectedGroups.has(row.deliveryGroup)}
+          className="w-32"
         />
       ),
     },
@@ -173,80 +315,92 @@ export function ConfigureStep() {
       key: 'route_count',
       header: 'Route Count',
       render: (row) => (
-        <div className="relative w-24">
+        <div className="relative w-20">
           <Input
             type="number"
-            value={row.form.route_count ?? ''}
-            placeholder="0"
-            onChange={(e) =>
-              updateEntry(row.delivery_group, {
-                route_count:
-                  e.target.value === '' ? undefined : Number(e.target.value),
+            min={1}
+            max={row.stops}
+            value={row.form.routeCount ?? ''}
+            disabled={deselectedGroups.has(row.deliveryGroup)}
+            aria-label={`Route count for ${row.deliveryGroup}`}
+            onChange={(event) =>
+              updateEntry(row.deliveryGroup, {
+                routeCount:
+                  event.target.value === ''
+                    ? undefined
+                    : Number(event.target.value),
               })
             }
-            className="px-3 py-2"
+            className="py-2 pr-8"
           />
-          <div className="text-grey-400 pointer-events-none absolute inset-y-0 right-3 flex items-center">
-            <EditIcon className="size-4" />
-          </div>
+          <EditIcon className="text-grey-400 pointer-events-none absolute top-1/2 right-3 size-4 -translate-y-1/2" />
         </div>
       ),
     },
     {
-      key: 'end_location',
-      header: 'End Location',
+      key: 'return_to_warehouse',
+      header: 'Return to Warehouse',
       render: (row) => (
-        <Dropdown
-          value={row.form.end_location}
-          onValueChange={(val) =>
-            updateEntry(row.delivery_group, { end_location: val })
+        <ReturnToggle
+          checked={row.form.returnToWarehouse}
+          disabled={deselectedGroups.has(row.deliveryGroup)}
+          onChange={(returnToWarehouse) =>
+            updateEntry(row.deliveryGroup, { returnToWarehouse })
           }
-        >
-          <DropdownTrigger className="w-40">
-            <DropdownValue />
-          </DropdownTrigger>
-          <DropdownContent>
-            {END_LOCATION_OPTIONS.map((opt) => (
-              <DropdownItem key={opt.value} value={opt.value}>
-                {opt.label}
-              </DropdownItem>
-            ))}
-          </DropdownContent>
-        </Dropdown>
+        />
       ),
     },
   ];
 
   return (
     <>
-      {/* Header */}
-      <div className="flex flex-col gap-4">
+      <section className="flex flex-col gap-4">
         <div className="flex flex-col gap-1">
           <h2 className="text-grey-500">Configure Routes</h2>
-          <p className="text-p1 text-grey-400">
-            Route data has been prefilled based on the imported data. Please
-            review the details, make any necessary changes, and select which
-            routes to generate.
+          <p className="text-p1 text-grey-500">
+            Route groups were created from the imported data. Please review the
+            details, make necessary changes, and select which routes to
+            generate.
           </p>
         </div>
 
-        <DataTable
-          columns={columns}
-          rows={rows}
-          getRowKey={(row) => row.delivery_group}
-        />
-      </div>
+        {groupsError && (
+          <Banner variant="error">
+            Could not load the imported route groups. Please try again.
+          </Banner>
+        )}
+        {missingGroups.length > 0 && !groupsPending && (
+          <Banner variant="error">
+            Some imported route groups could not be loaded. Go back and apply
+            the import again.
+          </Banner>
+        )}
+        {groupsPending ? (
+          <div className="flex justify-center py-16">
+            <Spinner size="lg" />
+          </div>
+        ) : (
+          <DataTable
+            columns={columns}
+            rows={rows}
+            getRowKey={(row) => row.deliveryGroup}
+          />
+        )}
+      </section>
 
       <GenerationFooter>
         <Button variant="tertiary" onClick={() => setLeaveOpen(true)}>
           Back to review changes
         </Button>
-        <Button variant="primary" onClick={() => setConfirmOpen(true)}>
+        <Button
+          variant="primary"
+          disabled={!canContinue}
+          onClick={() => setConfirmOpen(true)}
+        >
           Continue to generate routes
         </Button>
       </GenerationFooter>
 
-      {/* Leave without saving dialog */}
       <Modal open={leaveOpen} onOpenChange={setLeaveOpen}>
         <ModalContent>
           <ModalHeader>
@@ -270,14 +424,13 @@ export function ConfigureStep() {
         </ModalContent>
       </Modal>
 
-      {/* Generate routes confirmation dialog */}
       <Modal open={confirmOpen} onOpenChange={setConfirmOpen}>
         <ModalContent>
           <ModalHeader>
             <ModalTitle>Continue to Generation</ModalTitle>
             <ModalDescription>
-              You're about to generate routes for routes you have selected. This
-              action cannot be undone.
+              You're about to generate delivery routes for the groups you have
+              selected. This action cannot be undone.
             </ModalDescription>
           </ModalHeader>
           <ModalFooter>

--- a/frontend/src/pages/admin/routes/generation/ConfigureStep.tsx
+++ b/frontend/src/pages/admin/routes/generation/ConfigureStep.tsx
@@ -53,8 +53,12 @@ const WEEKDAYS: Record<string, number> = {
 };
 
 function nextRouteDate(groupName: string, today = new Date()): Date {
-  const weekdayName = groupName.trim().split(/\s+/)[0]?.toLowerCase();
-  const targetDay = WEEKDAYS[weekdayName];
+  const weekdayName = groupName
+    .toLowerCase()
+    .match(
+      /\b(sunday|monday|tuesday|wednesday|thursday|friday|saturday)\b/
+    )?.[1];
+  const targetDay = weekdayName ? WEEKDAYS[weekdayName] : undefined;
   const result = new Date(today);
   result.setHours(0, 0, 0, 0);
 
@@ -117,7 +121,7 @@ function ReturnToggle({
       >
         <span
           className={cn(
-            'absolute top-0.5 size-4 rounded-full bg-white transition-transform',
+            'absolute top-0.5 left-0 size-4 rounded-full bg-white transition-transform',
             checked ? 'translate-x-[18px]' : 'translate-x-0.5'
           )}
         />
@@ -169,17 +173,17 @@ export function ConfigureStep() {
 
   const defaultEntry = (groupName: string): RouteFormEntry => {
     const stops = importedGroupCounts.get(groupName) ?? 0;
-    const defaultCap = systemSettings?.default_cap;
+    const boxesPerCar = systemSettings?.boxes_per_car;
     const routeDate = nextRouteDate(groupName);
     return {
       name: defaultRouteName(groupName, routeDate),
       routeDate,
       startTime: normalizeTime(systemSettings?.route_start_time),
       routeCount:
-        defaultCap && defaultCap > 0
-          ? Math.max(1, Math.ceil(stops / defaultCap))
+        boxesPerCar && boxesPerCar > 0
+          ? Math.max(1, Math.ceil(stops / boxesPerCar))
           : 1,
-      returnToWarehouse: selectedDeliveryType.toLowerCase().includes('school'),
+      returnToWarehouse: false,
     };
   };
 
@@ -265,10 +269,10 @@ export function ConfigureStep() {
             ),
             num_routes: row.form.routeCount,
             return_to_warehouse: row.form.returnToWarehouse,
-            max_stops_per_route: systemSettings?.default_cap ?? null,
-            max_boxes_per_driver: systemSettings?.boxes_per_car ?? 10,
-            children_per_box: systemSettings?.children_per_box ?? 2,
-            service_time_minutes: systemSettings?.dropoff_minutes ?? 3,
+            max_stops_per_route: null,
+            max_boxes_per_driver: systemSettings?.boxes_per_car,
+            children_per_box: systemSettings?.children_per_box,
+            service_time_minutes: systemSettings?.dropoff_minutes,
           },
         };
       })
@@ -340,9 +344,17 @@ export function ConfigureStep() {
       render: (row) => (
         <DatePicker
           value={row.form.routeDate}
-          onChange={(routeDate) =>
-            updateEntry(row.deliveryGroup, { routeDate })
-          }
+          onChange={(routeDate) => {
+            const previousDefaultName = row.form.routeDate
+              ? defaultRouteName(row.deliveryGroup, row.form.routeDate)
+              : undefined;
+            updateEntry(row.deliveryGroup, {
+              routeDate,
+              ...(routeDate && row.form.name === previousDefaultName
+                ? { name: defaultRouteName(row.deliveryGroup, routeDate) }
+                : {}),
+            });
+          }}
           disabled={deselectedGroups.has(row.deliveryGroup)}
           className="w-36"
         />

--- a/frontend/src/pages/admin/routes/generation/ConfigureStep.tsx
+++ b/frontend/src/pages/admin/routes/generation/ConfigureStep.tsx
@@ -25,6 +25,7 @@ import type { GenerationOutletContext } from './AdminRoutesGenerationLayout';
 import { GenerationFooter } from './GenerationFooter';
 
 interface RouteFormEntry {
+  name: string;
   routeDate: Date | undefined;
   startTime: string;
   routeCount: number | undefined;
@@ -34,6 +35,7 @@ interface RouteFormEntry {
 type FormState = Record<string, RouteFormEntry>;
 
 interface RouteRow {
+  name: string;
   deliveryGroup: string;
   deliveryType: string;
   stops: number;
@@ -76,6 +78,14 @@ function routeStartDateTime(date: Date, time: string): string {
   const month = String(date.getMonth() + 1).padStart(2, '0');
   const day = String(date.getDate()).padStart(2, '0');
   return `${year}-${month}-${day}T${time}:00`;
+}
+
+function defaultRouteName(groupName: string, routeDate: Date): string {
+  const date = routeDate.toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+  });
+  return `${date} - ${groupName}`;
 }
 
 function ReturnToggle({
@@ -160,8 +170,10 @@ export function ConfigureStep() {
   const defaultEntry = (groupName: string): RouteFormEntry => {
     const stops = importedGroupCounts.get(groupName) ?? 0;
     const defaultCap = systemSettings?.default_cap;
+    const routeDate = nextRouteDate(groupName);
     return {
-      routeDate: nextRouteDate(groupName),
+      name: defaultRouteName(groupName, routeDate),
+      routeDate,
       startTime: normalizeTime(systemSettings?.route_start_time),
       routeCount:
         defaultCap && defaultCap > 0
@@ -194,6 +206,7 @@ export function ConfigureStep() {
   };
 
   const rows: RouteRow[] = importedGroups.map((group) => ({
+    name: getEntry(group.name).name,
     deliveryGroup: group.name,
     deliveryType: selectedDeliveryType,
     stops: importedGroupCounts.get(group.name) ?? group.num_locations,
@@ -203,6 +216,13 @@ export function ConfigureStep() {
   const selectedRows = rows.filter(
     (row) => !deselectedGroups.has(row.deliveryGroup)
   );
+  const allSelected = rows.length > 0 && selectedRows.length === rows.length;
+
+  const toggleAllGroups = () => {
+    setDeselectedGroups(
+      allSelected ? new Set(rows.map((row) => row.deliveryGroup)) : new Set()
+    );
+  };
   const missingGroups = [...importedGroupCounts.keys()].filter(
     (name) => !importedGroups.some((group) => group.name === name)
   );
@@ -211,6 +231,7 @@ export function ConfigureStep() {
     missingGroups.length === 0 &&
     selectedRows.every(
       (row) =>
+        row.form.name.trim().length > 0 &&
         row.form.routeDate &&
         row.form.startTime &&
         row.form.routeCount !== undefined &&
@@ -233,7 +254,7 @@ export function ConfigureStep() {
         return {
           location_group: {
             location_group_id: group.location_group_id,
-            name: group.name,
+            name: row.form.name,
             color: group.color,
             notes: group.notes,
           },
@@ -259,7 +280,19 @@ export function ConfigureStep() {
   const columns: Column<RouteRow>[] = [
     {
       key: 'selected',
-      header: '',
+      header: (
+        <input
+          type="checkbox"
+          checked={allSelected}
+          onChange={toggleAllGroups}
+          aria-label={
+            allSelected
+              ? 'Deselect all route groups'
+              : 'Select all route groups'
+          }
+          className="size-4 cursor-pointer rounded-[4px] accent-blue-300"
+        />
+      ),
       headerClassName: 'w-8 px-2',
       cellClassName: 'w-8 px-2',
       render: (row) => (
@@ -270,6 +303,24 @@ export function ConfigureStep() {
           aria-label={`Generate routes for ${row.deliveryGroup}`}
           className="size-4 cursor-pointer rounded-[4px] accent-blue-300"
         />
+      ),
+    },
+    {
+      key: 'name',
+      header: 'Name',
+      render: (row) => (
+        <div className="relative w-48">
+          <Input
+            value={row.form.name}
+            disabled={deselectedGroups.has(row.deliveryGroup)}
+            aria-label={`Name for ${row.deliveryGroup}`}
+            onChange={(event) =>
+              updateEntry(row.deliveryGroup, { name: event.target.value })
+            }
+            className="py-2 pr-9"
+          />
+          <EditIcon className="text-grey-500 pointer-events-none absolute top-1/2 right-3 size-4 -translate-y-1/2" />
+        </div>
       ),
     },
     {
@@ -285,7 +336,7 @@ export function ConfigureStep() {
     { key: 'stops', header: 'Stops', render: (row) => String(row.stops) },
     {
       key: 'route_date',
-      header: 'Route Date',
+      header: 'Date',
       render: (row) => (
         <DatePicker
           value={row.form.routeDate}
@@ -313,7 +364,7 @@ export function ConfigureStep() {
     },
     {
       key: 'route_count',
-      header: 'Route Count',
+      header: 'Routes',
       render: (row) => (
         <div className="relative w-20">
           <Input
@@ -339,7 +390,7 @@ export function ConfigureStep() {
     },
     {
       key: 'return_to_warehouse',
-      header: 'Return to Warehouse',
+      header: 'End at Warehouse',
       render: (row) => (
         <ReturnToggle
           checked={row.form.returnToWarehouse}
@@ -356,7 +407,7 @@ export function ConfigureStep() {
     <>
       <section className="flex flex-col gap-4">
         <div className="flex flex-col gap-1">
-          <h2 className="text-grey-500">Configure Routes</h2>
+          <h2 className="text-grey-500">Edit Route Groups</h2>
           <p className="text-p1 text-grey-500">
             Route groups were created from the imported data. Please review the
             details, make necessary changes, and select which routes to
@@ -402,15 +453,15 @@ export function ConfigureStep() {
       </GenerationFooter>
 
       <Modal open={leaveOpen} onOpenChange={setLeaveOpen}>
-        <ModalContent>
+        <ModalContent showCloseButton={false}>
           <ModalHeader>
-            <ModalTitle>Leave Without Saving</ModalTitle>
+            <ModalTitle>Leave without Saving</ModalTitle>
             <ModalDescription>
               If you go back now, all the data you entered will be lost. Would
               you still like to go back anyway?
             </ModalDescription>
           </ModalHeader>
-          <ModalFooter>
+          <ModalFooter className="justify-end">
             <Button variant="secondary" onClick={() => setLeaveOpen(false)}>
               Stay on this page
             </Button>
@@ -425,15 +476,15 @@ export function ConfigureStep() {
       </Modal>
 
       <Modal open={confirmOpen} onOpenChange={setConfirmOpen}>
-        <ModalContent>
+        <ModalContent showCloseButton={false}>
           <ModalHeader>
             <ModalTitle>Continue to Generation</ModalTitle>
             <ModalDescription>
-              You're about to generate delivery routes for the groups you have
+              You're about to generate delivery routes for routes you have
               selected. This action cannot be undone.
             </ModalDescription>
           </ModalHeader>
-          <ModalFooter>
+          <ModalFooter className="justify-end">
             <Button variant="secondary" onClick={() => setConfirmOpen(false)}>
               Cancel
             </Button>


### PR DESCRIPTION
## Summary
- replace mocked route-group rows with groups created by the completed import
- prefill route dates, start times, route counts, and return behavior from imported data and system settings
- let admins select groups and edit generation settings in the Figma-aligned table
- pass validated per-group generation inputs to the Generate step
- add Figma-aligned confirmation and leave-without-saving dialogs

## Validation
- `docker compose exec frontend pnpm run build`
- `docker compose exec frontend pnpm run lint`
- `git diff --check`

No Postman files were added or changed.