### PR TITLE
Answer a bad token with 401, not 403

### DIFF
--- a/backend/python/app/dependencies/auth.py
+++ b/backend/python/app/dependencies/auth.py
@@ -69,14 +69,22 @@ def _verified_token(access_token: str) -> dict[str, Any]:
     round-trip — and applies the same email-verification bar to every caller,
     admins included.
 
-    :raises HTTPException: 401 if the token is invalid/expired, 403 if the
-        caller's email is not verified.
+    ``clock_skew_seconds`` tolerates a client whose clock runs slightly ahead
+    of Google's, which would otherwise reject a freshly minted token as
+    issued in the future.
+
+    :raises HTTPException: 401 if the token is invalid/expired/revoked, 403 if
+        the caller's email is not verified.
     """
     try:
         decoded_token: dict[str, Any] = firebase_admin.auth.verify_id_token(
-            access_token, check_revoked=True
+            access_token, check_revoked=True, clock_skew_seconds=5
         )
     except Exception as e:
+        # The response deliberately says only "invalid or expired". Which of
+        # revoked/expired/malformed it was belongs in the log, where it is the
+        # difference between "log back in" and "something is wrong with us".
+        logger.warning("Token verification failed: %s: %s", type(e).__name__, e)
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid or expired token",
@@ -123,18 +131,29 @@ def require_authorization_by_role(roles: set[str]) -> Callable[..., Awaitable[bo
     """
     Create a dependency that checks if the user has one of the required roles
 
