### PR TITLE
Block real email sends from the test suite

### DIFF
--- a/backend/python/tests/conftest.py
+++ b/backend/python/tests/conftest.py
@@ -5,7 +5,8 @@ Global test configuration and fixtures for the Food4Kids application.
 import asyncio
 import os
 from collections.abc import AsyncGenerator, Generator
-from typing import Any
+from typing import Any, NoReturn
+from unittest.mock import patch
 
 import pytest
 import pytest_asyncio
@@ -30,6 +31,29 @@ from app.models import get_session
 
 # Set test environment
 os.environ["APP_ENV"] = "testing"
+
+
+@pytest.fixture(autouse=True)
+def _block_real_email_sends() -> Generator[None, None, None]:
+    """Guard: no test may send through the real Gmail-backed EmailService.
+
+    Local and container runs load the root .env, whose MAILER_* credentials are
+    real — any endpoint a test drives into the real dispatcher (e.g. the auth
+    matrix hitting POST /announcements/{id}/email) would genuinely send Gmail
+    to the seeded @test.dev addresses and bounce. Tests that exercise email
+    flows must swap in their own fake transport (see _FakeEmailService in
+    test_email_reminder_jobs.py); anything reaching this method is a bug.
+    """
+    from app.services.implementations.email_service import EmailService
+
+    def _blocked(_self: EmailService, to: str, **_: str) -> NoReturn:
+        raise RuntimeError(
+            f"Blocked attempt to send a real email to {to!r} from a test - "
+            "override the email dispatcher with a fake transport"
+        )
+
+    with patch.object(EmailService, "send_email", _blocked):
+        yield
 
 
 async def _ensure_system_settings(test_session: AsyncSession) -> None:


### PR DESCRIPTION
## Why

Colin has been receiving email bounces for `self@test.dev` and `other@test.dev`. Root cause: `test_route_auth_matrix` seeds drivers with those addresses and hits `POST /announcements/{announcement_id}/email` as admin — an endpoint with only path params, so with no request body the handler runs to completion and emails every active driver through the real Gmail-backed `EmailService`. The `auth_client` fixture overrides the DB session and GCS client but not the email dispatcher, and any run with `MAILER_*` credentials in the environment (the root `.env` via docker-compose, or the throwaway test-container recipe) sends real mail — two bounces per full-suite run. CI was never the culprit: it only injects `GOOGLE_MAPS_API_KEY`, so sends there fail harmlessly.

## What

Autouse fixture in `tests/conftest.py` that patches `EmailService.send_email` to raise `RuntimeError`, so no test anywhere can reach the real Gmail transport — including any endpoint someone adds later. Tests that exercise email flows already swap in their own fake transport (`_FakeEmailService` in `test_email_reminder_jobs.py`) and are unaffected.

## Verification

Ran in a throwaway container pair with the real root `.env` loaded (the exact scenario that used to send mail):
- `tests/test_auth_integration.py` + `tests/test_email_reminder_jobs.py`: **81 passed**
- The announcement-email matrix case logs `Blocked attempt to send a real email to 'self@test.dev'` instead of `Sent … email` — guard confirmed intercepting
- `ruff check`, `ruff format --check`, `mypy` all clean on the changed file

🤖 Generated with [Claude Code](https://claude.com/claude-code)