### PR TITLE
Log request validation errors instead of failing silently

### DIFF
--- a/backend/python/app/__init__.py
+++ b/backend/python/app/__init__.py
@@ -4,6 +4,7 @@ from logging.config import dictConfig
 
 import firebase_admin
 from fastapi import FastAPI
+from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.routing import APIRoute
 
@@ -15,7 +16,7 @@ from app.dependencies.services import (
 from app.services.jobs import init_jobs
 
 from .config import settings
-from .middleware import UnhandledExceptionMiddleware
+from .middleware import UnhandledExceptionMiddleware, log_request_validation_error
 from .models import init_app as init_models
 from .routers import init_app as init_routers
 
@@ -216,6 +217,10 @@ def create_app() -> FastAPI:
         allow_methods=["*"],
         allow_headers=["*"],
     )
+
+    # A 422 is raised during parameter resolution, so it never reaches a handler
+    # and would otherwise be logged nowhere at all.
+    app.add_exception_handler(RequestValidationError, log_request_validation_error)
 
     # Initialize routers
     init_routers(app)

--- a/backend/python/app/middleware.py
+++ b/backend/python/app/middleware.py
@@ -1,9 +1,19 @@
-"""ASGI middleware wired into the app in :func:`app.create_app`."""
+"""How a failed request becomes a response, wired up in :func:`app.create_app`.
+
+Two paths, at opposite ends of the request: :class:`UnhandledExceptionMiddleware`
+catches what a route handler raised, and :func:`log_request_validation_error`
+catches what never reached one.
+"""
 
 import logging
+from collections.abc import Sequence
+from typing import Any
 
-from fastapi import status
+from fastapi import Request, status
+from fastapi.exception_handlers import request_validation_exception_handler
+from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
+from starlette.responses import Response
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 logger = logging.getLogger(__name__)
@@ -64,3 +74,43 @@ class UnhandledExceptionMiddleware:
                 content={"detail": "Internal server error"},
             )
             await response(scope, receive, send)
+
+
+def _describe(errors: Sequence[Any]) -> str:
+    """Render where each error is and what it is — never the value that caused it."""
+    return "; ".join(
+        f"{'.'.join(str(part) for part in error['loc']) or '<request>'}: {error['msg']}"
+        for error in errors
+    )
+
+
+async def log_request_validation_error(request: Request, exc: Exception) -> Response:
+    """Log a 422 on its way out, then let FastAPI answer it as it always has.
+
+    FastAPI rejects a malformed request while resolving the route's parameters,
+    which is *before* any handler body runs. Nothing downstream of that point
+    ever executes, so a 422 leaves no trace: the caller is told which fields are
+    missing, and the server log shows the request never happened. Debugging one
+    means reproducing it with a network tab open, because the logs cannot help.
+
+    That combination cost a long session on #242, where the frontend was posting
+    JSON to a multipart endpoint. The server knew exactly what was wrong with the
+    request and said so only to the caller.
+
+    Only the *shape* of each error is logged — its location and message. The
+    ``input`` key that pydantic also returns echoes the submitted value back, and
+    these endpoints carry household addresses, phone numbers and children's
+    names; that belongs in a 422 body going to an authenticated admin, not in
+    container logs. The response itself is delegated rather than rebuilt, so the
+    contract the frontend and OpenAPI schema depend on cannot drift from here.
+    """
+    if not isinstance(exc, RequestValidationError):  # pragma: no cover - defensive
+        raise exc
+
+    logger.warning(
+        "Request validation failed on %s %s — %s",
+        request.method,
+        request.url.path,
+        _describe(exc.errors()),
+    )
+    return await request_validation_exception_handler(request, exc)

