### PR TITLE
Stop re-seeding from signing everyone out

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,16 @@ docker-compose exec db psql -U postgres -d f4k
 
 # Seed with test data
 docker-compose exec backend python -m app.seed_database
+
+# ...and restore every seed account's password, if one has drifted.
+# Signs out everyone currently logged in, so it is opt-in.
+docker-compose exec backend python -m app.seed_database --reset-passwords
 ```
+
+Seeding leaves existing Firebase accounts' passwords alone. Writing a password
+moves the account's `tokensValidAfterTime`, which revokes every token already
+issued — so an unconditional rewrite signed out every open session, local and
+otherwise, on each run.
 
 ## API Testing
 

--- a/backend/python/app/seed_database.py
+++ b/backend/python/app/seed_database.py
@@ -3,6 +3,7 @@
 Comprehensive database seeding script with advanced features.
 """
 
+import argparse
 import csv
 import os
 import random
@@ -255,19 +256,38 @@ def ensure_firebase_user(
     role: str,
     first_name: str,
     last_name: str,
+    *,
+    reset_password: bool = False,
 ) -> str:
-    """Create or update a Firebase user so it is always loginable with the given credentials."""
+    """Create or update a Firebase user so it is always loginable.
+
+    An existing user's password is deliberately left alone. Firebase treats a
+    password write as a credential change: it moves the account's
+    ``tokensValidAfterTime`` to now, which revokes every ID and refresh token
+    already issued. Because ``verify_id_token`` is called with
+    ``check_revoked=True``, everyone holding one is signed out on their very
+    next request.
+
+    Rewriting the password unconditionally therefore made re-seeding sign out
+    every open session — including CI's, which seeds the same Firebase project
+    that local development uses, so an unrelated merge would log a developer
+    out mid-task. The password does not need writing anyway: it is a constant,
+    so on the second run it is already the value being written.
+
+    Measured against the real project, only the password does this — writing
+    ``display_name`` or custom claims leaves ``tokensValidAfterTime`` untouched.
+    The other fields are still written when they differ, which is why this
+    reconciles rather than blindly updating.
+
+    :param reset_password: Write the password even when the account exists, for
+        the case where it really has drifted. Signs everyone out; that is the
+        point, so it has to be asked for.
+    """
     full_name = f"{first_name} {last_name}"
+    claims = {"role": role, "given_name": first_name, "family_name": last_name}
+
     try:
-        auth.get_user(uid)
-        auth.update_user(
-            uid,
-            email=email,
-            password=password,
-            email_verified=True,
-            display_name=full_name,
-        )
-        print(f"  Firebase user {uid} ({email}) already exists, updated")
+        existing = auth.get_user(uid)
     except auth.UserNotFoundError:
         auth.create_user(
             uid=uid,
@@ -276,11 +296,27 @@ def ensure_firebase_user(
             email_verified=True,
             display_name=full_name,
         )
+        auth.set_custom_user_claims(uid, claims)
         print(f"  Firebase user {uid} ({email}) created")
-    auth.set_custom_user_claims(
-        uid,
-        {"role": role, "given_name": first_name, "family_name": last_name},
-    )
+        return uid
+
+    changes: dict[str, object] = {}
+    if existing.email != email:
+        changes["email"] = email
+    if existing.display_name != full_name:
+        changes["display_name"] = full_name
+    if not existing.email_verified:
+        changes["email_verified"] = True
+    if reset_password:
+        changes["password"] = password
+
+    if changes:
+        auth.update_user(uid, **changes)
+    if (existing.custom_claims or {}) != claims:
+        auth.set_custom_user_claims(uid, claims)
+
+    updated = ", ".join(sorted(changes)) if changes else "nothing to change"
+    print(f"  Firebase user {uid} ({email}) already exists, {updated}")
     return uid
 
 
@@ -583,8 +619,14 @@ def materialize_route_for_group(
     return route
 
 
-def main() -> None:
-    """Main seeding function"""
+def main(*, reset_passwords: bool = False) -> None:
+    """Main seeding function
+
+    :param reset_passwords: Rewrite every seeded account's password to
+        ``SEED_PASSWORD``, signing out everyone currently holding a token. Off
+        by default so a routine re-seed leaves open sessions alone; see
+        ``ensure_firebase_user``.
+    """
     print("Starting final database seeding...")
 
     if not firebase_admin._apps:  # type: ignore[attr-defined]
@@ -646,6 +688,7 @@ def main() -> None:
                     role="admin",
                     first_name=first_name,
                     last_name=last_name,
+                    reset_password=reset_passwords,
                 )
 
                 user = User(
@@ -808,6 +851,7 @@ def main() -> None:
                     role="driver",
                     first_name=first_name,
                     last_name=last_name,
+                    reset_password=reset_passwords,
                 )
 
                 user = User(
@@ -1299,4 +1343,14 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    main()
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--reset-passwords",
+        action="store_true",
+        help=(
+            f"Rewrite every seeded account's password to '{SEED_PASSWORD}'. "
+            "Signs out everyone currently logged in, so it is off by default — "
+            "use it only when a password has actually drifted."
+        ),
+    )
+    main(reset_passwords=parser.parse_args().reset_passwords)

--- a/backend/python/tests/test_seed_firebase_user.py
+++ b/backend/python/tests/test_seed_firebase_user.py
@@ -1,0 +1,262 @@
+"""Contract for the seed script's Firebase account reconciliation.
+
+``ensure_firebase_user`` used to rewrite every existing account's password on
+every run. Firebase treats a password write as a credential change and moves
+``tokensValidAfterTime`` to now, revoking every token already issued; because
+the app verifies with ``check_revoked=True``, that signs out everyone holding
+one. Re-seeding therefore logged out every open session, and CI's boot smoke
+seeds the *same* Firebase project local development uses, so an unrelated merge
+would sign a developer out mid-task.
+
+Measured against the real project, the password is the only write that does
+this — ``display_name`` and custom claims leave the timestamp alone. So these
+tests pin one rule above all: **an existing account's password is not written
+unless it is explicitly asked for.**
+
+``test_seed_database.py`` patches this function out wholesale to keep the seed
+tests offline, which is why it needs its own file. Firebase is a mock here for
+the same reason — the assertions are about which calls are made, not about
+Firebase's behaviour.
+"""
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.seed_database import ensure_firebase_user
+
+UID = "seed-admin-1"
+EMAIL = "admin1@f4k.dev"
+PASSWORD = "test123"
+FIRST, LAST = "Priya", "Raman"
+FULL_NAME = f"{FIRST} {LAST}"
+CLAIMS = {"role": "admin", "given_name": FIRST, "family_name": LAST}
+
+
+class UserNotFoundError(Exception):
+    """Stand-in for ``firebase_admin.auth.UserNotFoundError``."""
+
+
+# ``None`` is a meaningful value for ``custom_claims`` — it is what Firebase
+# returns for an account that has never had any set — so it cannot double as
+# "caller said nothing".
+_IN_SYNC = object()
+
+
+def _existing_user(
+    *,
+    email: str = EMAIL,
+    display_name: str = FULL_NAME,
+    email_verified: bool = True,
+    custom_claims: Any = _IN_SYNC,
+) -> MagicMock:
+    """A ``UserRecord`` as the seed script reads it, already fully in sync."""
+    record = MagicMock()
+    record.email = email
+    record.display_name = display_name
+    record.email_verified = email_verified
+    record.custom_claims = CLAIMS if custom_claims is _IN_SYNC else custom_claims
+    return record
+
+
+@pytest.fixture
+def auth_mock() -> Any:
+    """Patch the ``auth`` module the seed script imported.
+
+    ``get_user`` returns a fully in-sync account by default, so each test only
+    has to state the one thing it wants to be out of sync.
+    """
+    with patch("app.seed_database.auth") as mock:
+        mock.UserNotFoundError = UserNotFoundError
+        mock.get_user.return_value = _existing_user()
+        yield mock
+
+
+def _run(**kwargs: Any) -> str:
+    """Seed one account. The ``auth_mock`` fixture is what it talks to."""
+    return ensure_firebase_user(
+        uid=UID,
+        email=EMAIL,
+        password=PASSWORD,
+        role="admin",
+        first_name=FIRST,
+        last_name=LAST,
+        **kwargs,
+    )
+
+
+class TestExistingAccountKeepsItsPassword:
+    """The regression that matters: re-seeding must not sign anyone out."""
+
+    def test_password_is_not_written_when_the_account_exists(
+        self, auth_mock: Any
+    ) -> None:
+        _run()
+
+        for call in auth_mock.update_user.call_args_list:
+            assert "password" not in call.kwargs, (
+                "Writing the password revokes every outstanding token. The "
+                "account already exists, so there is nothing to establish."
+            )
+
+    def test_an_in_sync_account_is_not_written_to_at_all(self, auth_mock: Any) -> None:
+        """Nothing differs, so there is no reason to touch Firebase."""
+        _run()
+
+        auth_mock.update_user.assert_not_called()
+        auth_mock.set_custom_user_claims.assert_not_called()
+        auth_mock.create_user.assert_not_called()
+
+    def test_a_drifted_field_is_written_without_the_password(
+        self, auth_mock: Any
+    ) -> None:
+        """Reconciling other fields must not smuggle the password along."""
+        auth_mock.get_user.return_value = _existing_user(display_name="Stale Name")
+
+        _run()
+
+        auth_mock.update_user.assert_called_once_with(UID, display_name=FULL_NAME)
+
+    @pytest.mark.parametrize(
+        ("drift", "expected"),
+        [
+            ({"email": "old@f4k.dev"}, {"email": EMAIL}),
+            ({"display_name": "Old Name"}, {"display_name": FULL_NAME}),
+            ({"email_verified": False}, {"email_verified": True}),
+        ],
+    )
+    def test_only_the_field_that_drifted_is_written(
+        self, auth_mock: Any, drift: dict[str, Any], expected: dict[str, Any]
+    ) -> None:
+        auth_mock.get_user.return_value = _existing_user(**drift)
+
+        _run()
+
+        auth_mock.update_user.assert_called_once_with(UID, **expected)
+
+    def test_several_drifted_fields_are_written_in_one_call(
+        self, auth_mock: Any
+    ) -> None:
+        auth_mock.get_user.return_value = _existing_user(
+            email="old@f4k.dev", display_name="Old Name", email_verified=False
+        )
+
+        _run()
+
+        auth_mock.update_user.assert_called_once_with(
+            UID, email=EMAIL, display_name=FULL_NAME, email_verified=True
+        )
+
+
+class TestResetPasswordsIsOptIn:
+    """The escape hatch, for a password that really has drifted."""
+
+    def test_password_is_written_when_asked_for(self, auth_mock: Any) -> None:
+        _run(reset_password=True)
+
+        auth_mock.update_user.assert_called_once_with(UID, password=PASSWORD)
+
+    def test_password_rides_along_with_other_drifted_fields(
+        self, auth_mock: Any
+    ) -> None:
+        auth_mock.get_user.return_value = _existing_user(display_name="Old Name")
+
+        _run(reset_password=True)
+
+        auth_mock.update_user.assert_called_once_with(
+            UID, display_name=FULL_NAME, password=PASSWORD
+        )
+
+    def test_default_is_off(self, auth_mock: Any) -> None:
+        """Signing everyone out is never the default."""
+        _run()
+
+        auth_mock.update_user.assert_not_called()
+
+
+class TestMissingAccountIsCreated:
+    """A new account has no session to lose, so the password must be set."""
+
+    @pytest.fixture
+    def auth_mock(self, auth_mock: Any) -> Any:
+        auth_mock.get_user.side_effect = UserNotFoundError()
+        return auth_mock
+
+    def test_created_with_the_seed_password(self, auth_mock: Any) -> None:
+        _run()
+
+        auth_mock.create_user.assert_called_once_with(
+            uid=UID,
+            email=EMAIL,
+            password=PASSWORD,
+            email_verified=True,
+            display_name=FULL_NAME,
+        )
+        auth_mock.update_user.assert_not_called()
+
+    def test_claims_are_set_on_creation(self, auth_mock: Any) -> None:
+        """A new account has no claims, so the role has to be established."""
+        _run()
+
+        auth_mock.set_custom_user_claims.assert_called_once_with(UID, CLAIMS)
+
+    def test_reset_password_changes_nothing_for_a_new_account(
+        self, auth_mock: Any
+    ) -> None:
+        _run(reset_password=True)
+
+        auth_mock.create_user.assert_called_once()
+        auth_mock.update_user.assert_not_called()
+
+
+class TestClaims:
+    """Claims are reconciled like any other field. They do not revoke tokens,
+    but writing them every run is pointless work against a rate-limited API."""
+
+    def test_unchanged_claims_are_not_rewritten(self, auth_mock: Any) -> None:
+        _run()
+
+        auth_mock.set_custom_user_claims.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "stale",
+        [
+            {"role": "driver", "given_name": FIRST, "family_name": LAST},
+            {"role": "admin", "given_name": "Someone", "family_name": LAST},
+            {"role": "admin"},
+            {},
+            None,
+        ],
+    )
+    def test_stale_or_absent_claims_are_rewritten(
+        self, auth_mock: Any, stale: dict[str, Any] | None
+    ) -> None:
+        """A wrong role is a security-relevant drift, and ``None`` is what
+        Firebase returns for an account that has never had claims set."""
+        auth_mock.get_user.return_value = _existing_user(custom_claims=stale)
+
+        _run()
+
+        auth_mock.set_custom_user_claims.assert_called_once_with(UID, CLAIMS)
+
+    def test_claims_are_written_even_when_no_other_field_drifted(
+        self, auth_mock: Any
+    ) -> None:
+        auth_mock.get_user.return_value = _existing_user(custom_claims={})
+
+        _run()
+
+        auth_mock.update_user.assert_not_called()
+        auth_mock.set_custom_user_claims.assert_called_once_with(UID, CLAIMS)
+
+
+class TestReturnValue:
+    @pytest.mark.usefixtures("auth_mock")
+    def test_returns_the_uid_for_an_existing_account(self) -> None:
+        assert _run() == UID
+
+    def test_returns_the_uid_for_a_created_account(self, auth_mock: Any) -> None:
+        auth_mock.get_user.side_effect = UserNotFoundError()
+
+        assert _run() == UID


### PR DESCRIPTION
## Why

`ensure_firebase_user` rewrote **every existing account's password on every run**. Firebase treats a password write as a credential change: it moves the account's `tokensValidAfterTime` to now, revoking every ID *and* refresh token already issued. The app verifies with `check_revoked=True`, so everyone holding one is signed out on their very next request — with a `RevokedIdTokenError` that gives no hint where it came from.

Two consequences:

- Re-seeding logged out every open session.
- CI's boot smoke (`boot-smoke.yml:163`) seeds the **same Firebase project local development uses**, so an unrelated merge could sign a developer out mid-task. That is how this was found — an import flow broke immediately after a merge that had nothing to do with auth.

Firebase's own record made it plain: `seed-admin-1` was created 2026-07-04, but its `tokensValidAfter` matched the *final seconds of the most recent CI boot job*, to the second.

## What

The password never needed writing. It is a constant (`SEED_PASSWORD`), so from the second run onward the value being written is the value already there.

Existing accounts are now reconciled field by field — email, display name, verified flag, custom claims — and only fields that actually **differ** get written. A steady-state re-seed makes no writes at all.

`--reset-passwords` restores the old behaviour for the case where a password really has drifted. It signs everyone out; that is the point, so it has to be asked for.

## Measured, not assumed

The fix only works if the *password* is what moves the timestamp. Before writing it, I checked against the real Firebase project using a stale July leftover account (`driver090@f4k.dev`, outside the current seed range):

| write | `tokensValidAfterTime` |
| --- | --- |
| `display_name` | unchanged |
| `set_custom_user_claims` | unchanged |
| `password` | **moved** (2026-07-23 → now) |

So skipping the password is sufficient, not merely helpful.

## Tests

`ensure_firebase_user` had **zero** coverage — `test_seed_database.py` patches it out wholesale to keep the seed tests offline. This adds `tests/test_seed_firebase_user.py`, 22 tests in four groups:

- **existing account keeps its password** — the headline rule, plus each field drifting alone and several together, asserting the password never rides along
- **`--reset-passwords` is opt-in** — writes the password when asked, and only then
- **a missing account is created** — a new account has no session to lose, so the password *must* be set
- **claims** — reconciled like any other field, including the `None` Firebase returns for an account that has never had any

Reintroducing the password rewrite fails 9 of them.

Full backend suite: 613 passed. `ruff check`, `ruff format --check` and `mypy` (130 files) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)