### PR TITLE
Make every location import column reachable and non-lossy

### DIFF
--- a/backend/python/app/models/location.py
+++ b/backend/python/app/models/location.py
@@ -89,6 +89,7 @@ class AlertCode(str, Enum):
     INVALID_ADDRESS = "INVALID_ADDRESS"
     MISSING_PHONE_NUMBER = "MISSING_PHONE_NUMBER"
     INVALID_PHONE_NUMBER = "INVALID_PHONE_NUMBER"
+    INVALID_SECONDARY_PHONE_NUMBER = "INVALID_SECONDARY_PHONE_NUMBER"
     MISSING_NAME = "MISSING_NAME"
     INVALID_NAME = "INVALID_NAME"
     MISSING_DELIVERY_GROUP = "MISSING_DELIVERY_GROUP"
@@ -191,6 +192,11 @@ class ChangedFieldOptInt(SQLModel):
     old_value: int | None
 
 
+class ChangedFieldBool(SQLModel):
+    new_value: bool
+    old_value: bool
+
+
 class ChangedEntry(SQLModel):
     """An existing location whose fields differ from the import row.
 
@@ -201,15 +207,16 @@ class ChangedEntry(SQLModel):
     row: int
     location_id: UUID
     contact_name: str
-    # Diffed like the rest. The frames' Changed table has no Guardian Name
-    # column, but leaving it undiffed would mean a row whose only edit is the
-    # guardian's name never surfaces and the edit is dropped on ingest.
     guardian_name: str | ChangedFieldOptStr | None = None
     address: str | ChangedFieldStr
     delivery_group: str | ChangedFieldOptStr | None = None
     phone_primary: str | ChangedFieldStr
     phone_secondary: str | ChangedFieldOptStr | None = None
     num_children: int | ChangedFieldOptInt | None = None
+    # Never null: a blank cell leaves the stored value standing, so the
+    # unchanged case renders what the location already holds.
+    halal: bool | ChangedFieldBool = False
+    dietary_restrictions: str | ChangedFieldStr = ""
 
 
 class LocationImportPreview(SQLModel):

--- a/backend/python/app/services/implementations/location_import_validation.py
+++ b/backend/python/app/services/implementations/location_import_validation.py
@@ -68,8 +68,12 @@ def collect_field_alerts(
     elif phone_invalid:
         alerts.append(AlertCode.INVALID_PHONE_NUMBER)
 
+    # Its own code, not INVALID_PHONE_NUMBER: the Validate screen highlights
+    # the cell the alert names, so sharing the primary's code would mark a
+    # perfectly good primary number red. A blank secondary is not an alert —
+    # the field is optional.
     if phone_secondary_invalid:
-        alerts.append(AlertCode.INVALID_PHONE_NUMBER)
+        alerts.append(AlertCode.INVALID_SECONDARY_PHONE_NUMBER)
 
     if is_blank(entry.delivery_group):
         alerts.append(AlertCode.MISSING_DELIVERY_GROUP)

--- a/backend/python/app/services/implementations/location_service.py
+++ b/backend/python/app/services/implementations/location_service.py
@@ -5,7 +5,7 @@ from collections.abc import Iterable
 from dataclasses import dataclass
 from datetime import date, datetime
 from io import BytesIO
-from typing import TYPE_CHECKING, Any, TypeGuard
+from typing import TYPE_CHECKING, Any, TypeGuard, TypeVar
 from uuid import UUID
 from zoneinfo import ZoneInfo
 
@@ -24,6 +24,7 @@ from app.models.enum import (
 from app.models.location import (
     AlertCode,
     ChangedEntry,
+    ChangedFieldBool,
     ChangedFieldOptInt,
     ChangedFieldOptStr,
     ChangedFieldStr,
@@ -103,6 +104,20 @@ class ImportPlan:
 
 # How many referencing routes to name in a LocationInUseError message.
 IN_USE_SAMPLE_SIZE = 5
+
+T = TypeVar("T")
+
+
+def resolve_optional(new: T | None, current: T) -> T:
+    """The value an import row would leave on a field it may not speak to.
+
+    A blank cell parses to None, and so does a column the admin never mapped:
+    the two are indistinguishable, so neither can mean "clear this". None
+    therefore carries no information and the stored value stands. Change
+    detection and the applier both go through here so they cannot disagree
+    about what a blank cell means.
+    """
+    return current if new is None else new
 
 
 class LocationInUseError(Exception):
@@ -984,8 +999,13 @@ class LocationService:
             "phone_primary": entry_key.phone != location_key.phone,
             "phone_secondary": (entry.phone_secondary or None)
             != (location.phone_secondary or None),
-            "num_children": entry.num_children is not None
-            and entry.num_children != location.num_children,
+            "num_children": resolve_optional(entry.num_children, location.num_children)
+            != location.num_children,
+            "halal": resolve_optional(entry.halal, location.halal) != location.halal,
+            "dietary_restrictions": resolve_optional(
+                entry.dietary_restrictions, location.dietary_restrictions
+            )
+            != location.dietary_restrictions,
             "in_roster": not location.in_roster,
         }
 
@@ -1043,6 +1063,20 @@ class LocationService:
             )
             if num_children_changed
             else location.num_children,
+            halal=ChangedFieldBool(
+                new_value=resolve_optional(entry.halal, location.halal),
+                old_value=location.halal,
+            )
+            if changes["halal"]
+            else location.halal,
+            dietary_restrictions=ChangedFieldStr(
+                new_value=resolve_optional(
+                    entry.dietary_restrictions, location.dietary_restrictions
+                ),
+                old_value=location.dietary_restrictions,
+            )
+            if changes["dietary_restrictions"]
+            else location.dietary_restrictions,
         )
 
     async def _read_upload_file(self, file: UploadFile) -> pd.DataFrame:
@@ -1245,7 +1279,13 @@ class LocationService:
                     location.guardian_name = entry.guardian_name
                     location.phone_primary = entry.phone_primary
                     location.phone_secondary = entry.phone_secondary
-                    location.num_children = entry.num_children or 0
+                    location.num_children = resolve_optional(
+                        entry.num_children, location.num_children
+                    )
+                    location.halal = resolve_optional(entry.halal, location.halal)
+                    location.dietary_restrictions = resolve_optional(
+                        entry.dietary_restrictions, location.dietary_restrictions
+                    )
                     location.location_group_id = group_id
                     continue
 
@@ -1269,9 +1309,13 @@ class LocationService:
                         longitude=geocode_result.longitude,
                         latitude=geocode_result.latitude,
                         place_id=geocode_result.place_id,
-                        halal=location.halal,
-                        dietary_restrictions=location.dietary_restrictions,
-                        num_children=entry.num_children or 0,
+                        halal=resolve_optional(entry.halal, location.halal),
+                        dietary_restrictions=resolve_optional(
+                            entry.dietary_restrictions, location.dietary_restrictions
+                        ),
+                        num_children=resolve_optional(
+                            entry.num_children, location.num_children
+                        ),
                         delivery_type=delivery_type,
                         in_roster=True,
                         note_chain_id=note_chain_id,

--- a/backend/python/tests/test_location_import_validation.py
+++ b/backend/python/tests/test_location_import_validation.py
@@ -120,7 +120,42 @@ class TestFieldValidation:
             phone_invalid=False,
             phone_secondary_invalid=True,
         )
-        assert AlertCode.INVALID_PHONE_NUMBER in alerts
+        # Its own code, so the Validate screen does not redden a valid primary.
+        assert alerts == [AlertCode.INVALID_SECONDARY_PHONE_NUMBER]
+
+    def test_blank_phone_secondary_is_not_an_alert(self) -> None:
+        for blank in (None, "", "   "):
+            alerts = collect_field_alerts(
+                LocationImportEntry(
+                    contact_name="Smith",
+                    address="123 Main St",
+                    delivery_group="Tuesday A",
+                    phone_primary="+15195551234",
+                    phone_secondary=blank,
+                ),
+                geocode_ok=True,
+                phone_invalid=False,
+                phone_secondary_invalid=False,
+            )
+            assert alerts == []
+
+    def test_both_phones_invalid_reports_both_codes(self) -> None:
+        alerts = collect_field_alerts(
+            LocationImportEntry(
+                contact_name="Smith",
+                address="123 Main St",
+                delivery_group="Tuesday A",
+                phone_primary="not-a-phone",
+                phone_secondary="also-not-a-phone",
+            ),
+            geocode_ok=True,
+            phone_invalid=True,
+            phone_secondary_invalid=True,
+        )
+        assert alerts == [
+            AlertCode.INVALID_PHONE_NUMBER,
+            AlertCode.INVALID_SECONDARY_PHONE_NUMBER,
+        ]
 
     def test_multiple_errors_on_one_row(self) -> None:
         alerts = collect_field_alerts(

--- a/backend/python/tests/test_routes.py
+++ b/backend/python/tests/test_routes.py
@@ -40,6 +40,8 @@ IMPORT_COLUMN_MAP = {
     "phone_primary": "Phone",
     "phone_secondary": "Secondary Phone",
     "num_children": "Children",
+    "halal": "Halal",
+    "dietary_restrictions": "Food Restrictions",
 }
 
 
@@ -76,6 +78,8 @@ def import_review_request(
         "Phone",
         "Secondary Phone",
         "Children",
+        "Halal",
+        "Food Restrictions",
     ]
     lines = [",".join(headers)]
     for row in rows:
@@ -1682,6 +1686,13 @@ class TestLocationImportRoutes:
                     "Delivery Group": "Monday",
                     "Phone": "not-a-phone",
                 },
+                {
+                    "Name": "Invalid Secondary Phone Family",
+                    "Address": "3 Valid St",
+                    "Delivery Group": "Monday",
+                    "Phone": "+14164164170",
+                    "Secondary Phone": "not-a-phone",
+                },
             ]
         )
 
@@ -1699,7 +1710,13 @@ class TestLocationImportRoutes:
         assert body["rows"][1]["alerts"] == ["INVALID_NAME"]
         assert body["rows"][2]["alerts"] == ["INVALID_ADDRESS"]
         assert body["rows"][3]["alerts"] == ["INVALID_PHONE_NUMBER"]
-        assert fake_maps.calls == ["1 Valid St", "Invalid Address", "2 Valid St"]
+        assert body["rows"][4]["alerts"] == ["INVALID_SECONDARY_PHONE_NUMBER"]
+        assert fake_maps.calls == [
+            "1 Valid St",
+            "Invalid Address",
+            "2 Valid St",
+            "3 Valid St",
+        ]
 
     @pytest.mark.asyncio
     async def test_review_locations_rejects_imprecise_geocode(
@@ -2220,6 +2237,198 @@ class TestLocationImportRoutes:
         assert body["changed"] == []
         assert body["net_new"] == []
         assert body["stale"] == []
+
+    @pytest.mark.asyncio
+    async def test_review_and_ingest_apply_halal_and_dietary_restrictions(
+        self,
+        client_with_overrides: Any,
+        test_session: AsyncSession,
+        test_location_group: Any,
+    ) -> None:
+        """A row whose only edit is halal/restrictions must surface and apply.
+
+        Both fields are written by the import, so they have to take part in
+        change detection (or the row is never offered for review) and in the
+        applier (or the reviewed change is dropped on ingest).
+        """
+        fake_maps = FakeGoogleMapsClient()
+        async_client = await client_with_overrides(
+            {get_google_maps_client: lambda: fake_maps}
+        )
+        location = Location(
+            location_group_id=test_location_group.location_group_id,
+            name="Halal Family",
+            contact_name="Halal Family",
+            address="Formatted 77 Main St",
+            phone_primary="+14164164171",
+            num_children=3,
+            halal=False,
+            dietary_restrictions="Peanut",
+            delivery_type="Family",
+        )
+        test_session.add(location)
+        await test_session.commit()
+        location_id = location.location_id
+
+        rows = [
+            {
+                "Name": "Halal Family",
+                "Address": "77 Main St",
+                "Delivery Group": test_location_group.name,
+                "Phone": "+14164164171",
+                "Children": "3",
+                "Halal": "Yes",
+                "Food Restrictions": "Dairy",
+            }
+        ]
+
+        response = await async_client.post(
+            "/locations/import/preview", **import_review_request(rows)
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["success"] is True
+        assert len(body["changed"]) == 1
+        changed = body["changed"][0]
+        assert changed["halal"] == {"new_value": True, "old_value": False}
+        assert changed["dietary_restrictions"] == {
+            "new_value": "Dairy",
+            "old_value": "Peanut",
+        }
+        # Untouched fields stay plain values, not old/new pairs.
+        assert changed["num_children"] == 3
+
+        response = await async_client.post(
+            "/locations/import", **import_review_request(rows)
+        )
+        assert response.status_code == 200
+
+        await test_session.refresh(location)
+        assert location.location_id == location_id
+        assert location.halal is True
+        assert location.dietary_restrictions == "Dairy"
+
+    @pytest.mark.asyncio
+    async def test_ingest_blank_optional_cells_leave_stored_values(
+        self,
+        client_with_overrides: Any,
+        test_session: AsyncSession,
+        test_location_group: Any,
+    ) -> None:
+        """A blank cell carries no information and must not clear the field.
+
+        A blank cell and an unmapped column both parse to None, so None cannot
+        mean "clear this" — the stored value has to survive the import.
+        """
+        fake_maps = FakeGoogleMapsClient()
+        async_client = await client_with_overrides(
+            {get_google_maps_client: lambda: fake_maps}
+        )
+        location = Location(
+            location_group_id=test_location_group.location_group_id,
+            name="Blank Optionals Family",
+            contact_name="Blank Optionals Family",
+            address="Formatted 88 Main St",
+            phone_primary="+14164164172",
+            num_children=5,
+            halal=True,
+            dietary_restrictions="Gluten",
+            in_roster=False,
+            delivery_type="Family",
+        )
+        test_session.add(location)
+        await test_session.commit()
+
+        # in_roster=False makes this a changed row even though every mapped
+        # field matches, so the applier actually runs over it.
+        rows = [
+            {
+                "Name": "Blank Optionals Family",
+                "Address": "88 Main St",
+                "Delivery Group": test_location_group.name,
+                "Phone": "+14164164172",
+                "Children": "",
+                "Halal": "",
+                "Food Restrictions": "",
+            }
+        ]
+
+        response = await async_client.post(
+            "/locations/import/preview", **import_review_request(rows)
+        )
+        assert response.status_code == 200
+        changed = response.json()["changed"]
+        assert len(changed) == 1
+        assert changed[0]["num_children"] == 5
+        assert changed[0]["halal"] is True
+        assert changed[0]["dietary_restrictions"] == "Gluten"
+
+        response = await async_client.post(
+            "/locations/import", **import_review_request(rows)
+        )
+        assert response.status_code == 200
+
+        await test_session.refresh(location)
+        assert location.num_children == 5
+        assert location.halal is True
+        assert location.dietary_restrictions == "Gluten"
+        assert location.in_roster is True
+
+    @pytest.mark.asyncio
+    async def test_ingest_carries_optional_fields_through_an_address_change(
+        self,
+        client_with_overrides: Any,
+        test_session: AsyncSession,
+        test_location_group: Any,
+    ) -> None:
+        """A moved location keeps the import's values, not the old row's.
+
+        The move retires the old Location and builds a fresh one, which used to
+        copy halal/restrictions off the row being retired — silently discarding
+        the edit the admin had just reviewed.
+        """
+        fake_maps = FakeGoogleMapsClient()
+        async_client = await client_with_overrides(
+            {get_google_maps_client: lambda: fake_maps}
+        )
+        test_session.add(
+            Location(
+                location_group_id=test_location_group.location_group_id,
+                name="Moving Family",
+                contact_name="Moving Family",
+                address="Formatted 99 Old St",
+                phone_primary="+14164164173",
+                num_children=2,
+                halal=False,
+                dietary_restrictions="Peanut",
+                delivery_type="Family",
+            )
+        )
+        await test_session.commit()
+
+        rows = [
+            {
+                "Name": "Moving Family",
+                "Address": "100 New St",
+                "Delivery Group": test_location_group.name,
+                "Phone": "+14164164173",
+                "Children": "2",
+                "Halal": "Yes",
+                "Food Restrictions": "Dairy",
+            }
+        ]
+
+        response = await async_client.post(
+            "/locations/import", **import_review_request(rows)
+        )
+
+        assert response.status_code == 200
+        created = response.json()["created"]
+        assert len(created) == 1
+        assert created[0]["address"] == "Formatted 100 New St"
+        assert created[0]["halal"] is True
+        assert created[0]["dietary_restrictions"] == "Dairy"
 
     @pytest.mark.asyncio
     async def test_review_locations_claims_existing_matches_once(

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -8,6 +8,7 @@
           "INVALID_ADDRESS",
           "MISSING_PHONE_NUMBER",
           "INVALID_PHONE_NUMBER",
+          "INVALID_SECONDARY_PHONE_NUMBER",
           "MISSING_NAME",
           "INVALID_NAME",
           "MISSING_DELIVERY_GROUP",
@@ -364,6 +365,18 @@
             ],
             "title": "Delivery Group"
           },
+          "dietary_restrictions": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "$ref": "#/components/schemas/ChangedFieldStr"
+              }
+            ],
+            "default": "",
+            "title": "Dietary Restrictions"
+          },
           "guardian_name": {
             "anyOf": [
               {
@@ -377,6 +390,18 @@
               }
             ],
             "title": "Guardian Name"
+          },
+          "halal": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "$ref": "#/components/schemas/ChangedFieldBool"
+              }
+            ],
+            "default": false,
+            "title": "Halal"
           },
           "location_id": {
             "format": "uuid",
@@ -435,6 +460,24 @@
           "phone_primary"
         ],
         "title": "ChangedEntry",
+        "type": "object"
+      },
+      "ChangedFieldBool": {
+        "properties": {
+          "new_value": {
+            "title": "New Value",
+            "type": "boolean"
+          },
+          "old_value": {
+            "title": "Old Value",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "new_value",
+          "old_value"
+        ],
+        "title": "ChangedFieldBool",
         "type": "object"
       },
       "ChangedFieldOptInt": {

--- a/frontend/src/api/generated/index.ts
+++ b/frontend/src/api/generated/index.ts
@@ -93,6 +93,7 @@ export type {
   CancelJobResponse,
   CancelJobResponses,
   ChangedEntry,
+  ChangedFieldBool,
   ChangedFieldOptInt,
   ChangedFieldOptStr,
   ChangedFieldStr,

--- a/frontend/src/api/generated/types.gen.ts
+++ b/frontend/src/api/generated/types.gen.ts
@@ -14,6 +14,7 @@ export type AlertCode =
   | 'INVALID_ADDRESS'
   | 'MISSING_PHONE_NUMBER'
   | 'INVALID_PHONE_NUMBER'
+  | 'INVALID_SECONDARY_PHONE_NUMBER'
   | 'MISSING_NAME'
   | 'INVALID_NAME'
   | 'MISSING_DELIVERY_GROUP'
@@ -247,9 +248,17 @@ export type ChangedEntry = {
    */
   delivery_group?: string | ChangedFieldOptStr | null;
   /**
+   * Dietary Restrictions
+   */
+  dietary_restrictions?: string | ChangedFieldStr;
+  /**
    * Guardian Name
    */
   guardian_name?: string | ChangedFieldOptStr | null;
+  /**
+   * Halal
+   */
+  halal?: boolean | ChangedFieldBool;
   /**
    * Location Id
    */
@@ -270,6 +279,20 @@ export type ChangedEntry = {
    * Row
    */
   row: number;
+};
+
+/**
+ * ChangedFieldBool
+ */
+export type ChangedFieldBool = {
+  /**
+   * New Value
+   */
+  new_value: boolean;
+  /**
+   * Old Value
+   */
+  old_value: boolean;
 };
 
 /**

--- a/frontend/src/pages/admin/routes/generation/ImportStep.tsx
+++ b/frontend/src/pages/admin/routes/generation/ImportStep.tsx
@@ -25,6 +25,11 @@ import { GenerationFooter } from './GenerationFooter';
 
 const ACCEPTED_EXTENSIONS = new Set(['.xlsx']);
 
+// Radix Select cannot hold an item whose value is the empty string, so the
+// "leave unmapped" choice an optional field needs carries a sentinel that is
+// translated back to '' before it reaches the column map.
+const UNMAPPED = '__unmapped__';
+
 interface SystemField {
   key: string;
   label: string;
@@ -37,6 +42,10 @@ const SYSTEM_FIELDS: SystemField[] = [
   { key: 'address', label: 'Address', required: true },
   { key: 'delivery_group', label: 'Delivery Group', required: true },
   { key: 'phone_primary', label: 'Phone Number', required: true },
+  // Optional to match the backend: `phone_secondary` is a ChangedFieldOptStr
+  // and is absent from `_has_required_fields`, so a roster without a second
+  // phone column still imports. It is only validated when non-empty.
+  { key: 'phone_secondary', label: 'Secondary Phone Number' },
   { key: 'num_children', label: 'Number of Children', required: true },
   { key: 'dietary_restrictions', label: 'Food Restrictions', required: true },
   { key: 'halal', label: 'Halal?', required: true },
@@ -129,7 +138,7 @@ export function ImportStep() {
       // because every row holds a control. The header is 48 and top-aligned:
       // the frames draw it as a 40px box with 16px of air beneath, which a
       // borderless table row can only approximate, and this is the split that
-      // lands both the header text and all eight rows on their frame y.
+      // lands both the header text and every row on their frame y.
       headerClassName: 'h-12 align-top',
       getCellClassName: () => 'h-14',
       render: (row) => (
@@ -150,13 +159,21 @@ export function ImportStep() {
         <Dropdown
           value={columnMap[row.key] ?? ''}
           onValueChange={(val) =>
-            setColumnMap({ ...columnMap, [row.key]: val })
+            setColumnMap({
+              ...columnMap,
+              [row.key]: val === UNMAPPED ? '' : val,
+            })
           }
         >
           <DropdownTrigger>
             <DropdownValue placeholder="Select Column" />
           </DropdownTrigger>
           <DropdownContent>
+            {/* An optional field has to be un-settable again: without this the
+                first pick would be permanent for the rest of the wizard. */}
+            {!row.required && (
+              <DropdownItem value={UNMAPPED}>Not in my file</DropdownItem>
+            )}
             {headerOptions.map((opt) => (
               <DropdownItem key={opt.value} value={opt.value}>
                 {opt.label}

--- a/frontend/src/pages/admin/routes/generation/ReviewStep.tsx
+++ b/frontend/src/pages/admin/routes/generation/ReviewStep.tsx
@@ -37,6 +37,18 @@ function isChanged<T>(value: T | ChangedField<T>): value is ChangedField<T> {
   );
 }
 
+// Halal arrives as a bool on both sides of the diff. ChangedCell renders text,
+// so map through Yes/No while keeping the changed/unchanged shape intact.
+function yesNo(
+  value: boolean | ChangedField<boolean> | undefined
+): string | undefined | ChangedField<string | null> {
+  const label = (flag: boolean) => (flag ? 'Yes' : 'No');
+  if (value === undefined) return undefined;
+  return isChanged(value)
+    ? { new_value: label(value.new_value), old_value: label(value.old_value) }
+    : label(value);
+}
+
 function ChangedCell({
   value,
 }: {
@@ -189,9 +201,8 @@ export function ReviewStep() {
       header: 'School / Last Name',
       render: (row) => row.contact_name,
     },
-    // Not in the frames' Changed table. Without it, a row whose only edit is
-    // the guardian's name shows no visible difference, and there is nothing
-    // for the admin to check off — flag to the designer.
+    // Every field the import writes is diffed here: the admin checks a row off
+    // as reviewed, so a row whose only edit is invisible has nothing to review.
     {
       key: 'guardian_name',
       header: 'Guardian Name',
@@ -213,9 +224,24 @@ export function ReviewStep() {
       render: (row) => <ChangedCell value={row.phone_primary} />,
     },
     {
+      key: 'phone_secondary',
+      header: 'Secondary Phone Number',
+      render: (row) => <ChangedCell value={row.phone_secondary} />,
+    },
+    {
       key: 'num_children',
       header: 'Number of Children',
       render: (row) => <ChangedCell value={row.num_children} />,
+    },
+    {
+      key: 'dietary_restrictions',
+      header: 'Food Restrictions',
+      render: (row) => <ChangedCell value={row.dietary_restrictions} />,
+    },
+    {
+      key: 'halal',
+      header: 'Halal?',
+      render: (row) => <ChangedCell value={yesNo(row.halal)} />,
     },
   ];
 

--- a/frontend/src/pages/admin/routes/generation/ValidateStep.tsx
+++ b/frontend/src/pages/admin/routes/generation/ValidateStep.tsx
@@ -42,6 +42,8 @@ function getAlertDisplay(code: AlertCode): {
       return { type: 'error', label: 'Missing Phone Number' };
     case 'INVALID_PHONE_NUMBER':
       return { type: 'error', label: 'Invalid Phone Number' };
+    case 'INVALID_SECONDARY_PHONE_NUMBER':
+      return { type: 'error', label: 'Invalid Secondary Phone Number' };
     case 'MISSING_DELIVERY_GROUP':
       return { type: 'error', label: 'Missing Delivery Group' };
     case 'LOCAL_DUPLICATE':
@@ -62,6 +64,9 @@ const hasAddressAlert = (alerts: AlertCode[]) =>
 const hasPhoneAlert = (alerts: AlertCode[]) =>
   alerts.includes('MISSING_PHONE_NUMBER') ||
   alerts.includes('INVALID_PHONE_NUMBER');
+
+const hasSecondaryPhoneAlert = (alerts: AlertCode[]) =>
+  alerts.includes('INVALID_SECONDARY_PHONE_NUMBER');
 
 const hasInvalidOrMissingAlert = (row: { alerts: AlertCode[] }) =>
   row.alerts.some((code) => code !== 'LOCAL_DUPLICATE');
@@ -201,6 +206,16 @@ export function ValidateStep() {
             'phone_primary',
             duplicateFields(row)
           ),
+      },
+      // INVALID_SECONDARY_PHONE_NUMBER is a blocking alert, so the value has
+      // to be on screen — otherwise the admin is told to fix something they
+      // cannot see. Never a duplicate field: the 2-of-3 rule uses the primary.
+      {
+        key: 'phone_secondary',
+        header: 'Secondary Phone Number',
+        render: (row) => row.location.phone_secondary ?? '',
+        getCellClassName: (row) =>
+          getCellClass(invalid && hasSecondaryPhoneAlert(row.alerts)),
       },
     ];
   };


### PR DESCRIPTION
The Map Columns table offered eight fields. The backend has always parsed nine, and wrote three of them only for locations it was *creating* — so an admin editing an existing roster could lose data with no sign anything had happened.

## `phone_secondary` was never mappable

The backend parses, normalizes and validates it (`_parse_row` → `try_normalize_phone` → `collect_field_alerts`), and `test_routes.py` exercises it, but `SYSTEM_FIELDS` never listed it. A roster carrying a second phone number silently dropped it, and the `INVALID_PHONE_NUMBER`-on-secondary path could never fire in production.

It is now the one **optional** mapping, matching the backend — `phone_secondary` is a `ChangedFieldOptStr` and is absent from `_has_required_fields`, so a roster without the column still imports. Being optional means the dropdown needs a "Not in my file" choice: an optional field the admin can pick but never unpick is worse than no field at all. (Radix Select can't hold an empty-string value, hence the sentinel.)

## The secondary phone shared the primary's alert code

Making the value reachable made a latent bug reachable with it. An invalid secondary number raised `INVALID_PHONE_NUMBER`, and the Validate screen uses that code to redden the **primary** phone cell — telling the admin to fix a number that was fine. Split into `INVALID_SECONDARY_PHONE_NUMBER` with its own column, so the screen marks the cell that actually has to change.

## `halal` and `dietary_restrictions` were discarded on edit

Both were mappable, but for any location that already existed they were thrown away:

- `_import_field_changes` never compared them, so a row whose only edit was a restriction or the halal flag wasn't classed as changed and never reached the Review screen.
- The in-place update branch never assigned them.
- The moved-house branch copied both off the row being *retired*, so even an edit that did reach review was dropped on apply.

They only ever landed on net-new rows. All three paths are fixed, and both fields are now in the Changed table so there is something to check off.

## Blank cells needed a rule

A blank cell and an unmapped column both parse to `None`, so `None` can't mean "clear this". `resolve_optional` makes it mean "leave the stored value", and change detection and the applier both read it, so they can't disagree.

That also retires an existing inconsistency on `num_children`: a blank cell counted as "no change" during review but was applied as `entry.num_children or 0` — quietly zeroing the children, and therefore the box count, of any location whose spreadsheet cell was empty.

## Testing

Full backend suite green (632 passed), frontend vitest green (13), plus `ruff check`, `ruff format --check`, `mypy`, `tsc` and `eslint src` clean.

New coverage: secondary-only invalid phone gets its own code; both phones invalid reports both; blank secondary is not an alert; an end-to-end preview row with a bad secondary; halal/restrictions surfacing in review and landing on apply; blank cells leaving all three optional fields untouched; optional fields surviving an address change. The shared test fixture now maps `Halal` and `Food Restrictions`, which it previously did not.

The OpenAPI client is regenerated — the contract adds one `AlertCode` member, `ChangedFieldBool`, and the two `ChangedEntry` fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)