+    Verification and the role check are kept apart on purpose, because the
+    caller can only act on one of them. A token that cannot be verified —
+    expired, malformed, revoked because someone re-seeded — means "we don't
+    know who you are", and logging in again fixes it: 401. A verified token
+    whose role is not in ``roles`` means "we know exactly who you are, and this
+    is not for you", which logging in again will never fix: 403.
+
+    This used to run through ``auth_service.is_authorized_by_role``, which
+    wrapped verification in ``except Exception: return False``. Both cases —
+    plus a network blip reaching Firebase — arrived here as one boolean, so
+    every one of them became a 403. A client had no way to tell "your session
+    ended" from "you're not allowed", which is why the frontend could not send
+    an expired session to the login page without also trapping a driver who had
+    merely wandered into an admin route.
+
     :param roles: Set of authorized roles
     :return: FastAPI dependency function
     """
 
-    async def check_role(
-        access_token: str = Depends(get_access_token),
-        session: AsyncSession = Depends(get_session),
-    ) -> bool:
-        authorized = await auth_service.is_authorized_by_role(
-            session, access_token, roles
-        )
-        if not authorized:
+    async def check_role(access_token: str = Depends(get_access_token)) -> bool:
+        decoded_token = _verified_token(access_token)
+
+        if decoded_token.get("role") not in roles:
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail="You are not authorized to make this request.",

--- a/backend/python/app/services/implementations/auth_service.py
+++ b/backend/python/app/services/implementations/auth_service.py
@@ -10,8 +10,6 @@ from app.schemas.auth import AuthResponse
 from app.utilities.firebase_rest_client import FirebaseRestClient, FirebaseRestError
 
 if TYPE_CHECKING:
-    from firebase_admin.auth import UserRecord
-
     from app.services.implementations.driver_service import DriverService
     from app.services.implementations.email_service import EmailService
     from app.services.implementations.user_service import UserService
@@ -154,40 +152,3 @@ class AuthService:
             role=user.role,
         )
         return auth_response, token_response.refresh_token
-
-    async def is_authorized_by_role(
-        self, _session: AsyncSession, access_token: str, roles: set[str]
-    ) -> bool:
-        try:
-            decoded_id_token = firebase_admin.auth.verify_id_token(
-                access_token, check_revoked=True, clock_skew_seconds=5
-            )
-            user_role = decoded_id_token.get("role")
-            if not user_role:
-                self.logger.warning(
-                    f"User {decoded_id_token['uid']} has no role claim set"
-                )
-                return False
-            # Allow if role is in the authorized set
-            return user_role in roles
-        except Exception as e:
-            self.logger.error(f"Authorization failed: {type(e).__name__}: {e!s}")
-            return False
-
-    def is_authorized_by_email(self, access_token: str, requested_email: str) -> bool:
-        try:
-            decoded_id_token = firebase_admin.auth.verify_id_token(
-                access_token, check_revoked=True
-            )
-            firebase_user: UserRecord = firebase_admin.auth.get_user(
-                decoded_id_token["uid"]
-            )
-            return bool(
-                firebase_user.email_verified
-                and decoded_id_token["email"] == requested_email
-            )
-        except Exception as e:
-            self.logger.error(
-                f"Authorization by email failed: {type(e).__name__}: {e!s}"
-            )
-            return False

--- a/backend/python/tests/conftest.py
+++ b/backend/python/tests/conftest.py
@@ -276,16 +276,6 @@ def mock_firebase_admin_auth(mocker: Any) -> Any:
 
 
 @pytest.fixture
-def mock_auth_service(mocker: Any) -> Any:
-    """Mock the auth service for testing."""
-    mock_service = mocker.patch("app.services.implementations.auth_service.AuthService")
-    mock_service.return_value.is_authorized_by_role.return_value = True
-    mock_service.return_value.is_authorized_by_user_id.return_value = True
-    mock_service.return_value.is_authorized_by_email.return_value = True
-    return mock_service
-
-
-@pytest.fixture
 def auth_headers() -> dict[str, str]:
     """Provide authentication headers for testing."""
     return {"Authorization": "Bearer test-token"}

--- a/backend/python/tests/test_auth_middleware.py
+++ b/backend/python/tests/test_auth_middleware.py
@@ -10,6 +10,7 @@ from typing import Any
 from unittest.mock import AsyncMock, patch
 from uuid import UUID, uuid4
 
+import firebase_admin.auth
 import pytest
 from fastapi import Depends, FastAPI
 from httpx import ASGITransport, AsyncClient
@@ -56,6 +57,26 @@ async def _get(app: FastAPI, headers: dict[str, str] | None = None) -> Any:
         return await ac.get("/protected", headers=headers or {})
 
 
+def _token(
+    *,
+    role: str = "admin",
+    uid: str = "fb-uid",
+    email: str = "user@f4k.dev",
+    email_verified: bool = True,
+) -> dict[str, Any]:
+    """A decoded Firebase ID token, verified and in good standing by default.
+
+    Tests override only the claim they are about, so ``email_verified=True``
+    does not have to be restated by every case that is not about it.
+    """
+    return {
+        "uid": uid,
+        "email": email,
+        "email_verified": email_verified,
+        "role": role,
+    }
+
+
 # ---------------------------------------------------------------------------
 # get_access_token
 # ---------------------------------------------------------------------------
@@ -84,6 +105,14 @@ class TestGetAccessToken:
 
 
 class TestRequireAuthorizationByRole:
+    """The 401/403 split is the whole point of this dependency.
+
+    A client can only act on one of two things: re-authenticate, or give up.
+    A token that cannot be verified is 401 — logging in again fixes it. A
+    verified token whose role is wrong is 403 — logging in again never will.
+    These used to arrive as one boolean, so both answered 403.
+    """
+
     @pytest.mark.asyncio
     async def test_authorized_role_passes(self) -> None:
         """User with matching role gets 200."""
@@ -91,43 +120,118 @@ class TestRequireAuthorizationByRole:
         app = _make_app(dep)
 
         with patch(
-            "app.dependencies.auth.auth_service.is_authorized_by_role",
-            new_callable=AsyncMock,
-            return_value=True,
+            "app.dependencies.auth.firebase_admin.auth.verify_id_token",
+            return_value=_token(role="admin"),
         ):
             resp = await _get(app, {"Authorization": "Bearer tok"})
 
         assert resp.status_code == 200
 
     @pytest.mark.asyncio
-    async def test_unauthorized_role_returns_403(self) -> None:
-        """User without matching role gets 403."""
+    async def test_wrong_role_returns_403(self) -> None:
+        """Identity is established; the role simply is not allowed here."""
         dep = require_authorization_by_role({"admin"})
         app = _make_app(dep)
 
         with patch(
-            "app.dependencies.auth.auth_service.is_authorized_by_role",
-            new_callable=AsyncMock,
-            return_value=False,
+            "app.dependencies.auth.firebase_admin.auth.verify_id_token",
+            return_value=_token(role="driver"),
         ):
             resp = await _get(app, {"Authorization": "Bearer tok"})
 
         assert resp.status_code == 403
 
     @pytest.mark.asyncio
-    async def test_multiple_roles_any_match_passes(self) -> None:
+    async def test_missing_role_claim_returns_403(self) -> None:
+        """No role claim cannot satisfy any role set."""
+        dep = require_authorization_by_role({"admin"})
+        app = _make_app(dep)
+
+        token = _token()
+        del token["role"]
+
+        with patch(
+            "app.dependencies.auth.firebase_admin.auth.verify_id_token",
+            return_value=token,
+        ):
+            resp = await _get(app, {"Authorization": "Bearer tok"})
+
+        assert resp.status_code == 403
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "failure",
+        [
+            firebase_admin.auth.RevokedIdTokenError("revoked"),
+            firebase_admin.auth.InvalidIdTokenError("malformed"),
+            ValueError("not a JWT"),
+            Exception("network blip reaching Firebase"),
+        ],
+    )
+    async def test_unverifiable_token_returns_401(self, failure: Exception) -> None:
+        """The regression this class exists for.
+
+        Each of these used to be swallowed into ``False`` and answered with
+        403, so a client could not tell an ended session from a permission it
+        would never be granted. ``RevokedIdTokenError`` is the one that bit
+        us: re-seeding rewrote Firebase passwords, revoking every outstanding
+        token, and the app reported it as "forbidden".
+        """
+        dep = require_authorization_by_role({"admin"})
+        app = _make_app(dep)
+
+        with patch(
+            "app.dependencies.auth.firebase_admin.auth.verify_id_token",
+            side_effect=failure,
+        ):
+            resp = await _get(app, {"Authorization": "Bearer tok"})
+
+        assert resp.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_unverified_email_returns_403(self) -> None:
+        """Enforced for every caller, admins included, as elsewhere in this
+        module. The role gate used to skip this bar entirely."""
+        dep = require_authorization_by_role({"admin"})
+        app = _make_app(dep)
+
+        with patch(
+            "app.dependencies.auth.firebase_admin.auth.verify_id_token",
+            return_value=_token(role="admin", email_verified=False),
+        ):
+            resp = await _get(app, {"Authorization": "Bearer tok"})
+
+        assert resp.status_code == 403
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("role", ["admin", "driver"])
+    async def test_multiple_roles_any_match_passes(self, role: str) -> None:
         """User matching any role in the set gets 200."""
         dep = require_authorization_by_role({"admin", "driver"})
         app = _make_app(dep)
 
         with patch(
-            "app.dependencies.auth.auth_service.is_authorized_by_role",
-            new_callable=AsyncMock,
-            return_value=True,
+            "app.dependencies.auth.firebase_admin.auth.verify_id_token",
+            return_value=_token(role=role),
         ):
             resp = await _get(app, {"Authorization": "Bearer tok"})
 
         assert resp.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_revocation_is_checked(self) -> None:
+        """Without ``check_revoked`` a revoked token stays valid until it
+        expires, so a mid-session revocation would go unnoticed for an hour."""
+        dep = require_authorization_by_role({"admin"})
+        app = _make_app(dep)
+
+        with patch(
+            "app.dependencies.auth.firebase_admin.auth.verify_id_token",
+            return_value=_token(role="admin"),
+        ) as verify:
+            await _get(app, {"Authorization": "Bearer tok"})
+
+        assert verify.call_args.kwargs["check_revoked"] is True
 
 
 # ---------------------------------------------------------------------------
@@ -141,9 +245,8 @@ class TestRequireAdmin:
         app = _make_app(require_admin)
 
         with patch(
-            "app.dependencies.auth.auth_service.is_authorized_by_role",
-            new_callable=AsyncMock,
-            return_value=True,
+            "app.dependencies.auth.firebase_admin.auth.verify_id_token",
+            return_value=_token(role="admin"),
         ):
             resp = await _get(app, {"Authorization": "Bearer tok"})
 
@@ -154,13 +257,26 @@ class TestRequireAdmin:
         app = _make_app(require_admin)
 
         with patch(
-            "app.dependencies.auth.auth_service.is_authorized_by_role",
-            new_callable=AsyncMock,
-            return_value=False,
+            "app.dependencies.auth.firebase_admin.auth.verify_id_token",
+            return_value=_token(role="driver"),
         ):
             resp = await _get(app, {"Authorization": "Bearer tok"})
 
         assert resp.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_revoked_token_returns_401_not_403(self) -> None:
+        """The pre-built dependency guards most admin endpoints, so this is
+        the path a signed-out admin actually hits."""
+        app = _make_app(require_admin)
+
+        with patch(
+            "app.dependencies.auth.firebase_admin.auth.verify_id_token",
+            side_effect=firebase_admin.auth.RevokedIdTokenError("revoked"),
+        ):
+            resp = await _get(app, {"Authorization": "Bearer tok"})
+
+        assert resp.status_code == 401
 
 
 # ---------------------------------------------------------------------------

--- a/backend/python/tests/test_routes.py
+++ b/backend/python/tests/test_routes.py
@@ -107,18 +107,13 @@ class TestDriverRoutes:
     ) -> None:
         """Test POST /drivers creates a new driver."""
 
-        # We don't want to actually to send an email so we mock the call
-        with (
-            patch(
-                "app.services.implementations.email_dispatcher.EmailDispatcher.dispatch",
-                new_callable=AsyncMock,
-                return_value=None,
-            ),
-            patch(
-                "app.dependencies.auth.auth_service.is_authorized_by_role",
-                new_callable=AsyncMock,
-                return_value=True,
-            ),
+        # We don't want to actually to send an email so we mock the call.
+        # Authorization needs no patching: conftest overrides the role
+        # dependencies outright.
+        with patch(
+            "app.services.implementations.email_dispatcher.EmailDispatcher.dispatch",
+            new_callable=AsyncMock,
+            return_value=None,
         ):
             driver_register_data = {
                 "first_name": sample_driver_data["first_name"],
@@ -5169,16 +5164,11 @@ class TestValidationErrors:
             "license_plate": "ABC123",
             "car_make_model": "Toyota Camry",
         }
-        with patch(
-            "app.dependencies.auth.auth_service.is_authorized_by_role",
-            new_callable=AsyncMock,
-            return_value=True,
-        ):
-            response = await async_client.post(
-                "/drivers/initialize",
-                json=invalid_data,
-                headers={"Authorization": "Bearer test-token"},
-            )
+        response = await async_client.post(
+            "/drivers/initialize",
+            json=invalid_data,
+            headers={"Authorization": "Bearer test-token"},
+        )
         assert response.status_code == 422
 
     @pytest.mark.asyncio

--- a/frontend/src/api/authStore.ts
+++ b/frontend/src/api/authStore.ts
@@ -15,9 +15,18 @@ interface AuthState {
   } | null;
   isAuthenticated: boolean;
   isRestoringSession: boolean;
+  /**
+   * The session ended on its own rather than by logging out — the token was
+   * expired, or revoked out from under us. Distinguishes "we signed you out"
+   * from "you were never signed in", which the login page needs in order to
+   * explain itself to someone who was working a moment ago.
+   */
+  sessionExpired: boolean;
   setAuth: (authData: AuthResponse) => void;
   setAuthFromRegister: (registerData: DriverRegisterResponse) => void;
   clearAuth: () => void;
+  /** Sign out because the server rejected our token. See `axiosClient`. */
+  expireSession: () => void;
 }
 
 export const useAuthStore = create<AuthState>((set) => ({
@@ -25,6 +34,7 @@ export const useAuthStore = create<AuthState>((set) => ({
   user: null,
   isAuthenticated: false,
   isRestoringSession: true,
+  sessionExpired: false,
 
   // Called after a successful Login
   setAuth: (authData) =>
@@ -40,6 +50,8 @@ export const useAuthStore = create<AuthState>((set) => ({
       },
       isAuthenticated: true,
       isRestoringSession: false,
+      // Whatever ended the last session, this one supersedes it.
+      sessionExpired: false,
     }),
 
   // Called after a successful Registration
@@ -57,6 +69,7 @@ export const useAuthStore = create<AuthState>((set) => ({
       },
       isAuthenticated: true,
       isRestoringSession: false,
+      sessionExpired: false,
     }),
 
   clearAuth: () =>
@@ -65,5 +78,15 @@ export const useAuthStore = create<AuthState>((set) => ({
       user: null,
       isAuthenticated: false,
       isRestoringSession: false,
+      sessionExpired: false,
+    }),
+
+  expireSession: () =>
+    set({
+      accessToken: null,
+      user: null,
+      isAuthenticated: false,
+      isRestoringSession: false,
+      sessionExpired: true,
     }),
 }));

--- a/frontend/src/lib/axiosClient.test.ts
+++ b/frontend/src/lib/axiosClient.test.ts
@@ -1,6 +1,8 @@
 import type { AxiosResponse, InternalAxiosRequestConfig } from 'axios';
+import { AxiosError } from 'axios';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
+import { useAuthStore } from '@/api/authStore';
 import {
   applyLocationImport,
   createLocationGroup,
@@ -20,6 +22,9 @@ import axiosClient from '@/lib/axiosClient';
  * They assert on the config the *adapter* receives on purpose: that is the last
  * point before the wire, after interceptors and transformRequest have run, so a
  * regression anywhere along that chain is caught rather than just in one layer.
+ *
+ * The second half covers the response side: which failures end the session and,
+ * just as importantly, which must not.
  */
 
 const XLSX_TYPE =
@@ -165,5 +170,146 @@ describe('JSON operations are unaffected', () => {
       name: 'Tuesday A',
       location_ids: [],
     });
+  });
+});
+
+/**
+ * A 401 ends the session; nothing else does.
+ *
+ * The backend used to answer a revoked or expired token with 403, the same
+ * status it uses for "you are not allowed here", so the client had no way to
+ * act on either. Now that they are distinct, acting on the wrong one is the
+ * failure mode worth guarding: treating 403 as an ended session would bounce a
+ * driver who wandered into an admin route to the login page, where logging in
+ * successfully would return them to the same 403, forever.
+ */
+describe('session expiry', () => {
+  /**
+   * Answer the next request with this status instead of 200.
+   *
+   * Rejecting rather than resolving is what a real adapter does: it runs
+   * axios's `settle`, which applies `validateStatus` and rejects on a non-2xx.
+   * An adapter that merely resolves with `{ status: 401 }` skips that check
+   * entirely, so nothing would ever reach the error interceptor and every
+   * assertion here would pass against a client that does nothing.
+   */
+  function respondWith(status: number) {
+    axiosClient.defaults.adapter = async (config) => {
+      sent = config;
+      const response = {
+        data: { detail: 'nope' },
+        status,
+        statusText: 'Error',
+        headers: {},
+        config,
+      } as AxiosResponse;
+      throw new AxiosError(
+        `Request failed with status code ${status}`,
+        AxiosError.ERR_BAD_REQUEST,
+        config,
+        null,
+        response
+      );
+    };
+  }
+
+  function signedIn() {
+    useAuthStore.setState({
+      accessToken: 'token-abc',
+      user: null,
+      isAuthenticated: true,
+      isRestoringSession: false,
+      sessionExpired: false,
+    });
+  }
+
+  async function attempt() {
+    await expect(
+      createLocationGroup({
+        body: { name: 'Tuesday A', location_ids: [] },
+        throwOnError: true,
+      })
+    ).rejects.toBeDefined();
+  }
+
+  beforeEach(() => {
+    useAuthStore.getState().clearAuth();
+  });
+
+  afterEach(() => {
+    useAuthStore.getState().clearAuth();
+  });
+
+  it('signs the user out when a request with a token gets a 401', async () => {
+    signedIn();
+    respondWith(401);
+
+    await attempt();
+
+    const state = useAuthStore.getState();
+    expect(state.isAuthenticated).toBe(false);
+    expect(state.accessToken).toBeNull();
+    expect(state.sessionExpired).toBe(true);
+  });
+
+  it('leaves a 401 on an unauthenticated request alone', async () => {
+    // The session-restore call on a first visit. Nobody was signed in, so
+    // there is no session to report as ended.
+    respondWith(401);
+
+    await attempt();
+
+    expect(useAuthStore.getState().sessionExpired).toBe(false);
+  });
+
+  it.each([403, 404, 422, 500])(
+    'does not sign the user out on a %i',
+    async (status) => {
+      signedIn();
+      respondWith(status);
+
+      await attempt();
+
+      const state = useAuthStore.getState();
+      expect(state.isAuthenticated).toBe(true);
+      expect(state.accessToken).toBe('token-abc');
+      expect(state.sessionExpired).toBe(false);
+    }
+  );
+
+  it('leaves the session alone when the request never got a response', async () => {
+    signedIn();
+    axiosClient.defaults.adapter = async () => {
+      throw new Error('Network Error');
+    };
+
+    await attempt();
+
+    expect(useAuthStore.getState().isAuthenticated).toBe(true);
+  });
+
+  it('still rejects, so callers can handle the failure themselves', async () => {
+    signedIn();
+    respondWith(401);
+
+    await expect(
+      createLocationGroup({
+        body: { name: 'Tuesday A', location_ids: [] },
+        throwOnError: true,
+      })
+    ).rejects.toMatchObject({ response: { status: 401 } });
+  });
+
+  it('does not disturb a successful response', async () => {
+    signedIn();
+
+    await createLocationGroup({
+      body: { name: 'Tuesday A', location_ids: [] },
+      throwOnError: true,
+    });
+
+    const state = useAuthStore.getState();
+    expect(state.isAuthenticated).toBe(true);
+    expect(state.sessionExpired).toBe(false);
   });
 });

--- a/frontend/src/lib/axiosClient.ts
+++ b/frontend/src/lib/axiosClient.ts
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import axios, { isAxiosError } from 'axios';
 
 import { useAuthStore } from '@/api/authStore';
 
@@ -26,6 +26,29 @@ axiosClient.interceptors.request.use((config) => {
     config.headers.Authorization = `Bearer ${token}`;
   }
   return config;
+});
+
+// A 401 means the token we sent is no longer good — expired, or revoked out
+// from under us. There is nothing to retry with: revocation invalidates the
+// refresh token too, so the session is genuinely over and the only way forward
+// is logging in again. Clearing auth is enough to get there; `AuthProvider`
+// already sends an unauthenticated visitor to /login.
+//
+// Only requests that actually carried a token count. Without this guard, the
+// session-restore call that 401s on every first visit — the ordinary state of
+// someone who simply is not logged in — would announce an expired session to a
+// person who never had one.
+//
+// A 403 is deliberately left alone. It means the server knows exactly who we
+// are and this is not ours; logging in again would land the same 403, so
+// bouncing to the login page would only produce a loop.
+axiosClient.interceptors.response.use(undefined, (error: unknown) => {
+  if (isAxiosError(error) && error.response?.status === 401) {
+    if (error.config?.headers?.Authorization) {
+      useAuthStore.getState().expireSession();
+    }
+  }
+  return Promise.reject(error);
 });
 
 export default axiosClient;

--- a/frontend/src/pages/auth/LoginPage.tsx
+++ b/frontend/src/pages/auth/LoginPage.tsx
@@ -2,6 +2,7 @@ import { type FormEvent, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 
 import { describeApiFailure, useLogin } from '@/api';
+import { useAuthStore } from '@/api/authStore';
 import EyeIcon from '@/assets/icons/eye.svg?react';
 import EyeOffIcon from '@/assets/icons/eye-off.svg?react';
 import { Button, Field, FieldLabel, Input } from '@/common/components';
@@ -37,6 +38,10 @@ const LoginForm = () => {
   const [showPassword, setShowPassword] = useState(false);
   const [rememberMe, setRememberMe] = useState(false);
   const [error, setError] = useState<LoginError | null>(null);
+
+  // Someone sent here by an expired session was working a moment ago and did
+  // nothing wrong, so say what happened rather than presenting a bare form.
+  const sessionExpired = useAuthStore((state) => state.sessionExpired);
 
   const credentialsError = error?.scope === 'credentials';
 
@@ -152,9 +157,17 @@ const LoginForm = () => {
           </div>
 
           {/* Failures that aren't the credentials' fault get one note for the
-              whole form, not a red outline on fields that may be perfectly fine. */}
-          {error?.scope === 'form' && (
+              whole form, not a red outline on fields that may be perfectly fine.
+              A note about *this* attempt supersedes one about the last session. */}
+          {error?.scope === 'form' ? (
             <ErrorNote className="-mb-4">{error.message}</ErrorNote>
+          ) : (
+            !error &&
+            sessionExpired && (
+              <ErrorNote className="-mb-4">
+                Your session ended. Please log in again.
+              </ErrorNote>
+            )
           )}
 
           {/* Log In Button */}


### PR DESCRIPTION
## Why

`require_authorization_by_role` ran through `auth_service.is_authorized_by_role`, which wrapped `verify_id_token` in `except Exception: return False`. Five different situations arrived at the caller as the same boolean:

- token revoked (what re-seeding caused — see #244)
- token expired
- token malformed
- a network blip reaching Firebase
- a genuine "you are a driver and this is an admin route"

All five were answered **403**.

That flattening is the bug. A client can act on exactly one distinction: re-authenticate, or give up. **401** means "we don't know who you are" and logging in again fixes it. **403** means "we know exactly who you are, and this is not yours" and logging in again never will. With both reported as 403, the frontend could not send an ended session to the login page without also trapping a driver who had wandered into an admin route in a loop — log in, get 403, get sent back to log in.

Sixty lines up, the same module already did this correctly: `_verified_token` raises 401 on verification failure and reserves 403 for verified-but-not-permitted. Every other dependency in the file uses it. The role gate was the one holdout, and the one place the information was destroyed.

## What

The boolean goes. `check_role` calls `_verified_token` and checks the `role` claim on the decoded token — a deletion, not a new branch.

Two things carried across from the deleted code, both easy to lose silently:

- **`clock_skew_seconds=5`**, which `_verified_token` did not have. It keeps a client whose clock runs slightly fast from having a freshly minted token rejected as issued in the future.
- **The log line naming the underlying failure.** Without it a revoked token becomes invisible server-side again — exactly what #243 just fixed for 422s. The response still says only "invalid or expired"; which of revoked/expired/malformed it was goes to the log, where it is the difference between "log back in" and "something is wrong with us".

Also removed: `is_authorized_by_email`, same swallow, no callers outside a conftest fixture nothing used (one of its three lines already mocked a method that no longer existed). And the role dependency no longer takes a `session` it never used, so role-guarded endpoints stop opening a database session just to read a JWT claim.

### One behaviour tightens

Role-guarded routes now enforce `email_verified`, the bar `_verified_token` applies and the rest of the module already relies on. Every account this app creates sets it — `user_service.py:121` at creation, and the seed script — so nothing is locked out. The role gate was simply the one path skipping it.

## Frontend

A 401 on a request **that carried a token** clears auth; `AuthProvider` already sends an unauthenticated visitor to `/login`, so no new routing.

The token guard matters: without it, the session-restore call that 401s on every first visit — the ordinary state of someone who is not logged in — would announce an expired session to a person who never had one. 403 is deliberately left alone, for the loop described above.

The login page says the session ended rather than presenting a bare form to someone who was working a moment ago.

There is a small irony here: #242 deleted a response interceptor whose comment promised "redirect on 401" while doing nothing. This is that interceptor, actually doing it.

## Tests

**Backend** — the role tests now mock `verify_id_token`, the same seam as every other test in the file. That change is what makes the split assertable at all; mocking the old boolean could not express the difference. Revoked / invalid / unverifiable each pin 401; wrong role, missing role claim, and unverified email pin 403. Plus a test that `check_revoked` is actually passed, since without it a revoked token stays good for up to an hour.

**Frontend** — 7 new tests, verified in both directions:

- disabling the interceptor fails **1**
- making it fire on every error fails the other **6**

so neither the behaviour nor its guards pass vacuously. Fixing these also turned up a flaw in the test harness itself: an adapter that merely resolves with `{status: 401}` skips axios's `settle`, so nothing reaches the error interceptor and every assertion would have passed against a client that does nothing. The fake now rejects the way a real adapter does.

Full backend suite 600 passed; frontend 22 passed, `tsc`, `eslint` and `prettier` clean.

**Not verified in a browser:** the login-page note itself. It reuses the existing `ErrorNote` component and its condition is covered by `tsc`/lint, but I did not stand up a second dev server to look at it, since the running stack is in use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)