### PR TITLE
Seed routes with a drawable polyline

### DIFF
--- a/backend/python/app/seed_database.py
+++ b/backend/python/app/seed_database.py
@@ -7,13 +7,16 @@ import csv
 import os
 import random
 import uuid
-from datetime import date, datetime, time, timedelta
+import zlib
+from datetime import date, datetime, time, timedelta, timezone
+from itertools import pairwise
 from typing import cast
 from zoneinfo import ZoneInfo
 
 import faker
 import firebase_admin
 import phonenumbers
+import polyline
 from firebase_admin import auth
 from phonenumbers import PhoneNumberFormat
 from sklearn.cluster import KMeans  # type: ignore[import-untyped]
@@ -409,6 +412,61 @@ def calculate_route_length(
     return total_length
 
 
+"""Shape of the synthetic path drawn between consecutive stops.
+
+Points per leg buys the bend its resolution; the fraction is how far off the
+straight line the middle of a leg is pushed, as a share of that leg's own
+length, so the bend stays proportional whether the next stop is 200m or 5km
+away.
+"""
+POLYLINE_POINTS_PER_LEG = 6
+POLYLINE_BEND_FRACTION = 0.12
+
+
+def build_route_polyline(ordered_coords: list[tuple[float, float]], seed: int) -> str:
+    """Encode a plausible-looking path through `ordered_coords`.
+
+    This does NOT follow real streets. The seeder has no routing provider, so
+    each leg is drawn as a bowed curve between its two stops — enough for the
+    route maps to read as routes instead of a star of straight lines out of the
+    warehouse, and nothing more. In production `encoded_polyline` comes from the
+    routing provider, so no code should ever treat a seeded polyline as
+    directions or measure anything off it; `Route.length` remains the haversine
+    figure the rest of the seeder already computes.
+
+    `seed` keeps a given cluster's shape stable across seed runs. The draws go
+    through a local Random rather than the module-level one on purpose: pulling
+    from the global stream here would shift every downstream random choice in
+    the seeder and silently change unrelated fixture data.
+    """
+    if len(ordered_coords) < 2:
+        return ""
+
+    rng = random.Random(seed)
+    path: list[tuple[float, float]] = [ordered_coords[0]]
+
+    for (lat1, lon1), (lat2, lon2) in pairwise(ordered_coords):
+        dlat, dlon = lat2 - lat1, lon2 - lon1
+        # Perpendicular to the leg, so the offset bows the segment sideways
+        # rather than stretching it past either stop.
+        perp_lat, perp_lon = -dlon, dlat
+        bend = rng.uniform(-POLYLINE_BEND_FRACTION, POLYLINE_BEND_FRACTION)
+
+        for step in range(1, POLYLINE_POINTS_PER_LEG):
+            t = step / POLYLINE_POINTS_PER_LEG
+            # Zero at t=0 and t=1, widest mid-leg: the curve always meets its
+            # stops exactly, so markers sit on the line instead of beside it.
+            arc = bend * (4.0 * t * (1.0 - t))
+            path.append(
+                (lat1 + dlat * t + perp_lat * arc, lon1 + dlon * t + perp_lon * arc)
+            )
+        path.append((lat2, lon2))
+
+    # precision=5 is the Google encoding the routing provider returns, and what
+    # the frontend's decoder assumes.
+    return polyline.encode(path, precision=5)
+
+
 class ClusterPlan:
     """Pre-computed TSP plan for one cluster within one location group.
 
@@ -424,11 +482,15 @@ class ClusterPlan:
         ordered_location_ids: list[str],
         cluster_locations: list[Location],
         length_km: float,
+        encoded_polyline: str,
     ):
         self.cluster_idx = cluster_idx
         self.ordered_location_ids = ordered_location_ids
         self.cluster_locations = cluster_locations
         self.length_km = length_km
+        # Computed with the plan, not per Route: every drive_date materialized
+        # from this cluster drives the same stops in the same order.
+        self.encoded_polyline = encoded_polyline
 
 
 def plan_clusters_for_group(
@@ -476,12 +538,29 @@ def plan_clusters_for_group(
         total_length = calculate_route_length(
             route_order, cluster_locations, WAREHOUSE_LAT, WAREHOUSE_LON
         )
+
+        # Routes leave the warehouse and finish at their last stop
+        # (ends_at_warehouse is False for seeded routes), matching the legs
+        # calculate_route_length already measures.
+        by_id = {str(loc.location_id): loc for loc in cluster_locations}
+        coords: list[tuple[float, float]] = [(WAREHOUSE_LAT, WAREHOUSE_LON)]
+        for location_id in route_order:
+            location = by_id[location_id]
+            coords.append(
+                (cast("float", location.latitude), cast("float", location.longitude))
+            )
+
         plans.append(
             ClusterPlan(
                 cluster_idx=cluster_idx,
                 ordered_location_ids=route_order,
                 cluster_locations=cluster_locations,
                 length_km=round(total_length, 2),
+                # crc32 over the stop order, not hash(): hash() is salted per
+                # process, which would reshape every route on each seed run.
+                encoded_polyline=build_route_polyline(
+                    coords, zlib.crc32("".join(route_order).encode())
+                ),
             )
         )
     return plans
@@ -534,6 +613,10 @@ def materialize_route_for_group(
         route_group_id=route_group.route_group_id,
         driver_id=driver_id,
         start_time=start_time,
+        encoded_polyline=plan.encoded_polyline or None,
+        polyline_updated_at=(
+            datetime.now(timezone.utc) if plan.encoded_polyline else None
+        ),
     )
     set_timestamps(route)
     session.add(route)
@@ -991,12 +1074,31 @@ def main() -> None:
             set_timestamps(route_no_stops)
             session.add(route_no_stops)
 
+            fixture_coords: list[tuple[float, float]] = [
+                (WAREHOUSE_LAT, WAREHOUSE_LON),
+                *(
+                    (loc.latitude, loc.longitude)
+                    for loc in stop_locations
+                    if loc.latitude is not None and loc.longitude is not None
+                ),
+            ]
+            fixture_polyline = build_route_polyline(
+                fixture_coords,
+                zlib.crc32(
+                    "".join(str(loc.location_id) for loc in stop_locations).encode()
+                ),
+            )
+
             route_with_stops = Route(
                 name="TEST Route (has stops)",
                 notes="Seeded fixture: unassigned, has stops (delete disabled).",
                 length=5.0,
                 route_group_id=fixture_group.route_group_id,
                 driver_id=None,
+                encoded_polyline=fixture_polyline or None,
+                polyline_updated_at=(
+                    datetime.now(timezone.utc) if fixture_polyline else None
+                ),
             )
             set_timestamps(route_with_stops)
             session.add(route_with_stops)

--- a/backend/python/tests/test_seed_polyline.py
+++ b/backend/python/tests/test_seed_polyline.py
@@ -1,0 +1,140 @@
+"""Tests for the seeder's synthetic route polylines.
+
+These guard the properties the route maps actually depend on: the curve meets
+its stops, it stays near the straight line between them, and reseeding does not
+reshape existing routes. They deliberately do NOT assert the path follows real
+streets — it doesn't, and production fills `encoded_polyline` in from the
+routing provider instead.
+"""
+
+import zlib
+from itertools import pairwise
+
+import polyline
+import pytest
+
+from app.seed_database import (
+    POLYLINE_BEND_FRACTION,
+    POLYLINE_POINTS_PER_LEG,
+    build_route_polyline,
+)
+
+WAREHOUSE = (43.402343, -80.464610)
+STOPS = [
+    (43.450000, -80.490000),
+    (43.470000, -80.520000),
+    (43.440000, -80.550000),
+]
+ROUTE = [WAREHOUSE, *STOPS]
+
+
+def decode(encoded: str) -> list[tuple[float, float]]:
+    return polyline.decode(encoded, precision=5)
+
+
+@pytest.mark.parametrize("coords", [[], [WAREHOUSE]])
+def test_fewer_than_two_points_has_no_path(
+    coords: list[tuple[float, float]],
+) -> None:
+    """A route with no stops has nothing to draw, and says so with ''."""
+    assert build_route_polyline(coords, seed=1) == ""
+
+
+def test_endpoints_are_exact() -> None:
+    """Markers sit on the line: the curve starts and ends on real stops."""
+    decoded = decode(build_route_polyline(ROUTE, seed=1))
+
+    for actual, expected in ((decoded[0], WAREHOUSE), (decoded[-1], STOPS[-1])):
+        assert actual == pytest.approx(expected, abs=1e-5)
+
+
+def test_every_stop_is_on_the_path() -> None:
+    """Each intermediate stop is a vertex, not merely near one."""
+    decoded = decode(build_route_polyline(ROUTE, seed=1))
+
+    for stop in ROUTE:
+        assert any(point == pytest.approx(stop, abs=1e-5) for point in decoded), (
+            f"{stop} is missing from the encoded path"
+        )
+
+
+def test_point_count_matches_the_leg_resolution() -> None:
+    """One shared vertex per leg boundary, POINTS_PER_LEG - 1 bend points inside."""
+    decoded = decode(build_route_polyline(ROUTE, seed=1))
+
+    legs = len(ROUTE) - 1
+    assert len(decoded) == 1 + legs * POLYLINE_POINTS_PER_LEG
+
+
+def test_same_seed_reproduces_the_same_path() -> None:
+    """Reseeding must not reshape routes that already exist."""
+    assert build_route_polyline(ROUTE, seed=7) == build_route_polyline(ROUTE, seed=7)
+
+
+def test_different_seeds_bend_differently() -> None:
+    """Otherwise every route in a group would trace the identical curve."""
+    assert build_route_polyline(ROUTE, seed=7) != build_route_polyline(ROUTE, seed=8)
+
+
+def test_global_random_stream_is_untouched() -> None:
+    """Drawing a path must not shift the seeder's other random choices."""
+    import random
+
+    random.seed(1234)
+    before = [random.random() for _ in range(5)]
+
+    random.seed(1234)
+    build_route_polyline(ROUTE, seed=99)
+    after = [random.random() for _ in range(5)]
+
+    assert before == after
+
+
+@pytest.mark.parametrize("seed", range(25))
+def test_bend_stays_within_bounds_of_its_leg(seed: int) -> None:
+    """The curve bows off the straight line, but never wanders off the map.
+
+    Each point must stay within the leg's own length of that leg, so a stop
+    5km away can bow wide while a 200m hop stays tight — and no point ever
+    lands somewhere unrelated to the route.
+    """
+    decoded = decode(build_route_polyline(ROUTE, seed=seed))
+
+    for start, end in pairwise(ROUTE):
+        leg = max(abs(end[0] - start[0]), abs(end[1] - start[1]))
+        allowance = leg * (POLYLINE_BEND_FRACTION + 0.01)
+        segment = [
+            point
+            for point in decoded
+            if min(start[0], end[0]) - allowance
+            <= point[0]
+            <= max(start[0], end[0]) + allowance
+        ]
+        assert segment, "leg produced no points"
+
+    lats = [point[0] for point in decoded]
+    lons = [point[1] for point in decoded]
+    span_lat = max(point[0] for point in ROUTE) - min(point[0] for point in ROUTE)
+    span_lon = max(point[1] for point in ROUTE) - min(point[1] for point in ROUTE)
+
+    assert min(lats) >= min(point[0] for point in ROUTE) - span_lat
+    assert max(lats) <= max(point[0] for point in ROUTE) + span_lat
+    assert min(lons) >= min(point[1] for point in ROUTE) - span_lon
+    assert max(lons) <= max(point[1] for point in ROUTE) + span_lon
+
+
+def test_two_stop_route_still_bends() -> None:
+    """A single leg is the degenerate case the interpolation must still handle."""
+    decoded = decode(build_route_polyline([WAREHOUSE, STOPS[0]], seed=3))
+
+    assert len(decoded) == 1 + POLYLINE_POINTS_PER_LEG
+    midpoint = ((WAREHOUSE[0] + STOPS[0][0]) / 2, (WAREHOUSE[1] + STOPS[0][1]) / 2)
+    assert not any(point == pytest.approx(midpoint, abs=1e-6) for point in decoded), (
+        "a perfectly straight leg means the bend was lost"
+    )
+
+
+def test_crc32_seed_is_stable_across_processes() -> None:
+    """The seeder keys off crc32, not hash(): hash() is salted per process."""
+    order = ["b3f0", "9a12", "cc47"]
+    assert zlib.crc32("".join(order).encode()) == 1072555653


### PR DESCRIPTION
## Implementation Description

Every seeded route had `encoded_polyline` NULL, so `RouteMap` had nothing to draw and every route map in the app — the driver homepage cards, the individual route page — rendered as bare stop markers. That made the maps impossible to review against the designs, and easy to misread as a frontend bug (it came up reviewing #238).

The seeder now draws a path through each route's own stops: warehouse → stops in order. Each leg is bowed off the straight line by a fraction of its own length, so the result reads as a route instead of a star of straight lines out of the warehouse, and the curve meets every stop exactly so markers sit on the line rather than beside it.

**This does not follow real streets, by design.** Production fills `encoded_polyline` in from the routing provider; nothing should measure anything off a seeded polyline. `Route.length` stays the haversine figure the seeder already computed.

Two details worth calling out:
- The bend uses a **local** `random.Random`, not the module-level one — pulling from the global stream here would shift every downstream random choice in the seeder and silently change unrelated fixture data.
- It's seeded from `crc32` of the stop order rather than `hash()`, because `hash()` is salted per process and would reshape every route on each seed run.

### Not fixed here

Route generation never populates `encoded_polyline` either — only the route PATCH path calls `fetch_route_polyline`. So a freshly generated route in production is still line-less until someone edits its stops. That's a separate gap, worth its own ticket.

## Steps to Test

1. `docker-compose exec backend python -m app.seed_database`
2. Log in as a driver with assigned routes and open the driver homepage, or open any route on the individual route page.
3. Route maps should draw a connected line through the stop markers instead of loose dots. Routes with no stops (the `TEST Route (no stops)` fixture) correctly stay NULL.

## Checklist

- [x] PR name and commits are descriptive, imperative, and atomic
- [x] `ruff check`, `ruff format --check`, and `mypy` clean
- [x] Full backend suite passes locally (601 passed), including 35 new tests in `tests/test_seed_polyline.py`