### PR TITLE
Skip the validate step when the import preview is clean

### DIFF
--- a/frontend/src/pages/admin/routes/generation/ImportStep.tsx
+++ b/frontend/src/pages/admin/routes/generation/ImportStep.tsx
@@ -200,7 +200,13 @@ export function ImportStep() {
         deliveryType: selectedDeliveryType,
       });
       setReviewResult(result);
-      navigate('/admin/routes/generation/validate');
+      // A clean preview leaves the validate step with nothing to show and
+      // nothing to fix, so go straight to review.
+      navigate(
+        result.success
+          ? '/admin/routes/generation/review'
+          : '/admin/routes/generation/validate'
+      );
     } catch {
       setReviewError('Could not validate the file — please try again.');
     }

--- a/frontend/src/pages/admin/routes/generation/ReviewStep.tsx
+++ b/frontend/src/pages/admin/routes/generation/ReviewStep.tsx
@@ -369,7 +369,13 @@ export function ReviewStep() {
 
       <GenerationFooter>
         <Button variant="tertiary" asChild>
-          <Link to="/admin/routes/generation/validate">Back to validate</Link>
+          {/* Import skips validate when the preview is clean, so back goes
+              wherever the admin actually came from. */}
+          {reviewResult.success ? (
+            <Link to="/admin/routes/generation/import">Back to import</Link>
+          ) : (
+            <Link to="/admin/routes/generation/validate">Back to validate</Link>
+          )}
         </Button>
         <Button
           variant="primary"


### PR DESCRIPTION
During route generation, when the import preview comes back with no validation errors, the Validate step shows two empty tables and one enabled button — a click that carries no information. This skips straight to Review Changes in that case.

- `ImportStep` navigates to `review` instead of `validate` when `result.success` is true.
- `ReviewStep`'s back button points at Import rather than Validate in that case, so it matches where the admin actually came from.

The stepper still derives its state from the pathname, so Review shows as step 3 with Validate behind it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)