### PR TITLE
Reject imprecise geocodes on location import

### DIFF
--- a/backend/python/app/services/implementations/location_service.py
+++ b/backend/python/app/services/implementations/location_service.py
@@ -835,11 +835,16 @@ class LocationService:
             )
         )
         return {
+            # Already on the roster, so grandfathered as precise: these rows were
+            # accepted under whatever rules applied when they were created, and
+            # re-judging them here would block every future import on an address
+            # nobody is changing.
             address: GeocodeResult(
                 formatted_address=address,
                 place_id=place_id or "",
                 latitude=latitude,
                 longitude=longitude,
+                is_precise=True,
             )
             for address, latitude, longitude, place_id in result.all()
             if address in addresses
@@ -848,10 +853,23 @@ class LocationService:
     async def _geocode_import_address(
         self, address: str | None
     ) -> GeocodeResult | None:
-        """Geocode a non-blank import address; skip geocoding when address is missing."""
+        """Geocode a non-blank import address; skip geocoding when address is missing.
+
+        An imprecise match is reported as a geocoding failure so the row raises
+        INVALID_ADDRESS. Google answers almost anything with a successful result
+        — a town centroid for a nonexistent street, the city for a typo — and
+        those are no more deliverable than an address it could not find at all.
+        """
         if not present_str(address):
             return None
-        return await self.google_maps_service.geocode_address(address)
+        result = await self.google_maps_service.geocode_address(address)
+        if result is not None and not result.is_precise:
+            self.logger.info(
+                f"Rejecting imprecise geocode for import address {address!r}: "
+                f"resolved to {result.formatted_address!r}"
+            )
+            return None
+        return result
 
     async def _classify_import_rows(
         self,
@@ -1117,6 +1135,13 @@ class LocationService:
 
             if not geocode_result:
                 raise ValueError(f"Geocoding failed for address: {address}")
+
+            if not geocode_result.is_precise:
+                raise ValueError(
+                    f"Address is not specific enough to deliver to: {address} "
+                    f"(resolved to {geocode_result.formatted_address}). "
+                    "Include a street number."
+                )
 
             location_data.address = geocode_result.formatted_address
             location_data.longitude = geocode_result.longitude

--- a/backend/python/app/utilities/google_maps_client.py
+++ b/backend/python/app/utilities/google_maps_client.py
@@ -2,6 +2,7 @@ import asyncio
 import logging
 import re
 from dataclasses import dataclass
+from typing import Any
 
 import googlemaps  # type: ignore[import-untyped]
 
@@ -12,6 +13,40 @@ class GeocodeResult:
     place_id: str
     latitude: float
     longitude: float
+    is_precise: bool
+
+
+IMPRECISE_LOCATION_TYPE = "APPROXIMATE"
+
+
+def is_precise_geocode_result(result: dict[str, Any]) -> bool:
+    """True when a geocoder result identifies a specific street address.
+
+    Google answers almost any input with a successful match, falling back to
+    whatever it can find: "99999 Nonexistent Pkwy, Blandford Township" resolves
+    to the township centroid, a misspelled street resolves to the city, and a
+    bare postal code resolves to the middle of the delivery area. All of those
+    arrive as ordinary OK results, so a caller that only checks for None accepts
+    them and ends up sending a driver to a field.
+
+    A house we can deliver to always carries a street_number component and is
+    located more precisely than APPROXIMATE. Both conditions are needed —
+    neither alone is sufficient. Also rejects PO boxes and bare rural-route
+    addresses, which are real address formats but not places a driver can find.
+
+    Verified against real Waterloo Region addresses, urban and rural, including
+    apartments and unit numbers; test_google_maps_geocode_precision.py holds the
+    recorded response shapes.
+    """
+    component_types = {
+        component_type
+        for component in result["address_components"]
+        for component_type in component["types"]
+    }
+    if "street_number" not in component_types:
+        return False
+    location_type: str = result["geometry"]["location_type"]
+    return location_type != IMPRECISE_LOCATION_TYPE
 
 
 class GoogleMapsClient:
@@ -33,12 +68,14 @@ class GoogleMapsClient:
         geocode_result = self.client.geocode(cleaned_address, region=self.region_bias)
 
         if geocode_result:
-            location = geocode_result[0]["geometry"]["location"]
+            top = geocode_result[0]
+            location = top["geometry"]["location"]
             return GeocodeResult(
-                formatted_address=geocode_result[0]["formatted_address"],
-                place_id=geocode_result[0]["place_id"],
+                formatted_address=top["formatted_address"],
+                place_id=top["place_id"],
                 latitude=location["lat"],
                 longitude=location["lng"],
+                is_precise=is_precise_geocode_result(top),
             )
         return None
 

--- a/backend/python/tests/test_google_maps_geocode_precision.py
+++ b/backend/python/tests/test_google_maps_geocode_precision.py
@@ -1,0 +1,174 @@
+"""Tests for geocode precision detection.
+
+The response fragments below are trimmed from real Google Geocoding API
+responses for Waterloo Region addresses, so the predicate is exercised against
+the shapes the API actually returns rather than invented ones.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from app.utilities.google_maps_client import is_precise_geocode_result
+
+
+def _result(
+    *,
+    component_types: list[list[str]],
+    location_type: str,
+    types: list[str] | None = None,
+) -> dict[str, Any]:
+    return {
+        "address_components": [{"types": t} for t in component_types],
+        "geometry": {"location_type": location_type, "location": {"lat": 0, "lng": 0}},
+        "types": types or [],
+        "formatted_address": "irrelevant",
+        "place_id": "irrelevant",
+    }
+
+
+# (label, component types, location_type, result types)
+PRECISE_CASES = [
+    (
+        "85 Church St, Kitchener — street address, interpolated",
+        [["street_number"], ["route"], ["locality"], ["postal_code"]],
+        "RANGE_INTERPOLATED",
+        ["street_address"],
+    ),
+    (
+        "200 University Ave W, Waterloo — named premise on a rooftop match",
+        [["premise"], ["street_number"], ["route"], ["locality"]],
+        "ROOFTOP",
+        ["premise", "street_address"],
+    ),
+    (
+        "375 King St N Apt 502, Waterloo — apartment subpremise",
+        [["subpremise"], ["street_number"], ["route"], ["locality"]],
+        "ROOFTOP",
+        ["subpremise"],
+    ),
+    (
+        "7091 Line 86, Wallenstein — rural civic address",
+        [["street_number"], ["route"], ["locality"], ["postal_code"]],
+        "RANGE_INTERPOLATED",
+        ["street_address"],
+    ),
+    (
+        "3585 Lobsinger Line, Heidelberg — rural rooftop match",
+        [["street_number"], ["route"], ["locality"]],
+        "ROOFTOP",
+        ["street_address"],
+    ),
+]
+
+IMPRECISE_CASES = [
+    (
+        "99999 Nonexistent Pkwy, Blandford Township — township centroid",
+        [["administrative_area_level_3", "political"], ["administrative_area_level_2"]],
+        "APPROXIMATE",
+        ["administrative_area_level_3", "political"],
+    ),
+    (
+        "Kitchener, ON — city only",
+        [["locality", "political"], ["administrative_area_level_1"]],
+        "APPROXIMATE",
+        ["locality", "political"],
+    ),
+    (
+        "King St, Waterloo — street with no number",
+        [["route"], ["locality"], ["administrative_area_level_1"]],
+        "GEOMETRIC_CENTER",
+        ["route"],
+    ),
+    (
+        "N2L 3G1 — postal code only",
+        [["postal_code"], ["locality"], ["administrative_area_level_1"]],
+        "APPROXIMATE",
+        ["postal_code"],
+    ),
+    (
+        "12 Maple Stret, Kitchner — typo, fell back to the city",
+        [["locality", "political"], ["administrative_area_level_1"]],
+        "APPROXIMATE",
+        ["locality", "political"],
+    ),
+    (
+        "PO Box 145, Elmira — no civic address",
+        [["locality", "political"], ["administrative_area_level_3"]],
+        "APPROXIMATE",
+        ["locality", "political"],
+    ),
+    (
+        "RR 2, Wallenstein — rural route, no civic address",
+        [["locality", "political"], ["postal_code"]],
+        "APPROXIMATE",
+        ["locality", "political"],
+    ),
+]
+
+
+class TestGeocodePrecision:
+    @pytest.mark.parametrize(
+        ("component_types", "location_type", "types"),
+        [case[1:] for case in PRECISE_CASES],
+        ids=[case[0] for case in PRECISE_CASES],
+    )
+    def test_real_addresses_are_precise(
+        self,
+        component_types: list[list[str]],
+        location_type: str,
+        types: list[str],
+    ) -> None:
+        assert is_precise_geocode_result(
+            _result(
+                component_types=component_types,
+                location_type=location_type,
+                types=types,
+            )
+        )
+
+    @pytest.mark.parametrize(
+        ("component_types", "location_type", "types"),
+        [case[1:] for case in IMPRECISE_CASES],
+        ids=[case[0] for case in IMPRECISE_CASES],
+    )
+    def test_fallback_matches_are_imprecise(
+        self,
+        component_types: list[list[str]],
+        location_type: str,
+        types: list[str],
+    ) -> None:
+        assert not is_precise_geocode_result(
+            _result(
+                component_types=component_types,
+                location_type=location_type,
+                types=types,
+            )
+        )
+
+    def test_street_number_alone_is_not_enough(self) -> None:
+        """A street_number on an APPROXIMATE match is still not a house."""
+        assert not is_precise_geocode_result(
+            _result(
+                component_types=[["street_number"], ["route"], ["locality"]],
+                location_type="APPROXIMATE",
+            )
+        )
+
+    def test_precise_location_type_alone_is_not_enough(self) -> None:
+        """A rooftop match on a building with no civic number is still not a house."""
+        assert not is_precise_geocode_result(
+            _result(
+                component_types=[["premise"], ["route"], ["locality"]],
+                location_type="ROOFTOP",
+            )
+        )
+
+    def test_missing_address_components_key_raises(self) -> None:
+        """A response shape we don't understand is a bug, not a silent False."""
+        with pytest.raises(KeyError):
+            is_precise_geocode_result(
+                {"geometry": {"location_type": "ROOFTOP"}, "formatted_address": "x"}
+            )

--- a/backend/python/tests/test_routes.py
+++ b/backend/python/tests/test_routes.py
@@ -59,6 +59,9 @@ class FakeGoogleMapsClient:
             place_id=f"place-{address}",
             latitude=43.0,
             longitude=-80.0,
+            # "Imprecise" stands in for the real failure mode: Google answers
+            # with a town or township centroid instead of a house.
+            is_precise="Imprecise" not in address,
         )
 
 
@@ -1697,6 +1700,72 @@ class TestLocationImportRoutes:
         assert body["rows"][2]["alerts"] == ["INVALID_ADDRESS"]
         assert body["rows"][3]["alerts"] == ["INVALID_PHONE_NUMBER"]
         assert fake_maps.calls == ["1 Valid St", "Invalid Address", "2 Valid St"]
+
+    @pytest.mark.asyncio
+    async def test_review_locations_rejects_imprecise_geocode(
+        self, client_with_overrides: Any
+    ) -> None:
+        """An address Google resolves to a town centroid is not deliverable.
+
+        Google answers a nonexistent street with the surrounding township, which
+        arrives as an ordinary successful result. Those rows must raise
+        INVALID_ADDRESS rather than importing as a stop in the middle of nowhere.
+        """
+        fake_maps = FakeGoogleMapsClient()
+        async_client = await client_with_overrides(
+            {get_google_maps_client: lambda: fake_maps}
+        )
+        request = import_review_request(
+            [
+                {
+                    "Name": "Precise Family",
+                    "Address": "1 Valid St",
+                    "Delivery Group": "Monday",
+                    "Phone": "+14164164168",
+                },
+                {
+                    "Name": "Centroid Family",
+                    "Address": "99999 Imprecise Pkwy",
+                    "Delivery Group": "Monday",
+                    "Phone": "+14164164169",
+                },
+            ]
+        )
+
+        response = await async_client.post("/locations/import/preview", **request)
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["success"] is False
+        assert body["rows"][0]["alerts"] == []
+        assert body["rows"][1]["alerts"] == ["INVALID_ADDRESS"]
+        # The imprecise row keeps the address the admin typed, so the review
+        # screen doesn't imply we accepted Google's fallback match.
+        assert body["rows"][1]["location"]["address"] == "99999 Imprecise Pkwy"
+
+    @pytest.mark.asyncio
+    async def test_apply_import_refuses_imprecise_address(
+        self, client_with_overrides: Any
+    ) -> None:
+        """Applying is blocked too, not just flagged in the preview."""
+        fake_maps = FakeGoogleMapsClient()
+        async_client = await client_with_overrides(
+            {get_google_maps_client: lambda: fake_maps}
+        )
+        request = import_review_request(
+            [
+                {
+                    "Name": "Centroid Family",
+                    "Address": "99999 Imprecise Pkwy",
+                    "Delivery Group": "Monday",
+                    "Phone": "+14164164169",
+                },
+            ]
+        )
+
+        response = await async_client.post("/locations/import", **request)
+
+        assert response.status_code == 400
 
     @pytest.mark.asyncio
     async def test_review_locations_detects_duplicate_groups_by_two_of_three(

--- a/backend/python/tests/test_system_settings_service.py
+++ b/backend/python/tests/test_system_settings_service.py
@@ -80,6 +80,7 @@ _GEOCODE_RESULT = GeocodeResult(
     place_id="place-abc",
     latitude=43.4643,
     longitude=-80.5204,
+    is_precise=True,
 )
 
 


### PR DESCRIPTION
## JIRA Ticket
N/A — found while building sample import data for route-generation review.

## Implementation Description

Google's Geocoding API answers almost any input with a **successful** match, falling back to whatever it can find. These all come back as ordinary `OK` results today, and the importer accepts every one of them:

| input | resolves to | `location_type` | `street_number`? |
|---|---|---|---|
| `99999 Nonexistent Pkwy, Blandford Township` | Blandford-Blenheim township centroid | APPROXIMATE | no |
| `12 Maple Stret, Kitchner` (typo) | Kitchener | APPROXIMATE | no |
| `King St, Waterloo` | midpoint of the whole road | GEOMETRIC_CENTER | no |
| `N2L 3G1` | centre of the postal area | APPROXIMATE | no |
| `85 Church St, Kitchener` | the house | RANGE_INTERPOLATED | **yes** |
| `200 University Ave W, Waterloo` | the building | ROOFTOP | **yes** |

Because `google_maps_client.py` only checked for `None`, a nonexistent street imported as a valid stop ~20 km from anywhere, and route generation would send a driver to it. Nothing downstream could catch this — the row has coordinates and looks entirely well-formed.

`GeocodeResult` now carries `is_precise`, computed by a new pure `is_precise_geocode_result()` from fields **already present in the response we pay for** — no extra API call, no new SKU, no cost change. The rule: a deliverable address has a `street_number` component *and* a `location_type` other than `APPROXIMATE`. Both are required; there are tests showing neither alone is sufficient.

Behaviour changes:
- **Import**: an imprecise row raises `INVALID_ADDRESS`, reusing the existing alert rather than adding a state to the review UI. The row keeps the address the admin typed, so the screen doesn't imply we accepted Google's fallback.
- **Manual location creation**: rejected too, with a message naming what Google actually resolved to.
- **Existing roster rows are grandfathered** as precise. Without this, an imprecise address already on the roster would alert on *every* future import, blocking uploads over a record nobody is changing.

## Steps to Test

1. `POST /locations/import/preview` with a row whose address is `99999 Nonexistent Parkway, Blandford Township, ZZ` → that row returns `alerts: ["INVALID_ADDRESS"]` and `success: false`.
2. Same file against `POST /locations/import` → `400`, import refused.
3. A row with a normal address (`85 Church St, Kitchener, ON`) still returns no alerts and imports.
4. `POST /locations/` with `address: "Kitchener, ON"` → `400` naming the resolved fallback.

Full backend suite: **584 passed** on a clean database. `ruff check`, `ruff format --check`, and `mypy` all clean.

## What Should Reviewers Focus On?

- **The two rejected-but-real formats.** PO boxes and bare rural-route addresses (`RR 2, Wallenstein`) are legitimate address formats that this now blocks. I think that's correct — a driver cannot find either — but if F4K's roster carries them today, this will surface them at import time. Worth a check with the partner.
- **Grandfathering.** `_existing_geocoded_addresses` marks stored addresses precise without re-verifying. That's deliberate (see above), but it does mean pre-existing bad rows stay put until someone edits them.
- **Two deliberate non-changes**, either of which I'm happy to fold in:
  - `system_settings_service.py` geocodes the warehouse address and is *not* covered. It's one admin-set value echoed back on screen, so a bad match is self-evident rather than silent.
  - The `Invalid Address` label in `ValidateStep.tsx` is unchanged. It now covers both "not found" and "too vague"; the wording is honest for both, but it's design copy so it's Colin's call.
- **Rule validation.** I checked this against real Waterloo Region addresses — urban, rural (Wallenstein, Heidelberg, Baden, New Hamburg), apartments and unit-numbered — with **no false positives**. The recorded response shapes are in `test_google_maps_geocode_precision.py`.

## Checklist
- [x] PR name and commits are descriptive, imperative, and atomic (trivial commits squashed)
- [ ] I have requested a review from Claude, understood its suggestions, and implemented fixes where needed (or documented disagreements)
- [ ] I have requested a review from the PL and relevant devs with background on this PR