--- a/backend/python/tests/test_request_validation_logging.py
+++ b/backend/python/tests/test_request_validation_logging.py
@@ -1,0 +1,183 @@
+"""Contract for the app-wide 422 handler.
+
+A validation failure is resolved before any route handler runs, so until
+:func:`~app.middleware.log_request_validation_error` was wired in it produced no
+log line at all — the caller was told which fields were wrong and the server
+side stayed silent (see #242).
+
+These tests pin the two halves of that fix: the failure has to reach the log
+with enough detail to act on, and it must not drag the submitted values along
+with it.
+"""
+
+import logging
+
+import pytest
+from fastapi import APIRouter, status
+from httpx import ASGITransport, AsyncClient
+from pydantic import BaseModel
+
+from app import create_app
+
+LOGGER_NAME = "app.middleware"
+
+ALLOWED_ORIGIN = "http://localhost:3000"
+
+# Stands in for the household data these endpoints really carry: if a value like
+# this can reach the log, so can a real family's address.
+SENSITIVE_VALUE = "417 Erb St W, Waterloo — guardian Priya Raman, 3 children"
+
+probe_router = APIRouter(prefix="/_probe")
+
+
+class Household(BaseModel):
+    address: str
+    num_children: int
+
+
+@probe_router.post("/household")
+async def probe_household(household: Household) -> dict[str, int]:
+    return {"num_children": household.num_children}
+
+
+@pytest.fixture
+def probe_client() -> AsyncClient:
+    """A client for the real app, with a route that validates a body.
+
+    Built from ``create_app`` so the handler under test is the one the app
+    actually registers, rather than a hand-wired copy.
+    """
+    app = create_app()
+    app.include_router(probe_router)
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+class TestValidationFailureIsLogged:
+    @pytest.mark.asyncio
+    async def test_missing_fields_are_named_in_the_log(
+        self, probe_client: AsyncClient, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The log has to say *which* fields, or it cannot end the debugging."""
+        with caplog.at_level(logging.WARNING, logger=LOGGER_NAME):
+            async with probe_client as client:
+                await client.post("/_probe/household", json={})
+
+        (record,) = [r for r in caplog.records if r.name == LOGGER_NAME]
+        message = record.getMessage()
+        assert "POST" in message
+        assert "/_probe/household" in message
+        assert "body.address" in message
+        assert "body.num_children" in message
+
+    @pytest.mark.asyncio
+    async def test_wrong_type_is_logged(
+        self, probe_client: AsyncClient, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        with caplog.at_level(logging.WARNING, logger=LOGGER_NAME):
+            async with probe_client as client:
+                await client.post(
+                    "/_probe/household",
+                    json={"address": "1 King St", "num_children": "lots"},
+                )
+
+        (record,) = [r for r in caplog.records if r.name == LOGGER_NAME]
+        assert "body.num_children" in record.getMessage()
+
+    @pytest.mark.asyncio
+    async def test_logged_at_warning_not_error(
+        self, probe_client: AsyncClient, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A malformed request is the caller's bug, not an outage."""
+        with caplog.at_level(logging.WARNING, logger=LOGGER_NAME):
+            async with probe_client as client:
+                await client.post("/_probe/household", json={})
+
+        (record,) = [r for r in caplog.records if r.name == LOGGER_NAME]
+        assert record.levelno == logging.WARNING
+
+    @pytest.mark.asyncio
+    async def test_a_valid_request_logs_nothing(
+        self, probe_client: AsyncClient, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        with caplog.at_level(logging.WARNING, logger=LOGGER_NAME):
+            async with probe_client as client:
+                response = await client.post(
+                    "/_probe/household",
+                    json={"address": "1 King St", "num_children": 2},
+                )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert [r for r in caplog.records if r.name == LOGGER_NAME] == []
+
+
+class TestSubmittedValuesStayOutOfTheLog:
+    """pydantic returns the offending value under ``input``; it must not be logged.
+
+    These endpoints carry household addresses, phone numbers and children's
+    names. A 422 body goes to an authenticated admin over TLS, but container
+    logs are a different audience with a different retention story.
+    """
+
+    @pytest.mark.asyncio
+    async def test_offending_value_is_not_logged(
+        self, probe_client: AsyncClient, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        with caplog.at_level(logging.WARNING, logger=LOGGER_NAME):
+            async with probe_client as client:
+                await client.post(
+                    "/_probe/household",
+                    json={"address": SENSITIVE_VALUE, "num_children": "lots"},
+                )
+
+        assert SENSITIVE_VALUE not in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_valid_sibling_fields_are_not_logged(
+        self, probe_client: AsyncClient, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The value that *passed* validation is just as sensitive as the one
+        that failed, and has even less reason to be echoed."""
+        with caplog.at_level(logging.WARNING, logger=LOGGER_NAME):
+            async with probe_client as client:
+                await client.post(
+                    "/_probe/household", json={"address": SENSITIVE_VALUE}
+                )
+
+        assert SENSITIVE_VALUE not in caplog.text
+
+
+class TestResponseIsUnchanged:
+    """Logging is additive: the 422 body is FastAPI's, and stays FastAPI's.
+
+    The generated TypeScript client and the OpenAPI schema both describe this
+    shape, so rebuilding the response here would let it drift.
+    """
+
+    @pytest.mark.asyncio
+    async def test_status_and_body_shape_are_fastapis(
+        self, probe_client: AsyncClient
+    ) -> None:
+        async with probe_client as client:
+            response = await client.post("/_probe/household", json={})
+
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+        detail = response.json()["detail"]
+        assert isinstance(detail, list)
+        assert {tuple(error["loc"]) for error in detail} == {
+            ("body", "address"),
+            ("body", "num_children"),
+        }
+        assert all(error["type"] == "missing" for error in detail)
+
+    @pytest.mark.asyncio
+    async def test_422_carries_cors_headers(self, probe_client: AsyncClient) -> None:
+        """Registered inside CORS, like the 500 path — a browser cannot read an
+        error response that arrives without the header."""
+        async with probe_client as client:
+            response = await client.post(
+                "/_probe/household", json={}, headers={"Origin": ALLOWED_ORIGIN}
+            )
+
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+        assert response.headers["access-control-allow-origin"] == ALLOWED_ORIGIN

--- a/backend/python/tests/test_request_validation_logging.py
+++ b/backend/python/tests/test_request_validation_logging.py
@@ -160,7 +160,7 @@ class TestResponseIsUnchanged:
         async with probe_client as client:
             response = await client.post("/_probe/household", json={})
 
-        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
         detail = response.json()["detail"]
         assert isinstance(detail, list)
@@ -179,5 +179,5 @@ class TestResponseIsUnchanged:
                 "/_probe/household", json={}, headers={"Origin": ALLOWED_ORIGIN}
             )
 
-        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
         assert response.headers["access-control-allow-origin"] == ALLOWED_ORIGIN


### PR DESCRIPTION
## Why

A 422 is raised while FastAPI resolves a route's parameters, **before any handler body runs**. Nothing downstream of that point executes, so the failure left no trace at all — the caller was told which fields were wrong, and the server log showed the request as if it had never arrived.

That cost a long debugging session on #242, where the frontend was posting JSON to a multipart endpoint. The server knew exactly what was wrong with the request and said so only to the caller. Reaching for `docker logs` first — the obvious move — turned up nothing, so the only way forward was reproducing the request with a network tab open.

## What

`log_request_validation_error` is registered app-wide in `create_app`. It logs the **location and message** of each error at WARNING (a malformed request is the caller's bug, not an outage), then delegates to FastAPI's own `request_validation_exception_handler` — so the 422 body that the generated TypeScript client and the OpenAPI schema both describe cannot drift from here.

```
WARNING - Request validation failed on POST /locations/import — body.file: Input should be a valid upload; body.column_map: Field required
```

It sits alongside `UnhandledExceptionMiddleware` in `middleware.py`: two paths at opposite ends of a request — one catches what a handler raised, the other catches what never reached one.

### It does not log the submitted values

pydantic also returns an `input` key echoing the value that failed. These endpoints carry household addresses, phone numbers and children's names. That belongs in a 422 going to an authenticated admin over TLS, not in container logs — a different audience with a different retention story. Two tests pin this, including one for a field that *passed* validation (just as sensitive, and with even less reason to be echoed).

## Tests

`tests/test_request_validation_logging.py`, 8 tests in three groups, all built from the real `create_app` so the handler under test is the one the app actually registers:

- **the failure reaches the log** — fields named, wrong types named, WARNING not ERROR, and a valid request logs nothing
- **submitted values stay out** — neither the offending value nor a valid sibling field appears in `caplog.text`
- **the response is unchanged** — status and body shape are still FastAPI's, and the 422 carries CORS headers (a browser cannot read an error response that arrives without them)

Validated by reintroducing the bug: with the handler unregistered, exactly the 3 logging tests fail and the other 5 pass.

Gates run locally in a throwaway backend container: `ruff check`, `ruff format --check`, `mypy` (128 files clean), and the full `pytest` suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)