### PR TITLE
F4KRP-49: Wire route generation

### DIFF
--- a/backend/python/app/__init__.py
+++ b/backend/python/app/__init__.py
@@ -147,11 +147,7 @@ async def lifespan(_app: FastAPI) -> AsyncGenerator[None, None]:
         await session.commit()
         await init_jobs(scheduler_service, session)
 
-        # Start the worker before the startup sweep so a recover-time wake is
-        # not cleared by start_route_generation_worker().
         start_route_generation_worker()
-        # Fail jobs left RUNNING across a reload/restart, and wake the worker
-        # if any PENDING work survived in the durable queue.
         await recover_route_generation_jobs(session)
 
     yield

--- a/backend/python/app/__init__.py
+++ b/backend/python/app/__init__.py
@@ -13,6 +13,11 @@ from app.dependencies.services import (
     get_scheduler_service,
     get_system_settings_service,
 )
+from app.services.implementations.route_generation_worker import (
+    recover_route_generation_jobs,
+    start_route_generation_worker,
+    stop_route_generation_worker,
+)
 from app.services.jobs import init_jobs
 
 from .config import settings
@@ -142,9 +147,17 @@ async def lifespan(_app: FastAPI) -> AsyncGenerator[None, None]:
         await session.commit()
         await init_jobs(scheduler_service, session)
 
+        # Start the worker before the startup sweep so a recover-time wake is
+        # not cleared by start_route_generation_worker().
+        start_route_generation_worker()
+        # Fail jobs left RUNNING across a reload/restart, and wake the worker
+        # if any PENDING work survived in the durable queue.
+        await recover_route_generation_jobs(session)
+
     yield
 
-    # Cleanup: stop the scheduler service during application shutdown
+    # Cleanup: stop background work before tearing down the scheduler.
+    await stop_route_generation_worker()
     scheduler_service.stop()
 
 

--- a/backend/python/app/dependencies/services.py
+++ b/backend/python/app/dependencies/services.py
@@ -22,11 +22,11 @@ from app.services.implementations.auth_service import AuthService
 from app.services.implementations.driver_service import DriverService
 from app.services.implementations.email_dispatcher import EmailDispatcher
 from app.services.implementations.email_service import EmailService
+from app.services.implementations.google_maps_routing_service import (
+    GoogleMapsFleetRoutingAlgorithm,
+)
 from app.services.implementations.location_group_service import LocationGroupService
 from app.services.implementations.location_service import LocationService
-from app.services.implementations.mock_routing_algorithm import (
-    MockRoutingAlgorithm,
-)
 from app.services.implementations.note_chain_service import NoteChainService
 from app.services.implementations.password_reset_token_service import (
     PasswordResetTokenService,
@@ -155,11 +155,12 @@ def get_route_group_service() -> RouteGroupService:
 
 @lru_cache
 def get_routing_algorithm() -> RoutingAlgorithmProtocol:
-    """Get routing algorithm instance (mock).
+    """Select the routing algorithm to use for route generation.
 
-    Swap this to use a different algorithm implementation.
+    Currently always returns the real Google Fleet Routing implementation.
+
     """
-    return MockRoutingAlgorithm()
+    return GoogleMapsFleetRoutingAlgorithm()
 
 
 @lru_cache

--- a/backend/python/app/routers/job_routes.py
+++ b/backend/python/app/routers/job_routes.py
@@ -38,6 +38,7 @@ async def generate_job(
     service: JobService = Depends(get_job_service),
     _auth: bool = Depends(require_driver_or_admin),
 ) -> JobEnqueueResponse:
+    """Accept a generation request: persist it as PENDING and wake the worker."""
     job_id = await service.generate_job(req)
     await service.enqueue(job_id)
     return JobEnqueueResponse(job_id=job_id)

--- a/backend/python/app/services/implementations/job_service.py
+++ b/backend/python/app/services/implementations/job_service.py
@@ -147,6 +147,16 @@ class JobService:
             raise error
 
     async def enqueue(self, job_id: UUID) -> None:
+        """Wake route-generation worker for a pending job.
+
+        Does not claim or run the job; that is the worker's job. A cancelled
+        (or otherwise non-pending) job is left alone so a late enqueue cannot
+        resurrect work that an admin already stopped.
+        """
+        from app.services.implementations.route_generation_worker import (
+            wake_route_generation_worker,
+        )
+
         try:
             job = await self.get_job(job_id)
 
@@ -162,13 +172,6 @@ class JobService:
                 )
                 return
 
-            job.progress = ProgressEnum.RUNNING
-            job.started_at = self.est_now_naive()
-            self.session.add(job)
-            await self.session.commit()
+            wake_route_generation_worker()
         except Exception:
             self.logger.exception("Enqueue failed for job %s", job_id)
-            try:
-                await self.update_progress(job_id, ProgressEnum.FAILED)
-            except Exception:
-                self.logger.exception("Failed to mark job %s as FAILED", job_id)

--- a/backend/python/app/services/implementations/job_service.py
+++ b/backend/python/app/services/implementations/job_service.py
@@ -11,6 +11,9 @@ from sqlmodel import col, select
 from app.models.enum import ProgressEnum
 from app.models.job import Job
 from app.schemas.route_generation import RouteGenerationGroupInput
+from app.services.implementations.route_generation_worker import (
+    wake_route_generation_worker,
+)
 
 if TYPE_CHECKING:
     from sqlalchemy.engine import CursorResult
@@ -153,10 +156,6 @@ class JobService:
         (or otherwise non-pending) job is left alone so a late enqueue cannot
         resurrect work that an admin already stopped.
         """
-        from app.services.implementations.route_generation_worker import (
-            wake_route_generation_worker,
-        )
-
         try:
             job = await self.get_job(job_id)
 

--- a/backend/python/app/services/implementations/job_service.py
+++ b/backend/python/app/services/implementations/job_service.py
@@ -174,3 +174,4 @@ class JobService:
             wake_route_generation_worker()
         except Exception:
             self.logger.exception("Enqueue failed for job %s", job_id)
+            raise

--- a/backend/python/app/services/implementations/route_generation_runner.py
+++ b/backend/python/app/services/implementations/route_generation_runner.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import time
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, cast
 from zoneinfo import ZoneInfo
@@ -79,6 +80,7 @@ async def run_generation_job(
     cancelled along the way, in which case the cancellation stands and
     nothing is saved.
     """
+    started = time.perf_counter()
     try:
         job = await _load_running_job(session, job_id)
         if job is None:
@@ -88,13 +90,30 @@ async def run_generation_job(
         group, locations = await _resolve_locations(session, request.location_group)
         warehouse_lat, warehouse_lon = await _resolve_warehouse(session)
 
+        logger.info(
+            "Job %s generating with %s for %d location(s) in group '%s' "
+            "(%d route(s) requested).",
+            job_id,
+            type(algorithm).__name__,
+            len(locations),
+            group.name,
+            request.settings.num_routes,
+        )
+
         async with asyncio.timeout(GENERATION_TIMEOUT_SECONDS):
+            engine_started = time.perf_counter()
             clusters = await algorithm.generate_routes(
                 locations,
                 warehouse_lat,
                 warehouse_lon,
                 request.settings,
                 timeout_seconds=ENGINE_TIMEOUT_SECONDS,
+            )
+            logger.info(
+                "Job %s routing engine finished in %.1fs (%d non-empty cluster(s)).",
+                job_id,
+                time.perf_counter() - engine_started,
+                sum(1 for cluster in clusters if cluster),
             )
             route_group = await _build_route_group(
                 group, request.settings, clusters, warehouse_lat, warehouse_lon
@@ -105,6 +124,12 @@ async def run_generation_job(
     except GenerationFailed as error:
         await _fail(session, job_id, str(error))
     except TimeoutError:
+        logger.warning(
+            "Job %s hit the %.0fs generation budget after %.1fs.",
+            job_id,
+            GENERATION_TIMEOUT_SECONDS,
+            time.perf_counter() - started,
+        )
         await _fail(
             session,
             job_id,
@@ -112,9 +137,19 @@ async def run_generation_job(
             "fewer locations or routes.",
         )
     except HTTPException as error:
+        logger.warning(
+            "Job %s routing API error after %.1fs: %s",
+            job_id,
+            time.perf_counter() - started,
+            error.detail,
+        )
         await _fail(session, job_id, f"Routing API error: {error.detail}")
     except Exception as error:
-        logger.exception("Route generation job %s hit an unexpected error", job_id)
+        logger.exception(
+            "Route generation job %s hit an unexpected error after %.1fs",
+            job_id,
+            time.perf_counter() - started,
+        )
         await _fail(session, job_id, f"Unexpected error: {error}")
 
 
@@ -129,8 +164,8 @@ async def _load_running_job(session: AsyncSession, job_id: UUID) -> Job | None:
         return None
 
     if job.progress != ProgressEnum.RUNNING:
-        logger.warning(
-            "Not running job %s: expected it to be Running, found %s.",
+        logger.info(
+            "Skipping job %s: no longer Running (now %s), most likely cancelled.",
             job_id,
             job.progress,
         )
@@ -262,7 +297,7 @@ async def _build_route_group(
     name = f"{group.name} - {settings.route_start_time:%Y-%m-%d}"
     route_group = RouteGroup(
         name=name[:ROUTE_GROUP_NAME_MAX_LENGTH],
-        drive_date=settings.route_start_time,
+        drive_date=settings.route_start_time.date(),
     )
 
     for number, cluster in enumerate(filled, start=1):
@@ -325,8 +360,6 @@ async def _save_or_discard(
                 total_families=len(
                     {stop.location_id for route in routes for stop in route.route_stops}
                 ),
-                # Job opts out of the automatic updated_at bump (its
-                # timestamps start null), so a Core update sets it by hand.
                 updated_at=now,
                 finished_at=now,
             )
@@ -344,6 +377,13 @@ async def _save_or_discard(
         return
 
     await session.commit()
+    logger.info(
+        "Job %s completed: route_group=%s routes=%d stops=%d.",
+        job_id,
+        route_group.route_group_id,
+        len(routes),
+        sum(len(route.route_stops) for route in routes),
+    )
 
 
 async def _fail(session: AsyncSession, job_id: UUID, message: str) -> None:
@@ -356,15 +396,24 @@ async def _fail(session: AsyncSession, job_id: UUID, message: str) -> None:
 
     await session.rollback()
     now = _now_est_naive()
-    await session.execute(
-        update(Job)
-        .where(col(Job.job_id) == job_id)
-        .where(col(Job.progress) != ProgressEnum.CANCELLED)
-        .values(
-            progress=ProgressEnum.FAILED,
-            error_message=message,
-            updated_at=now,
-            finished_at=now,
-        )
+    result = cast(
+        "CursorResult[Any]",
+        await session.execute(
+            update(Job)
+            .where(col(Job.job_id) == job_id)
+            .where(col(Job.progress) == ProgressEnum.RUNNING)
+            .values(
+                progress=ProgressEnum.FAILED,
+                error_message=message,
+                updated_at=now,
+                finished_at=now,
+            )
+        ),
     )
     await session.commit()
+    if not result.rowcount:
+        logger.warning(
+            "Job %s failure was not recorded: it was no longer Running "
+            "(likely cancelled).",
+            job_id,
+        )

--- a/backend/python/app/services/implementations/route_generation_runner.py
+++ b/backend/python/app/services/implementations/route_generation_runner.py
@@ -79,6 +79,11 @@ async def run_generation_job(
     summary recorded) or `FAILED` (with `error_message` set), unless it was
     cancelled along the way, in which case the cancellation stands and
     nothing is saved.
+
+    TODO(cancel): Honor POST /jobs/{id}/cancel cooperatively via the jobs row:
+    if progress is no longer Running at load/save/fail checkpoints, exit without
+    completing or overwriting Cancelled. Do not try to abort the in-flight
+    routing call — discard results instead.
     """
     started = time.perf_counter()
     try:
@@ -154,7 +159,11 @@ async def run_generation_job(
 
 
 async def _load_running_job(session: AsyncSession, job_id: UUID) -> Job | None:
-    """Fetch the job, if it is still ours to run."""
+    """Fetch the job, if it is still ours to run.
+
+    TODO(cancel): If POST /jobs/{id}/cancel flipped this job to Cancelled before
+    we start real work, return None here so generation never begins.
+    """
     job = (
         await session.execute(select(Job).where(Job.job_id == job_id))
     ).scalar_one_or_none()
@@ -339,6 +348,10 @@ async def _save_or_discard(
     routing engine is working takes the routes with them, instead of leaving
     a RouteGroup attached to a cancelled job, `update_progress` would refuse
     to overwrite the cancellation, and the routes would be stranded.
+
+    TODO(cancel): When POST /jobs/{id}/cancel sets Cancelled mid-run, this
+    Running-only UPDATE must miss (rowcount 0), roll back the RouteGroup, and
+    leave the Cancelled row alone.
     """
     session.add(route_group)
     await session.flush()
@@ -391,6 +404,9 @@ async def _fail(session: AsyncSession, job_id: UUID, message: str) -> None:
 
     Guarded the same way `JobService.update_progress` is, so a job an admin
     already cancelled stays cancelled instead of resurfacing as a failure.
+
+    TODO(cancel): If POST /jobs/{id}/cancel already set Cancelled, this
+    Running-only failure UPDATE must no-op so Cancelled is not overwritten.
     """
     logger.warning("Route generation job %s failed: %s", job_id, message)
 

--- a/backend/python/app/services/implementations/route_generation_runner.py
+++ b/backend/python/app/services/implementations/route_generation_runner.py
@@ -287,7 +287,9 @@ async def _build_route_group(
 
     The engine only says who rides on which route and in what order; the line
     drawn on the map and the distance come from a second call each, so this
-    is one `fetch_route_polyline` per route.
+    is one `fetch_route_polyline` per route. Those HTTP calls run concurrently
+    via ``asyncio.gather`` so they share the remaining generation timeout
+    instead of stacking end-to-end.
 
     Nothing here touches the session, because the caller may still throw the
     whole thing away if the job was cancelled while these calls were running.
@@ -304,13 +306,22 @@ async def _build_route_group(
         drive_date=settings.route_start_time.date(),
     )
 
-    for number, cluster in enumerate(filled, start=1):
-        encoded_polyline, distance_km = await fetch_route_polyline(
-            locations=cluster,
-            warehouse_lat=warehouse_lat,
-            warehouse_lon=warehouse_lon,
-            ends_at_warehouse=settings.return_to_warehouse,
+    polyline_results = await asyncio.gather(
+        *(
+            fetch_route_polyline(
+                locations=cluster,
+                warehouse_lat=warehouse_lat,
+                warehouse_lon=warehouse_lon,
+                ends_at_warehouse=settings.return_to_warehouse,
+            )
+            for cluster in filled
         )
+    )
+
+    for number, (cluster, (encoded_polyline, distance_km)) in enumerate(
+        zip(filled, polyline_results, strict=True),
+        start=1,
+    ):
         route = Route(
             name=f"Route {number}",
             length=distance_km,

--- a/backend/python/app/services/implementations/route_generation_runner.py
+++ b/backend/python/app/services/implementations/route_generation_runner.py
@@ -20,7 +20,6 @@ import logging
 import time
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, cast
-from zoneinfo import ZoneInfo
 
 from fastapi import HTTPException
 from pydantic import ValidationError
@@ -39,6 +38,7 @@ from app.schemas.route_generation import RouteGenerationGroupInput
 from app.services.implementations.route_group_service import (
     ROUTE_GROUP_NAME_MAX_LENGTH,
 )
+from app.utilities.datetime_utils import now_est_naive
 from app.utilities.routes_utils import fetch_route_polyline
 
 if TYPE_CHECKING:
@@ -62,10 +62,6 @@ class GenerationFailed(Exception):
 
     Caught by `run_generation_job`, which stores the message on the job.
     """
-
-
-def _now_est_naive() -> datetime:
-    return datetime.now(ZoneInfo("America/New_York")).replace(tzinfo=None)
 
 
 async def run_generation_job(
@@ -357,7 +353,7 @@ async def _save_or_discard(
     await session.flush()
 
     routes = route_group.routes
-    now = _now_est_naive()
+    now = now_est_naive()
     result = cast(
         "CursorResult[Any]",
         await session.execute(
@@ -411,7 +407,7 @@ async def _fail(session: AsyncSession, job_id: UUID, message: str) -> None:
     logger.warning("Route generation job %s failed: %s", job_id, message)
 
     await session.rollback()
-    now = _now_est_naive()
+    now = now_est_naive()
     result = cast(
         "CursorResult[Any]",
         await session.execute(

--- a/backend/python/app/services/implementations/route_generation_runner.py
+++ b/backend/python/app/services/implementations/route_generation_runner.py
@@ -1,0 +1,370 @@
+"""Runs one claimed route generation job end to end.
+
+Called by the background worker after it has claimed a `PENDING` job and
+marked it `RUNNING`. The session is passed in rather than opened here, and
+the algorithm is passed in rather than resolved here. That is what makes the
+runner testable: tests call it directly with the `test_session` fixture
+(whose writes are never committed, so a worker-owned session on another
+connection couldn't see them) and a fake algorithm, instead of standing up
+a worker.
+
+`run_generation_job` never raises. Every failure is recorded on the job as
+`FAILED` with a reason, because a job left sitting in `RUNNING` is a job the
+UI waits on forever.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any, cast
+from zoneinfo import ZoneInfo
+
+from fastapi import HTTPException
+from pydantic import ValidationError
+from sqlalchemy import update
+from sqlmodel import col, select
+
+from app.models.enum import ProgressEnum
+from app.models.job import Job
+from app.models.location import Location
+from app.models.location_group import LocationGroup
+from app.models.route import Route
+from app.models.route_group import RouteGroup
+from app.models.route_stop import RouteStop
+from app.models.system_settings import SystemSettings
+from app.schemas.route_generation import RouteGenerationGroupInput
+from app.services.implementations.route_group_service import (
+    ROUTE_GROUP_NAME_MAX_LENGTH,
+)
+from app.utilities.routes_utils import fetch_route_polyline
+
+if TYPE_CHECKING:
+    from uuid import UUID
+
+    from sqlalchemy.engine import CursorResult
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+    from app.schemas.route_generation import RouteGenerationSettings
+    from app.services.protocols.routing_algorithm import RoutingAlgorithmProtocol
+
+logger = logging.getLogger(__name__)
+
+GENERATION_TIMEOUT_SECONDS = 180.0
+
+ENGINE_TIMEOUT_SECONDS = 120.0
+
+
+class GenerationFailed(Exception):
+    """A job that can't go on, carrying a reason worth showing an admin.
+
+    Caught by `run_generation_job`, which stores the message on the job.
+    """
+
+
+def _now_est_naive() -> datetime:
+    return datetime.now(ZoneInfo("America/New_York")).replace(tzinfo=None)
+
+
+async def run_generation_job(
+    job_id: UUID,
+    session: AsyncSession,
+    algorithm: RoutingAlgorithmProtocol,
+) -> None:
+    """Generate and save the routes one job asked for.
+
+    Ends with the job either `COMPLETED` (with a `RouteGroup` linked and the
+    summary recorded) or `FAILED` (with `error_message` set), unless it was
+    cancelled along the way, in which case the cancellation stands and
+    nothing is saved.
+    """
+    try:
+        job = await _load_running_job(session, job_id)
+        if job is None:
+            return
+
+        request = _parse_request(job)
+        group, locations = await _resolve_locations(session, request.location_group)
+        warehouse_lat, warehouse_lon = await _resolve_warehouse(session)
+
+        async with asyncio.timeout(GENERATION_TIMEOUT_SECONDS):
+            clusters = await algorithm.generate_routes(
+                locations,
+                warehouse_lat,
+                warehouse_lon,
+                request.settings,
+                timeout_seconds=ENGINE_TIMEOUT_SECONDS,
+            )
+            route_group = await _build_route_group(
+                group, request.settings, clusters, warehouse_lat, warehouse_lon
+            )
+
+        await _save_or_discard(session, job_id, route_group)
+
+    except GenerationFailed as error:
+        await _fail(session, job_id, str(error))
+    except TimeoutError:
+        await _fail(
+            session,
+            job_id,
+            "Route generation took too long and was stopped. Try again with "
+            "fewer locations or routes.",
+        )
+    except HTTPException as error:
+        await _fail(session, job_id, f"Routing API error: {error.detail}")
+    except Exception as error:
+        logger.exception("Route generation job %s hit an unexpected error", job_id)
+        await _fail(session, job_id, f"Unexpected error: {error}")
+
+
+async def _load_running_job(session: AsyncSession, job_id: UUID) -> Job | None:
+    """Fetch the job, if it is still ours to run."""
+    job = (
+        await session.execute(select(Job).where(Job.job_id == job_id))
+    ).scalar_one_or_none()
+
+    if job is None:
+        logger.error("Route generation job %s no longer exists.", job_id)
+        return None
+
+    if job.progress != ProgressEnum.RUNNING:
+        logger.warning(
+            "Not running job %s: expected it to be Running, found %s.",
+            job_id,
+            job.progress,
+        )
+        return None
+
+    return job
+
+
+def _parse_request(job: Job) -> RouteGenerationGroupInput:
+    """Rebuild the request that POST /jobs/generate saved when it queued."""
+    if job.input_payload is None:
+        raise GenerationFailed("This job was queued without a request to run.")
+
+    try:
+        return RouteGenerationGroupInput.model_validate(job.input_payload)
+    except ValidationError as error:
+        raise GenerationFailed(
+            f"The saved generation request could not be read back: {error}"
+        ) from error
+
+
+async def _resolve_locations(
+    session: AsyncSession, requested: LocationGroup
+) -> tuple[LocationGroup, list[Location]]:
+    """Find the location group the admin picked and the locations to route.
+
+    Matched on id first and name second, because `RouteGenerationGroupInput`
+    types `location_group` as the table model, whose id defaults to a freshly
+    invented UUID. A client that sends only a name and colour, which
+    POST /jobs/generate accepts, therefore arrives here with an id matching
+    nothing at all. Name is unique and indexed, so it is a safe second key.
+    """
+    group = (
+        await session.execute(
+            select(LocationGroup).where(
+                LocationGroup.location_group_id == requested.location_group_id
+            )
+        )
+    ).scalar_one_or_none()
+
+    if group is None:
+        group = (
+            await session.execute(
+                select(LocationGroup).where(LocationGroup.name == requested.name)
+            )
+        ).scalar_one_or_none()
+
+    if group is None:
+        raise GenerationFailed(
+            f"No location group matches id {requested.location_group_id} or "
+            f"name '{requested.name}'."
+        )
+
+    locations = (
+        (
+            await session.execute(
+                select(Location).where(
+                    Location.location_group_id == group.location_group_id
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+    routable = [
+        location
+        for location in locations
+        if location.latitude is not None and location.longitude is not None
+    ]
+
+    if not routable:
+        raise GenerationFailed(
+            f"Location group '{group.name}' has no geocoded locations to route."
+        )
+
+    if len(routable) < len(locations):
+        logger.warning(
+            "Routing %d of the %d locations in group '%s'; the rest are not "
+            "geocoded yet.",
+            len(routable),
+            len(locations),
+            group.name,
+        )
+
+    return group, routable
+
+
+async def _resolve_warehouse(session: AsyncSession) -> tuple[float, float]:
+    """Read the depot every route starts from."""
+    system_settings = (
+        (await session.execute(select(SystemSettings).limit(1))).scalars().first()
+    )
+
+    latitude = system_settings.warehouse_latitude if system_settings else None
+    longitude = system_settings.warehouse_longitude if system_settings else None
+
+    if latitude is None or longitude is None:
+        raise GenerationFailed(
+            "Warehouse coordinates are not set in system settings, so there is "
+            "nowhere for the routes to start from."
+        )
+
+    return latitude, longitude
+
+
+async def _build_route_group(
+    group: LocationGroup,
+    settings: RouteGenerationSettings,
+    clusters: list[list[Location]],
+    warehouse_lat: float,
+    warehouse_lon: float,
+) -> RouteGroup:
+    """Turn the engine's output into a RouteGroup that isn't saved yet.
+
+    The engine only says who rides on which route and in what order; the line
+    drawn on the map and the distance come from a second call each, so this
+    is one `fetch_route_polyline` per route.
+
+    Nothing here touches the session, because the caller may still throw the
+    whole thing away if the job was cancelled while these calls were running.
+    """
+    filled = [cluster for cluster in clusters if cluster]
+    if not filled:
+        raise GenerationFailed(
+            "The routing engine did not place any locations onto a route."
+        )
+
+    name = f"{group.name} - {settings.route_start_time:%Y-%m-%d}"
+    route_group = RouteGroup(
+        name=name[:ROUTE_GROUP_NAME_MAX_LENGTH],
+        drive_date=settings.route_start_time,
+    )
+
+    for number, cluster in enumerate(filled, start=1):
+        encoded_polyline, distance_km = await fetch_route_polyline(
+            locations=cluster,
+            warehouse_lat=warehouse_lat,
+            warehouse_lon=warehouse_lon,
+            ends_at_warehouse=settings.return_to_warehouse,
+        )
+        route = Route(
+            name=f"Route {number}",
+            length=distance_km,
+            encoded_polyline=encoded_polyline,
+            polyline_updated_at=datetime.now(timezone.utc),
+            ends_at_warehouse=settings.return_to_warehouse,
+            route_group_id=route_group.route_group_id,
+        )
+        route_group.routes.append(route)
+
+        for stop_number, location in enumerate(cluster, start=1):
+            route.route_stops.append(
+                RouteStop(
+                    route_id=route.route_id,
+                    location_id=location.location_id,
+                    stop_number=stop_number,
+                )
+            )
+
+    return route_group
+
+
+async def _save_or_discard(
+    session: AsyncSession, job_id: UUID, route_group: RouteGroup
+) -> None:
+    """Save the routes and complete the job, or save neither.
+
+    The inserts and the job update share one transaction, and the update only
+    matches a job that is still Running. So an admin who cancels while the
+    routing engine is working takes the routes with them, instead of leaving
+    a RouteGroup attached to a cancelled job, `update_progress` would refuse
+    to overwrite the cancellation, and the routes would be stranded.
+    """
+    session.add(route_group)
+    await session.flush()
+
+    routes = route_group.routes
+    now = _now_est_naive()
+    result = cast(
+        "CursorResult[Any]",
+        await session.execute(
+            update(Job)
+            .where(col(Job.job_id) == job_id)
+            .where(col(Job.progress) == ProgressEnum.RUNNING)
+            .values(
+                progress=ProgressEnum.COMPLETED,
+                route_group_id=route_group.route_group_id,
+                routes_created=len(routes),
+                total_stops=sum(len(route.route_stops) for route in routes),
+                total_distance_km=sum(route.length for route in routes),
+                total_families=len(
+                    {stop.location_id for route in routes for stop in route.route_stops}
+                ),
+                # Job opts out of the automatic updated_at bump (its
+                # timestamps start null), so a Core update sets it by hand.
+                updated_at=now,
+                finished_at=now,
+            )
+        ),
+    )
+
+    if not result.rowcount:
+        logger.info(
+            "Job %s stopped being Running while it generated, most likely "
+            "cancelled; discarding its %d route(s).",
+            job_id,
+            len(routes),
+        )
+        await session.rollback()
+        return
+
+    await session.commit()
+
+
+async def _fail(session: AsyncSession, job_id: UUID, message: str) -> None:
+    """Undo anything half-written, then record why the job failed.
+
+    Guarded the same way `JobService.update_progress` is, so a job an admin
+    already cancelled stays cancelled instead of resurfacing as a failure.
+    """
+    logger.warning("Route generation job %s failed: %s", job_id, message)
+
+    await session.rollback()
+    now = _now_est_naive()
+    await session.execute(
+        update(Job)
+        .where(col(Job.job_id) == job_id)
+        .where(col(Job.progress) != ProgressEnum.CANCELLED)
+        .values(
+            progress=ProgressEnum.FAILED,
+            error_message=message,
+            updated_at=now,
+            finished_at=now,
+        )
+    )
+    await session.commit()

--- a/backend/python/app/services/implementations/route_generation_runner.py
+++ b/backend/python/app/services/implementations/route_generation_runner.py
@@ -75,11 +75,6 @@ async def run_generation_job(
     summary recorded) or `FAILED` (with `error_message` set), unless it was
     cancelled along the way, in which case the cancellation stands and
     nothing is saved.
-
-    TODO(cancel): Honor POST /jobs/{id}/cancel cooperatively via the jobs row:
-    if progress is no longer Running at load/save/fail checkpoints, exit without
-    completing or overwriting Cancelled. Do not try to abort the in-flight
-    routing call — discard results instead.
     """
     started = time.perf_counter()
     try:
@@ -155,11 +150,7 @@ async def run_generation_job(
 
 
 async def _load_running_job(session: AsyncSession, job_id: UUID) -> Job | None:
-    """Fetch the job, if it is still ours to run.
-
-    TODO(cancel): If POST /jobs/{id}/cancel flipped this job to Cancelled before
-    we start real work, return None here so generation never begins.
-    """
+    """Fetch the job, if it is still ours to run."""
     job = (
         await session.execute(select(Job).where(Job.job_id == job_id))
     ).scalar_one_or_none()
@@ -354,10 +345,6 @@ async def _save_or_discard(
     routing engine is working takes the routes with them, instead of leaving
     a RouteGroup attached to a cancelled job, `update_progress` would refuse
     to overwrite the cancellation, and the routes would be stranded.
-
-    TODO(cancel): When POST /jobs/{id}/cancel sets Cancelled mid-run, this
-    Running-only UPDATE must miss (rowcount 0), roll back the RouteGroup, and
-    leave the Cancelled row alone.
     """
     session.add(route_group)
     await session.flush()
@@ -410,9 +397,6 @@ async def _fail(session: AsyncSession, job_id: UUID, message: str) -> None:
 
     Guarded the same way `JobService.update_progress` is, so a job an admin
     already cancelled stays cancelled instead of resurfacing as a failure.
-
-    TODO(cancel): If POST /jobs/{id}/cancel already set Cancelled, this
-    Running-only failure UPDATE must no-op so Cancelled is not overwritten.
     """
     logger.warning("Route generation job %s failed: %s", job_id, message)
 

--- a/backend/python/app/services/implementations/route_generation_runner.py
+++ b/backend/python/app/services/implementations/route_generation_runner.py
@@ -248,12 +248,11 @@ async def _resolve_locations(
         )
 
     if len(routable) < len(locations):
-        logger.warning(
-            "Routing %d of the %d locations in group '%s'; the rest are not "
-            "geocoded yet.",
-            len(routable),
-            len(locations),
-            group.name,
+        raise GenerationFailed(
+            f"Location group '{group.name}' has {len(locations) - len(routable)} "
+            f"location(s) that are not geocoded yet "
+            f"({len(routable)} of {len(locations)} are ready). "
+            "Geocode every location in the group before generating routes."
         )
 
     return group, routable

--- a/backend/python/app/services/implementations/route_generation_worker.py
+++ b/backend/python/app/services/implementations/route_generation_worker.py
@@ -6,6 +6,11 @@ at a time and hands each to ``run_generation_job``. The ``jobs`` table is the
 durable queue; the event is only an in-memory signal, so a process restart
 needs the startup sweep to fail orphaned ``RUNNING`` rows and re-ring if any
 ``PENDING`` work is waiting.
+
+Assumes a single process runs this worker. The drain loop treats a failed claim
+(``None``) as "queue empty" and stops. With multiple uvicorn/gunicorn workers
+or replicas, a lost claim race can also return ``None`` while ``PENDING`` jobs
+remain, leaving them stuck until the next ``POST /jobs/generate`` wake.
 """
 
 from __future__ import annotations
@@ -127,7 +132,11 @@ async def recover_route_generation_jobs(session: AsyncSession) -> None:
 
 
 async def route_generation_worker_loop() -> None:
-    """Sleep until woken, then drain PENDING jobs one at a time."""
+    """Sleep until woken, then drain PENDING jobs one at a time.
+
+    Single-process assumption: ``_claim_and_run_one`` returning False means the
+    queue is empty. That is an unsafe assumptionif multiple processes claim concurrently.
+    """
     logger.info("Route generation worker started")
     try:
         while True:
@@ -143,7 +152,11 @@ async def route_generation_worker_loop() -> None:
 
 
 async def _claim_and_run_one() -> bool:
-    """Claim one job and run it. Returns False when the queue is empty."""
+    """Claim one job and run it. Returns False when claim finds no PENDING job.
+
+    Under a single worker process, that means the queue is empty. With multiple
+    processes, ``None`` can also mean another process claimed first.
+    """
     session_maker = app_models.async_session_maker_instance
     if session_maker is None:
         logger.error(

--- a/backend/python/app/services/implementations/route_generation_worker.py
+++ b/backend/python/app/services/implementations/route_generation_worker.py
@@ -49,7 +49,7 @@ RECOVERY_ERROR_MESSAGE = (
 
 
 def wake_route_generation_worker() -> None:
-    """Wakes the worker looks for PENDING jobs."""
+    """Wake the worker so it looks for PENDING jobs."""
     _wake_event.set()
 
 

--- a/backend/python/app/services/implementations/route_generation_worker.py
+++ b/backend/python/app/services/implementations/route_generation_worker.py
@@ -59,10 +59,6 @@ async def claim_next_pending_job(session: AsyncSession) -> UUID | None:
     The progress check is in the UPDATE itself, so two workers (or a cancel
     racing the claim) cannot both start the same job: zero rows updated means
     someone else got there first.
-
-    TODO(cancel): When POST /jobs/{id}/cancel marks a job Cancelled, this claim
-    must keep skipping non-Pending rows so a cancelled Pending job is never
-    started. No wake/interrupt is needed here — cancel is honored by not claiming.
     """
     now = now_est_naive()
     oldest_pending = (

--- a/backend/python/app/services/implementations/route_generation_worker.py
+++ b/backend/python/app/services/implementations/route_generation_worker.py
@@ -1,0 +1,187 @@
+"""Background consumer for route generation jobs.
+
+One long-lived asyncio task sleeps on a wake event until
+``POST /jobs/generate`` wakes the worker, then claims ``PENDING`` jobs one
+at a time and hands each to ``run_generation_job``. The ``jobs`` table is the
+durable queue; the event is only an in-memory signal, so a process restart
+needs the startup sweep to fail orphaned ``RUNNING`` rows and re-ring if any
+``PENDING`` work is waiting.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+from datetime import datetime
+from typing import TYPE_CHECKING, Any, cast
+from zoneinfo import ZoneInfo
+
+from sqlalchemy import update
+from sqlmodel import col, select
+
+from app.dependencies.services import get_routing_algorithm
+from app.models import async_session_maker_instance
+from app.models.enum import ProgressEnum
+from app.models.job import Job
+from app.services.implementations.route_generation_runner import run_generation_job
+
+if TYPE_CHECKING:
+    from uuid import UUID
+
+    from sqlalchemy.engine import CursorResult
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+logger = logging.getLogger(__name__)
+
+_wake_event = asyncio.Event()
+_worker_task: asyncio.Task[None] | None = None
+
+RECOVERY_ERROR_MESSAGE = (
+    "Route generation was interrupted because the server restarted. "
+    "Enqueue the job again."
+)
+
+
+def _now_est_naive() -> datetime:
+    """Now in F4K's timezone, tz-naive."""
+    return datetime.now(ZoneInfo("America/New_York")).replace(tzinfo=None)
+
+
+def wake_route_generation_worker() -> None:
+    """Wakes the worker looks for PENDING jobs."""
+    _wake_event.set()
+
+
+async def claim_next_pending_job(session: AsyncSession) -> UUID | None:
+    """Atomically take the oldest PENDING job and mark it RUNNING.
+
+    The progress check is in the UPDATE itself, so two workers (or a cancel
+    racing the claim) cannot both start the same job: zero rows updated means
+    someone else got there first.
+    """
+    now = _now_est_naive()
+    oldest_pending = (
+        select(Job.job_id)
+        .where(col(Job.progress) == ProgressEnum.PENDING)
+        .order_by(col(Job.created_at).asc(), col(Job.job_id).asc())
+        .limit(1)
+        .scalar_subquery()
+    )
+    result = await session.execute(
+        update(Job)
+        .where(col(Job.job_id) == oldest_pending)
+        .where(col(Job.progress) == ProgressEnum.PENDING)
+        .values(
+            progress=ProgressEnum.RUNNING,
+            started_at=now,
+            updated_at=now,
+        )
+        .returning(Job.job_id)
+    )
+    job_id = result.scalar_one_or_none()
+    if job_id is None:
+        await session.rollback()
+        return None
+
+    await session.commit()
+    return job_id
+
+
+async def recover_route_generation_jobs(session: AsyncSession) -> None:
+    """Fail jobs left RUNNING across a restart, and wake if PENDING remain.
+
+    A RUNNING job cannot be resumed: the Google call is gone with the old
+    process. Leaving it RUNNING would make the UI wait forever.
+    """
+    now = _now_est_naive()
+    result = cast(
+        "CursorResult[Any]",
+        await session.execute(
+            update(Job)
+            .where(col(Job.progress) == ProgressEnum.RUNNING)
+            .values(
+                progress=ProgressEnum.FAILED,
+                error_message=RECOVERY_ERROR_MESSAGE,
+                updated_at=now,
+                finished_at=now,
+            )
+        ),
+    )
+    if result.rowcount:
+        logger.warning(
+            "Marked %d interrupted route generation job(s) as Failed after restart.",
+            result.rowcount,
+        )
+    await session.commit()
+
+    pending = (
+        await session.execute(
+            select(Job.job_id).where(col(Job.progress) == ProgressEnum.PENDING).limit(1)
+        )
+    ).scalar_one_or_none()
+    if pending is not None:
+        logger.info(
+            "Found PENDING route generation job(s) on startup; waking the worker."
+        )
+        wake_route_generation_worker()
+
+
+async def route_generation_worker_loop() -> None:
+    """Sleep until woken, then drain PENDING jobs one at a time."""
+    logger.info("Route generation worker started")
+    try:
+        while True:
+            await _wake_event.wait()
+            _wake_event.clear()
+            while True:
+                ran = await _claim_and_run_one()
+                if not ran:
+                    break
+    except asyncio.CancelledError:
+        logger.info("Route generation worker stopping")
+        raise
+
+
+async def _claim_and_run_one() -> bool:
+    """Claim one job and run it. Returns False when the queue is empty."""
+    if async_session_maker_instance is None:
+        logger.error(
+            "Cannot run route generation: database session maker is not initialized."
+        )
+        return False
+
+    algorithm = get_routing_algorithm()
+    async with async_session_maker_instance() as session:
+        job_id = await claim_next_pending_job(session)
+        if job_id is None:
+            return False
+        logger.info("Running route generation job %s", job_id)
+        await run_generation_job(job_id, session, algorithm)
+        return True
+
+
+def start_route_generation_worker() -> asyncio.Task[None]:
+    """Start the background worker task. Call once from app lifespan."""
+    global _worker_task
+    if _worker_task is not None and not _worker_task.done():
+        return _worker_task
+
+    _wake_event.clear()
+    _worker_task = asyncio.create_task(
+        route_generation_worker_loop(),
+        name="route_generation_worker",
+    )
+    return _worker_task
+
+
+async def stop_route_generation_worker() -> None:
+    """Cancel the background worker task. Call once from app lifespan shutdown."""
+    global _worker_task
+    if _worker_task is None:
+        return
+
+    _worker_task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await _worker_task
+    _worker_task = None

--- a/backend/python/app/services/implementations/route_generation_worker.py
+++ b/backend/python/app/services/implementations/route_generation_worker.py
@@ -20,8 +20,8 @@ from zoneinfo import ZoneInfo
 from sqlalchemy import update
 from sqlmodel import col, select
 
+from app import models as app_models
 from app.dependencies.services import get_routing_algorithm
-from app.models import async_session_maker_instance
 from app.models.enum import ProgressEnum
 from app.models.job import Job
 from app.services.implementations.route_generation_runner import run_generation_job
@@ -145,14 +145,15 @@ async def route_generation_worker_loop() -> None:
 
 async def _claim_and_run_one() -> bool:
     """Claim one job and run it. Returns False when the queue is empty."""
-    if async_session_maker_instance is None:
+    session_maker = app_models.async_session_maker_instance
+    if session_maker is None:
         logger.error(
             "Cannot run route generation: database session maker is not initialized."
         )
         return False
 
     algorithm = get_routing_algorithm()
-    async with async_session_maker_instance() as session:
+    async with session_maker() as session:
         job_id = await claim_next_pending_job(session)
         if job_id is None:
             return False

--- a/backend/python/app/services/implementations/route_generation_worker.py
+++ b/backend/python/app/services/implementations/route_generation_worker.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import logging
+import time
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, cast
 from zoneinfo import ZoneInfo
@@ -157,8 +158,14 @@ async def _claim_and_run_one() -> bool:
         job_id = await claim_next_pending_job(session)
         if job_id is None:
             return False
-        logger.info("Running route generation job %s", job_id)
+        logger.info("Claimed route generation job %s", job_id)
+        started = time.perf_counter()
         await run_generation_job(job_id, session, algorithm)
+        logger.info(
+            "Finished route generation job %s in %.1fs",
+            job_id,
+            time.perf_counter() - started,
+        )
         return True
 
 

--- a/backend/python/app/services/implementations/route_generation_worker.py
+++ b/backend/python/app/services/implementations/route_generation_worker.py
@@ -60,6 +60,10 @@ async def claim_next_pending_job(session: AsyncSession) -> UUID | None:
     The progress check is in the UPDATE itself, so two workers (or a cancel
     racing the claim) cannot both start the same job: zero rows updated means
     someone else got there first.
+
+    TODO(cancel): When POST /jobs/{id}/cancel marks a job Cancelled, this claim
+    must keep skipping non-Pending rows so a cancelled Pending job is never
+    started. No wake/interrupt is needed here — cancel is honored by not claiming.
     """
     now = _now_est_naive()
     oldest_pending = (

--- a/backend/python/app/services/implementations/route_generation_worker.py
+++ b/backend/python/app/services/implementations/route_generation_worker.py
@@ -81,7 +81,7 @@ async def claim_next_pending_job(session: AsyncSession) -> UUID | None:
             started_at=now,
             updated_at=now,
         )
-        .returning(Job.job_id)
+        .returning(col(Job.job_id))
     )
     job_id = result.scalar_one_or_none()
     if job_id is None:

--- a/backend/python/app/services/implementations/route_generation_worker.py
+++ b/backend/python/app/services/implementations/route_generation_worker.py
@@ -14,9 +14,7 @@ import asyncio
 import contextlib
 import logging
 import time
-from datetime import datetime
 from typing import TYPE_CHECKING, Any, cast
-from zoneinfo import ZoneInfo
 
 from sqlalchemy import update
 from sqlmodel import col, select
@@ -26,6 +24,7 @@ from app.dependencies.services import get_routing_algorithm
 from app.models.enum import ProgressEnum
 from app.models.job import Job
 from app.services.implementations.route_generation_runner import run_generation_job
+from app.utilities.datetime_utils import now_est_naive
 
 if TYPE_CHECKING:
     from uuid import UUID
@@ -44,11 +43,6 @@ RECOVERY_ERROR_MESSAGE = (
 )
 
 
-def _now_est_naive() -> datetime:
-    """Now in F4K's timezone, tz-naive."""
-    return datetime.now(ZoneInfo("America/New_York")).replace(tzinfo=None)
-
-
 def wake_route_generation_worker() -> None:
     """Wakes the worker looks for PENDING jobs."""
     _wake_event.set()
@@ -65,7 +59,7 @@ async def claim_next_pending_job(session: AsyncSession) -> UUID | None:
     must keep skipping non-Pending rows so a cancelled Pending job is never
     started. No wake/interrupt is needed here — cancel is honored by not claiming.
     """
-    now = _now_est_naive()
+    now = now_est_naive()
     oldest_pending = (
         select(Job.job_id)
         .where(col(Job.progress) == ProgressEnum.PENDING)
@@ -99,7 +93,7 @@ async def recover_route_generation_jobs(session: AsyncSession) -> None:
     A RUNNING job cannot be resumed: the Google call is gone with the old
     process. Leaving it RUNNING would make the UI wait forever.
     """
-    now = _now_est_naive()
+    now = now_est_naive()
     result = cast(
         "CursorResult[Any]",
         await session.execute(

--- a/backend/python/app/utilities/datetime_utils.py
+++ b/backend/python/app/utilities/datetime_utils.py
@@ -1,0 +1,7 @@
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+
+def now_est_naive() -> datetime:
+    """Current time in F4K's timezone (America/New_York), stored tz-naive."""
+    return datetime.now(ZoneInfo("America/New_York")).replace(tzinfo=None)

--- a/backend/python/migrations/versions/d4eefe397549_add_input_payload_error_message_and_.py
+++ b/backend/python/migrations/versions/d4eefe397549_add_input_payload_error_message_and_.py
@@ -1,7 +1,11 @@
 """add input payload, error message and summary columns to jobs
 
 Revision ID: d4eefe397549
+<<<<<<< HEAD
 Revises: a1c2e3f4b5d6
+=======
+Revises: bc7876e56dd1
+>>>>>>> 6ed58b7 (add changes to the jobs table)
 Create Date: 2026-07-28 02:26:20.612153
 
 """
@@ -11,7 +15,11 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = 'd4eefe397549'
+<<<<<<< HEAD
 down_revision = 'a1c2e3f4b5d6'
+=======
+down_revision = 'bc7876e56dd1'
+>>>>>>> 6ed58b7 (add changes to the jobs table)
 branch_labels = None
 depends_on = None
 

--- a/backend/python/migrations/versions/d4eefe397549_add_input_payload_error_message_and_.py
+++ b/backend/python/migrations/versions/d4eefe397549_add_input_payload_error_message_and_.py
@@ -1,11 +1,7 @@
 """add input payload, error message and summary columns to jobs
 
 Revision ID: d4eefe397549
-<<<<<<< HEAD
 Revises: a1c2e3f4b5d6
-=======
-Revises: bc7876e56dd1
->>>>>>> 6ed58b7 (add changes to the jobs table)
 Create Date: 2026-07-28 02:26:20.612153
 
 """
@@ -15,11 +11,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = 'd4eefe397549'
-<<<<<<< HEAD
 down_revision = 'a1c2e3f4b5d6'
-=======
-down_revision = 'bc7876e56dd1'
->>>>>>> 6ed58b7 (add changes to the jobs table)
 branch_labels = None
 depends_on = None
 

--- a/backend/python/tests/test_route_generation_runner.py
+++ b/backend/python/tests/test_route_generation_runner.py
@@ -243,30 +243,26 @@ class TestSuccessfulGeneration:
         assert job.routes_created == 1
 
     @pytest.mark.asyncio
-    async def test_routes_only_the_geocoded_locations(
+    async def test_ungeocoded_locations_fail_the_job(
         self, test_session: AsyncSession
     ) -> None:
-        """A location without coordinates is skipped, not fatal."""
+        """A mix of geocoded and ungeocoded locations is fatal — do not
+        silently route only the ready subset."""
         group = await _add_group(test_session)
-        geocoded = await _add_location(test_session, group, "Family A")
+        await _add_location(test_session, group, "Family A")
         await _add_location(
             test_session, group, "Family B", latitude=None, longitude=None
         )
         await _add_warehouse(test_session)
         job = await _queue_running_job(test_session, group, num_routes=1)
 
-        seen: list[list[Location]] = []
+        await run_generation_job(
+            job.job_id, test_session, FakeRoutingAlgorithm(lambda locations: [locations])
+        )
 
-        def _plan(locations: list[Location]) -> Any:
-            seen.append(locations)
-            return [locations]
-
-        await run_generation_job(job.job_id, test_session, FakeRoutingAlgorithm(_plan))
-
-        assert [location.location_id for location in seen[0]] == [geocoded.location_id]
         await test_session.refresh(job)
-        assert job.progress == ProgressEnum.COMPLETED
-        assert job.total_families == 1
+        assert job.progress == ProgressEnum.FAILED
+        assert "not geocoded" in (job.error_message or "")
 
     @pytest.mark.asyncio
     async def test_empty_clusters_do_not_become_routes(

--- a/backend/python/tests/test_route_generation_runner.py
+++ b/backend/python/tests/test_route_generation_runner.py
@@ -257,7 +257,9 @@ class TestSuccessfulGeneration:
         job = await _queue_running_job(test_session, group, num_routes=1)
 
         await run_generation_job(
-            job.job_id, test_session, FakeRoutingAlgorithm(lambda locations: [locations])
+            job.job_id,
+            test_session,
+            FakeRoutingAlgorithm(lambda locations: [locations]),
         )
 
         await test_session.refresh(job)
@@ -369,6 +371,40 @@ class TestFailedGeneration:
         assert job.progress == ProgressEnum.FAILED
         assert "too long" in (job.error_message or "")
         assert await _route_groups(test_session) == []
+
+    @pytest.mark.asyncio
+    async def test_polyline_fetches_run_concurrently(
+        self, test_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Each route's polyline fetch overlaps with the others."""
+        group = await _add_group(test_session)
+        first = await _add_location(test_session, group, "Family A")
+        second = await _add_location(test_session, group, "Family B")
+        third = await _add_location(test_session, group, "Family C")
+        await _add_warehouse(test_session)
+        job = await _queue_running_job(test_session, group, num_routes=3)
+
+        in_flight = 0
+        max_in_flight = 0
+
+        async def _overlapping_polyline(**_kwargs: Any) -> tuple[str, float]:
+            nonlocal in_flight, max_in_flight
+            in_flight += 1
+            max_in_flight = max(max_in_flight, in_flight)
+            await asyncio.sleep(0.05)
+            in_flight -= 1
+            return "fake-polyline", POLYLINE_KM
+
+        monkeypatch.setattr(runner, "fetch_route_polyline", _overlapping_polyline)
+
+        algorithm = FakeRoutingAlgorithm(
+            lambda _locations: [[first], [second], [third]]
+        )
+        await run_generation_job(job.job_id, test_session, algorithm)
+
+        await test_session.refresh(job)
+        assert job.progress == ProgressEnum.COMPLETED
+        assert max_in_flight == 3
 
     @pytest.mark.asyncio
     async def test_polyline_api_error_fails_the_job(

--- a/backend/python/tests/test_route_generation_runner.py
+++ b/backend/python/tests/test_route_generation_runner.py
@@ -1,0 +1,614 @@
+"""Tests for the route generation runner.
+
+These call `run_generation_job` the way the future worker loop will — with a
+session and an algorithm handed to it — so the whole pipeline is exercised
+without a worker, and without reaching Google: the algorithm is a fake and
+`fetch_route_polyline` is patched out for every test in this file.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+from datetime import datetime
+from typing import TYPE_CHECKING, Any, cast
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException
+from sqlmodel import col, select
+
+from app.models.enum import ProgressEnum
+from app.models.job import Job
+from app.models.location import Location
+from app.models.location_group import LocationGroup
+from app.models.route import Route
+from app.models.route_group import RouteGroup
+from app.models.route_stop import RouteStop
+from app.models.system_settings import SystemSettings
+from app.schemas.route_generation import (
+    RouteGenerationGroupInput,
+    RouteGenerationSettings,
+)
+from app.services.implementations import route_generation_runner as runner
+from app.services.implementations.route_generation_runner import run_generation_job
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+WAREHOUSE_LAT = 43.6532
+WAREHOUSE_LON = -79.3832
+POLYLINE_KM = 12.5
+DRIVE_DATE = datetime(2026, 6, 1, 8, 0)
+
+
+class FakeRoutingAlgorithm:
+    """Stands in for the real engine. `plan` decides what one call does:
+    return clusters, return an awaitable, or raise."""
+
+    def __init__(self, plan: Callable[[list[Location]], Any]) -> None:
+        self._plan = plan
+        self.calls = 0
+        self.timeout_seconds: float | None = None
+
+    async def generate_routes(
+        self,
+        locations: list[Location],
+        warehouse_lat: float,  # noqa: ARG002
+        warehouse_lon: float,  # noqa: ARG002
+        settings: RouteGenerationSettings,  # noqa: ARG002
+        timeout_seconds: float | None = None,
+    ) -> list[list[Location]]:
+        self.calls += 1
+        self.timeout_seconds = timeout_seconds
+        outcome: Any = self._plan(locations)
+        if inspect.isawaitable(outcome):
+            outcome = await outcome
+        return cast("list[list[Location]]", outcome)
+
+
+def _never_called(_locations: list[Location]) -> Any:
+    pytest.fail("the routing engine should not have been reached")
+
+
+@pytest.fixture(autouse=True)
+def fake_polyline(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No test in this file may reach the real Google Maps API."""
+
+    async def _fetch(**_kwargs: Any) -> tuple[str, float]:
+        return "fake-polyline", POLYLINE_KM
+
+    monkeypatch.setattr(runner, "fetch_route_polyline", _fetch)
+
+
+async def _add_group(session: AsyncSession, name: str = "Test Group") -> LocationGroup:
+    group = LocationGroup(name=name, color="#FF5733")
+    session.add(group)
+    await session.commit()
+    await session.refresh(group)
+    return group
+
+
+async def _add_location(
+    session: AsyncSession,
+    group: LocationGroup,
+    name: str,
+    *,
+    latitude: float | None = 43.7,
+    longitude: float | None = -79.4,
+) -> Location:
+    location = Location(
+        location_group_id=group.location_group_id,
+        name=name,
+        contact_name=name,
+        address=f"{name} Street",
+        phone_primary="5550000000",
+        delivery_type="Family",
+        latitude=latitude,
+        longitude=longitude,
+    )
+    session.add(location)
+    await session.commit()
+    await session.refresh(location)
+    return location
+
+
+async def _add_warehouse(session: AsyncSession, *, configured: bool = True) -> None:
+    session.add(
+        SystemSettings(
+            warehouse_latitude=WAREHOUSE_LAT if configured else None,
+            warehouse_longitude=WAREHOUSE_LON if configured else None,
+        )
+    )
+    await session.commit()
+
+
+async def _queue_running_job(
+    session: AsyncSession, requested_group: LocationGroup, *, num_routes: int = 2
+) -> Job:
+    """A job in the state the worker hands to the runner: claimed (Running)
+    with the request it was queued with saved on it."""
+    request = RouteGenerationGroupInput(
+        location_group=requested_group,
+        settings=RouteGenerationSettings(
+            route_start_time=DRIVE_DATE, num_routes=num_routes
+        ),
+    )
+    job = Job(
+        progress=ProgressEnum.RUNNING,
+        input_payload=request.model_dump(mode="json"),
+    )
+    session.add(job)
+    await session.commit()
+    await session.refresh(job)
+    return job
+
+
+async def _route_groups(session: AsyncSession) -> list[RouteGroup]:
+    return list((await session.execute(select(RouteGroup))).scalars().all())
+
+
+class TestSuccessfulGeneration:
+    @pytest.mark.asyncio
+    async def test_saves_routes_and_records_the_summary(
+        self, test_session: AsyncSession
+    ) -> None:
+        """The happy path: engine output becomes a RouteGroup with ordered
+        stops, and the job completes carrying the summary numbers."""
+        group = await _add_group(test_session)
+        first = await _add_location(test_session, group, "Family A")
+        second = await _add_location(test_session, group, "Family B")
+        third = await _add_location(test_session, group, "Family C")
+        await _add_warehouse(test_session)
+        job = await _queue_running_job(test_session, group)
+
+        algorithm = FakeRoutingAlgorithm(lambda _locations: [[first, second], [third]])
+        await run_generation_job(job.job_id, test_session, algorithm)
+
+        await test_session.refresh(job)
+        assert job.progress == ProgressEnum.COMPLETED
+        assert job.error_message is None
+        assert job.finished_at is not None
+        assert job.route_group_id is not None
+        assert job.routes_created == 2
+        assert job.total_stops == 3
+        assert job.total_distance_km == pytest.approx(2 * POLYLINE_KM)
+        assert job.total_families == 3
+
+        route_group = (
+            await test_session.execute(
+                select(RouteGroup).where(
+                    RouteGroup.route_group_id == job.route_group_id
+                )
+            )
+        ).scalar_one()
+        assert route_group.name == "Test Group - 2026-06-01"
+        assert route_group.drive_date == DRIVE_DATE
+
+        routes = (
+            (
+                await test_session.execute(
+                    select(Route)
+                    .where(Route.route_group_id == route_group.route_group_id)
+                    .order_by(Route.name)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert [route.name for route in routes] == ["Route 1", "Route 2"]
+        assert all(route.encoded_polyline == "fake-polyline" for route in routes)
+        assert all(route.length == pytest.approx(POLYLINE_KM) for route in routes)
+        assert all(route.driver_id is None for route in routes)
+
+        stops = (
+            (
+                await test_session.execute(
+                    select(RouteStop)
+                    .where(RouteStop.route_id == routes[0].route_id)
+                    .order_by(col(RouteStop.stop_number))
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert [stop.stop_number for stop in stops] == [1, 2]
+        assert [stop.location_id for stop in stops] == [
+            first.location_id,
+            second.location_id,
+        ]
+
+    @pytest.mark.asyncio
+    async def test_finds_the_group_by_name_when_the_id_is_made_up(
+        self, test_session: AsyncSession
+    ) -> None:
+        """A request that carried only a name still resolves: Pydantic
+        invents an id for it, and that id matches nothing."""
+        group = await _add_group(test_session)
+        location = await _add_location(test_session, group, "Family A")
+        await _add_warehouse(test_session)
+        job = await _queue_running_job(
+            test_session,
+            LocationGroup(name=group.name, color=group.color),
+            num_routes=1,
+        )
+
+        algorithm = FakeRoutingAlgorithm(lambda _locations: [[location]])
+        await run_generation_job(job.job_id, test_session, algorithm)
+
+        await test_session.refresh(job)
+        assert job.progress == ProgressEnum.COMPLETED
+        assert job.routes_created == 1
+
+    @pytest.mark.asyncio
+    async def test_routes_only_the_geocoded_locations(
+        self, test_session: AsyncSession
+    ) -> None:
+        """A location without coordinates is skipped, not fatal."""
+        group = await _add_group(test_session)
+        geocoded = await _add_location(test_session, group, "Family A")
+        await _add_location(
+            test_session, group, "Family B", latitude=None, longitude=None
+        )
+        await _add_warehouse(test_session)
+        job = await _queue_running_job(test_session, group, num_routes=1)
+
+        seen: list[list[Location]] = []
+
+        def _plan(locations: list[Location]) -> Any:
+            seen.append(locations)
+            return [locations]
+
+        await run_generation_job(job.job_id, test_session, FakeRoutingAlgorithm(_plan))
+
+        assert [location.location_id for location in seen[0]] == [geocoded.location_id]
+        await test_session.refresh(job)
+        assert job.progress == ProgressEnum.COMPLETED
+        assert job.total_families == 1
+
+    @pytest.mark.asyncio
+    async def test_empty_clusters_do_not_become_routes(
+        self, test_session: AsyncSession
+    ) -> None:
+        """Asking for more routes than the engine can fill leaves empty
+        clusters, and an empty route is not worth saving."""
+        group = await _add_group(test_session)
+        location = await _add_location(test_session, group, "Family A")
+        await _add_warehouse(test_session)
+        job = await _queue_running_job(test_session, group, num_routes=3)
+
+        algorithm = FakeRoutingAlgorithm(lambda _locations: [[location], [], []])
+        await run_generation_job(job.job_id, test_session, algorithm)
+
+        await test_session.refresh(job)
+        assert job.progress == ProgressEnum.COMPLETED
+        assert job.routes_created == 1
+        assert job.total_stops == 1
+
+    @pytest.mark.asyncio
+    async def test_the_engine_is_given_a_timeout(
+        self, test_session: AsyncSession
+    ) -> None:
+        """One hung call would stall every later job, so the engine never
+        gets to run unbounded."""
+        group = await _add_group(test_session)
+        location = await _add_location(test_session, group, "Family A")
+        await _add_warehouse(test_session)
+        job = await _queue_running_job(test_session, group, num_routes=1)
+
+        algorithm = FakeRoutingAlgorithm(lambda _locations: [[location]])
+        await run_generation_job(job.job_id, test_session, algorithm)
+
+        assert algorithm.timeout_seconds == runner.ENGINE_TIMEOUT_SECONDS
+
+
+class TestFailedGeneration:
+    @pytest.mark.asyncio
+    async def test_engine_error_fails_the_job_and_saves_nothing(
+        self, test_session: AsyncSession
+    ) -> None:
+        group = await _add_group(test_session)
+        await _add_location(test_session, group, "Family A")
+        await _add_warehouse(test_session)
+        job = await _queue_running_job(test_session, group)
+
+        def _explode(_locations: list[Location]) -> Any:
+            raise RuntimeError("the engine fell over")
+
+        await run_generation_job(
+            job.job_id, test_session, FakeRoutingAlgorithm(_explode)
+        )
+
+        await test_session.refresh(job)
+        assert job.progress == ProgressEnum.FAILED
+        assert job.error_message is not None
+        assert "the engine fell over" in job.error_message
+        assert job.route_group_id is None
+        assert await _route_groups(test_session) == []
+
+    @pytest.mark.asyncio
+    async def test_engine_timeout_fails_the_job(
+        self, test_session: AsyncSession
+    ) -> None:
+        group = await _add_group(test_session)
+        await _add_location(test_session, group, "Family A")
+        await _add_warehouse(test_session)
+        job = await _queue_running_job(test_session, group)
+
+        def _time_out(_locations: list[Location]) -> Any:
+            raise TimeoutError
+
+        await run_generation_job(
+            job.job_id, test_session, FakeRoutingAlgorithm(_time_out)
+        )
+
+        await test_session.refresh(job)
+        assert job.progress == ProgressEnum.FAILED
+        assert "too long" in (job.error_message or "")
+
+    @pytest.mark.asyncio
+    async def test_overall_budget_covers_the_polyline_calls_too(
+        self, test_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The engine returning in time is not enough: the polyline calls
+        that follow are inside the same budget."""
+        group = await _add_group(test_session)
+        location = await _add_location(test_session, group, "Family A")
+        await _add_warehouse(test_session)
+        job = await _queue_running_job(test_session, group, num_routes=1)
+
+        async def _slow_polyline(**_kwargs: Any) -> tuple[str, float]:
+            await asyncio.sleep(5)
+            return "never-gets-here", 1.0
+
+        monkeypatch.setattr(runner, "fetch_route_polyline", _slow_polyline)
+        monkeypatch.setattr(runner, "GENERATION_TIMEOUT_SECONDS", 0.05)
+
+        algorithm = FakeRoutingAlgorithm(lambda _locations: [[location]])
+        await run_generation_job(job.job_id, test_session, algorithm)
+
+        await test_session.refresh(job)
+        assert job.progress == ProgressEnum.FAILED
+        assert "too long" in (job.error_message or "")
+        assert await _route_groups(test_session) == []
+
+    @pytest.mark.asyncio
+    async def test_polyline_api_error_fails_the_job(
+        self, test_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """fetch_route_polyline raises HTTP exceptions because of where it
+        usually runs; here there is no request, only a failed job."""
+        group = await _add_group(test_session)
+        location = await _add_location(test_session, group, "Family A")
+        await _add_warehouse(test_session)
+        job = await _queue_running_job(test_session, group, num_routes=1)
+
+        async def _unavailable(**_kwargs: Any) -> tuple[str, float]:
+            raise HTTPException(status_code=503, detail="Google Maps API error: nope")
+
+        monkeypatch.setattr(runner, "fetch_route_polyline", _unavailable)
+
+        algorithm = FakeRoutingAlgorithm(lambda _locations: [[location]])
+        await run_generation_job(job.job_id, test_session, algorithm)
+
+        await test_session.refresh(job)
+        assert job.progress == ProgressEnum.FAILED
+        assert "Google Maps API error: nope" in (job.error_message or "")
+        assert await _route_groups(test_session) == []
+
+    @pytest.mark.asyncio
+    async def test_unset_warehouse_fails_before_calling_the_engine(
+        self, test_session: AsyncSession
+    ) -> None:
+        group = await _add_group(test_session)
+        await _add_location(test_session, group, "Family A")
+        await _add_warehouse(test_session, configured=False)
+        job = await _queue_running_job(test_session, group)
+
+        algorithm = FakeRoutingAlgorithm(_never_called)
+        await run_generation_job(job.job_id, test_session, algorithm)
+
+        await test_session.refresh(job)
+        assert job.progress == ProgressEnum.FAILED
+        assert "Warehouse coordinates" in (job.error_message or "")
+        assert algorithm.calls == 0
+
+    @pytest.mark.asyncio
+    async def test_missing_system_settings_fails_the_job(
+        self, test_session: AsyncSession
+    ) -> None:
+        """A database with no settings row at all reads the same as one with
+        no warehouse set."""
+        group = await _add_group(test_session)
+        await _add_location(test_session, group, "Family A")
+        job = await _queue_running_job(test_session, group)
+
+        algorithm = FakeRoutingAlgorithm(_never_called)
+        await run_generation_job(job.job_id, test_session, algorithm)
+
+        await test_session.refresh(job)
+        assert job.progress == ProgressEnum.FAILED
+        assert "Warehouse coordinates" in (job.error_message or "")
+
+    @pytest.mark.asyncio
+    async def test_unknown_location_group_fails_the_job(
+        self, test_session: AsyncSession
+    ) -> None:
+        """The group can be deleted between queueing and running."""
+        await _add_warehouse(test_session)
+        job = await _queue_running_job(
+            test_session, LocationGroup(name="Ghost Group", color="#000000")
+        )
+
+        algorithm = FakeRoutingAlgorithm(_never_called)
+        await run_generation_job(job.job_id, test_session, algorithm)
+
+        await test_session.refresh(job)
+        assert job.progress == ProgressEnum.FAILED
+        assert "Ghost Group" in (job.error_message or "")
+        assert algorithm.calls == 0
+
+    @pytest.mark.asyncio
+    async def test_group_without_geocoded_locations_fails_the_job(
+        self, test_session: AsyncSession
+    ) -> None:
+        group = await _add_group(test_session)
+        await _add_location(
+            test_session, group, "Family A", latitude=None, longitude=None
+        )
+        await _add_warehouse(test_session)
+        job = await _queue_running_job(test_session, group)
+
+        algorithm = FakeRoutingAlgorithm(_never_called)
+        await run_generation_job(job.job_id, test_session, algorithm)
+
+        await test_session.refresh(job)
+        assert job.progress == ProgressEnum.FAILED
+        assert "no geocoded locations" in (job.error_message or "")
+
+    @pytest.mark.asyncio
+    async def test_engine_returning_nothing_fails_the_job(
+        self, test_session: AsyncSession
+    ) -> None:
+        group = await _add_group(test_session)
+        await _add_location(test_session, group, "Family A")
+        await _add_warehouse(test_session)
+        job = await _queue_running_job(test_session, group, num_routes=1)
+
+        algorithm = FakeRoutingAlgorithm(lambda _locations: [])
+        await run_generation_job(job.job_id, test_session, algorithm)
+
+        await test_session.refresh(job)
+        assert job.progress == ProgressEnum.FAILED
+        assert "did not place any locations" in (job.error_message or "")
+        assert await _route_groups(test_session) == []
+
+    @pytest.mark.asyncio
+    async def test_job_without_a_saved_request_fails(
+        self, test_session: AsyncSession
+    ) -> None:
+        job = Job(progress=ProgressEnum.RUNNING)
+        test_session.add(job)
+        await test_session.commit()
+        await test_session.refresh(job)
+
+        algorithm = FakeRoutingAlgorithm(_never_called)
+        await run_generation_job(job.job_id, test_session, algorithm)
+
+        await test_session.refresh(job)
+        assert job.progress == ProgressEnum.FAILED
+        assert "without a request" in (job.error_message or "")
+
+    @pytest.mark.asyncio
+    async def test_unreadable_saved_request_fails(
+        self, test_session: AsyncSession
+    ) -> None:
+        job = Job(progress=ProgressEnum.RUNNING, input_payload={"nonsense": True})
+        test_session.add(job)
+        await test_session.commit()
+        await test_session.refresh(job)
+
+        algorithm = FakeRoutingAlgorithm(_never_called)
+        await run_generation_job(job.job_id, test_session, algorithm)
+
+        await test_session.refresh(job)
+        assert job.progress == ProgressEnum.FAILED
+        assert "could not be read back" in (job.error_message or "")
+
+
+class TestJobsItShouldNotTouch:
+    @pytest.mark.asyncio
+    async def test_a_job_that_is_not_running_is_left_alone(
+        self, test_session: AsyncSession
+    ) -> None:
+        """The worker claims a job before handing it over, so anything else
+        belongs to someone else."""
+        job = Job(progress=ProgressEnum.PENDING)
+        test_session.add(job)
+        await test_session.commit()
+        await test_session.refresh(job)
+
+        algorithm = FakeRoutingAlgorithm(_never_called)
+        await run_generation_job(job.job_id, test_session, algorithm)
+
+        await test_session.refresh(job)
+        assert job.progress == ProgressEnum.PENDING
+        assert job.error_message is None
+
+    @pytest.mark.asyncio
+    async def test_a_missing_job_is_not_an_error(
+        self, test_session: AsyncSession
+    ) -> None:
+        await run_generation_job(
+            uuid4(), test_session, FakeRoutingAlgorithm(_never_called)
+        )
+
+    @pytest.mark.asyncio
+    async def test_cancelling_mid_flight_discards_the_routes(
+        self, test_session: AsyncSession
+    ) -> None:
+        """An admin cancelling while the engine works takes the routes with
+        them: a RouteGroup left behind would be attached to a cancelled job
+        that can never be marked complete."""
+        group = await _add_group(test_session)
+        location = await _add_location(test_session, group, "Family A")
+        location_id = location.location_id
+        await _add_warehouse(test_session)
+        job = await _queue_running_job(test_session, group, num_routes=1)
+
+        async def _cancel_then_answer(
+            locations: list[Location],
+        ) -> list[list[Location]]:
+            cancelled = await test_session.execute(
+                select(Job).where(Job.job_id == job.job_id)
+            )
+            cancelled.scalar_one().progress = ProgressEnum.CANCELLED
+            await test_session.commit()
+            return [locations]
+
+        await run_generation_job(
+            job.job_id, test_session, FakeRoutingAlgorithm(_cancel_then_answer)
+        )
+
+        await test_session.refresh(job)
+        assert job.progress == ProgressEnum.CANCELLED
+        assert job.route_group_id is None
+        assert job.routes_created is None
+        assert await _route_groups(test_session) == []
+        assert (await test_session.execute(select(Route))).scalars().first() is None
+        # Only the generated routes are rolled back. The locations the job read
+        # on its way there were committed before it started and must survive.
+        assert (
+            await test_session.execute(
+                select(Location).where(Location.location_id == location_id)
+            )
+        ).scalar_one_or_none() is not None
+
+    @pytest.mark.asyncio
+    async def test_cancelling_mid_flight_survives_a_failure(
+        self, test_session: AsyncSession
+    ) -> None:
+        """A job cancelled while the engine was failing stays cancelled
+        rather than being reopened as a failure."""
+        group = await _add_group(test_session)
+        await _add_location(test_session, group, "Family A")
+        await _add_warehouse(test_session)
+        job = await _queue_running_job(test_session, group, num_routes=1)
+
+        async def _cancel_then_explode(_locations: list[Location]) -> Any:
+            cancelled = await test_session.execute(
+                select(Job).where(Job.job_id == job.job_id)
+            )
+            cancelled.scalar_one().progress = ProgressEnum.CANCELLED
+            await test_session.commit()
+            raise RuntimeError("too late")
+
+        await run_generation_job(
+            job.job_id, test_session, FakeRoutingAlgorithm(_cancel_then_explode)
+        )
+
+        await test_session.refresh(job)
+        assert job.progress == ProgressEnum.CANCELLED
+        assert job.error_message is None

--- a/backend/python/tests/test_route_generation_runner.py
+++ b/backend/python/tests/test_route_generation_runner.py
@@ -185,7 +185,7 @@ class TestSuccessfulGeneration:
             )
         ).scalar_one()
         assert route_group.name == "Test Group - 2026-06-01"
-        assert route_group.drive_date == DRIVE_DATE
+        assert route_group.drive_date == DRIVE_DATE.date()
 
         routes = (
             (

--- a/backend/python/tests/test_route_generation_worker.py
+++ b/backend/python/tests/test_route_generation_worker.py
@@ -260,6 +260,26 @@ class TestEnqueueDoorbell:
         assert job.progress == ProgressEnum.CANCELLED
         assert wakes == []
 
+    @pytest.mark.asyncio
+    async def test_enqueue_reraises_unexpected_errors(
+        self, test_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """DB/lookup failures must not be swallowed after the job is already PENDING."""
+        job = Job(progress=ProgressEnum.PENDING)
+        test_session.add(job)
+        await test_session.commit()
+        await test_session.refresh(job)
+
+        service = JobService(logger=logging.getLogger("test"), session=test_session)
+
+        async def boom(_job_id: Any) -> None:
+            raise RuntimeError("db unavailable")
+
+        monkeypatch.setattr(service, "get_job", boom)
+
+        with pytest.raises(RuntimeError, match="db unavailable"):
+            await service.enqueue(job.job_id)
+
 
 class TestWorkerLoop:
     @pytest.mark.asyncio

--- a/backend/python/tests/test_route_generation_worker.py
+++ b/backend/python/tests/test_route_generation_worker.py
@@ -10,11 +10,11 @@ from __future__ import annotations
 import asyncio
 import logging
 from datetime import datetime
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
-from sqlmodel import select
+from sqlmodel import col, select
 
 from app.models.enum import ProgressEnum
 from app.models.job import Job
@@ -60,7 +60,7 @@ class FakeRoutingAlgorithm:
         timeout_seconds: float | None = None,  # noqa: ARG002
     ) -> list[list[Location]]:
         self.calls += 1
-        return self._plan(locations)
+        return cast("list[list[Location]]", self._plan(locations))
 
 
 def _maker(test_db_engine: Any) -> async_sessionmaker[AsyncSession]:
@@ -75,7 +75,7 @@ def reset_worker_state() -> Any:
     worker._wake_event = asyncio.Event()
     worker._worker_task = None
     yield
-    task = worker._worker_task
+    task = cast("asyncio.Task[None] | None", worker._worker_task)
     worker._worker_task = None
     if task is not None and not task.done():
         task.cancel()
@@ -351,7 +351,7 @@ class TestWorkerLoop:
                     (
                         await session.execute(
                             select(Job).where(
-                                Job.job_id.in_([first.job_id, second.job_id])
+                                col(Job.job_id).in_([first.job_id, second.job_id])
                             )
                         )
                     )

--- a/backend/python/tests/test_route_generation_worker.py
+++ b/backend/python/tests/test_route_generation_worker.py
@@ -222,7 +222,7 @@ class TestEnqueueDoorbell:
     ) -> None:
         wakes: list[bool] = []
         monkeypatch.setattr(
-            "app.services.implementations.route_generation_worker.wake_route_generation_worker",
+            "app.services.implementations.job_service.wake_route_generation_worker",
             lambda: wakes.append(True),
         )
 
@@ -244,7 +244,7 @@ class TestEnqueueDoorbell:
     ) -> None:
         wakes: list[bool] = []
         monkeypatch.setattr(
-            "app.services.implementations.route_generation_worker.wake_route_generation_worker",
+            "app.services.implementations.job_service.wake_route_generation_worker",
             lambda: wakes.append(True),
         )
 

--- a/backend/python/tests/test_route_generation_worker.py
+++ b/backend/python/tests/test_route_generation_worker.py
@@ -1,0 +1,355 @@
+"""Tests for the route generation background worker.
+
+The worker opens its own sessions via the module-global session maker, so
+these tests point that global at the test engine (same pattern as the
+route-freeze job tests) and seed committed rows the worker can see.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import datetime
+from typing import TYPE_CHECKING, Any
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+from sqlmodel import select
+
+from app.models.enum import ProgressEnum
+from app.models.job import Job
+from app.models.location import Location
+from app.models.location_group import LocationGroup
+from app.models.route_group import RouteGroup
+from app.models.system_settings import SystemSettings
+from app.schemas.route_generation import (
+    RouteGenerationGroupInput,
+    RouteGenerationSettings,
+)
+from app.services.implementations import route_generation_runner as runner
+from app.services.implementations import route_generation_worker as worker
+from app.services.implementations.job_service import JobService
+from app.services.implementations.route_generation_worker import (
+    RECOVERY_ERROR_MESSAGE,
+    claim_next_pending_job,
+    recover_route_generation_jobs,
+    start_route_generation_worker,
+    stop_route_generation_worker,
+    wake_route_generation_worker,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+WAREHOUSE_LAT = 43.6532
+WAREHOUSE_LON = -79.3832
+DRIVE_DATE = datetime(2026, 6, 1, 8, 0)
+
+
+class FakeRoutingAlgorithm:
+    def __init__(self, plan: Callable[[list[Location]], Any]) -> None:
+        self._plan = plan
+        self.calls = 0
+
+    async def generate_routes(
+        self,
+        locations: list[Location],
+        warehouse_lat: float,  # noqa: ARG002
+        warehouse_lon: float,  # noqa: ARG002
+        settings: RouteGenerationSettings,  # noqa: ARG002
+        timeout_seconds: float | None = None,  # noqa: ARG002
+    ) -> list[list[Location]]:
+        self.calls += 1
+        return self._plan(locations)
+
+
+def _maker(test_db_engine: Any) -> async_sessionmaker[AsyncSession]:
+    return async_sessionmaker(
+        test_db_engine, class_=AsyncSession, expire_on_commit=False
+    )
+
+
+@pytest.fixture(autouse=True)
+def reset_worker_state() -> Any:
+    """Each test gets a fresh doorbell and no leftover worker task."""
+    worker._wake_event = asyncio.Event()
+    worker._worker_task = None
+    yield
+    task = worker._worker_task
+    worker._worker_task = None
+    if task is not None and not task.done():
+        task.cancel()
+
+
+@pytest.fixture(autouse=True)
+def fake_polyline(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def _fetch(**_kwargs: Any) -> tuple[str, float]:
+        return "fake-polyline", 12.5
+
+    monkeypatch.setattr(runner, "fetch_route_polyline", _fetch)
+
+
+async def _seed_routable_group(
+    maker: async_sessionmaker[AsyncSession],
+) -> tuple[LocationGroup, Location]:
+    async with maker() as session:
+        group = LocationGroup(name="Worker Group", color="#FF5733")
+        session.add(group)
+        await session.commit()
+        await session.refresh(group)
+
+        location = Location(
+            location_group_id=group.location_group_id,
+            name="Family A",
+            contact_name="Family A",
+            address="1 Test St",
+            phone_primary="5550000000",
+            delivery_type="Family",
+            latitude=43.7,
+            longitude=-79.4,
+        )
+        session.add(
+            SystemSettings(
+                warehouse_latitude=WAREHOUSE_LAT,
+                warehouse_longitude=WAREHOUSE_LON,
+            )
+        )
+        session.add(location)
+        await session.commit()
+        await session.refresh(location)
+        return group, location
+
+
+async def _queue_pending_job(
+    maker: async_sessionmaker[AsyncSession], group: LocationGroup
+) -> Job:
+    request = RouteGenerationGroupInput(
+        location_group=group,
+        settings=RouteGenerationSettings(route_start_time=DRIVE_DATE, num_routes=1),
+    )
+    async with maker() as session:
+        job = Job(
+            progress=ProgressEnum.PENDING,
+            input_payload=request.model_dump(mode="json"),
+        )
+        session.add(job)
+        await session.commit()
+        await session.refresh(job)
+        return job
+
+
+class TestClaimAndRecover:
+    @pytest.mark.asyncio
+    async def test_claim_takes_oldest_pending(self, test_db_engine: Any) -> None:
+        maker = _maker(test_db_engine)
+        async with maker() as session:
+            older = Job(progress=ProgressEnum.PENDING)
+            newer = Job(progress=ProgressEnum.PENDING)
+            session.add(older)
+            await session.commit()
+            await session.refresh(older)
+            session.add(newer)
+            await session.commit()
+            await session.refresh(newer)
+
+            claimed = await claim_next_pending_job(session)
+            assert claimed == older.job_id
+
+            await session.refresh(older)
+            await session.refresh(newer)
+            assert older.progress == ProgressEnum.RUNNING
+            assert older.started_at is not None
+            assert newer.progress == ProgressEnum.PENDING
+
+    @pytest.mark.asyncio
+    async def test_claim_returns_none_when_queue_empty(
+        self, test_db_engine: Any
+    ) -> None:
+        maker = _maker(test_db_engine)
+        async with maker() as session:
+            assert await claim_next_pending_job(session) is None
+
+    @pytest.mark.asyncio
+    async def test_claim_skips_non_pending_jobs(self, test_db_engine: Any) -> None:
+        maker = _maker(test_db_engine)
+        async with maker() as session:
+            session.add(Job(progress=ProgressEnum.CANCELLED))
+            session.add(Job(progress=ProgressEnum.COMPLETED))
+            await session.commit()
+            assert await claim_next_pending_job(session) is None
+
+    @pytest.mark.asyncio
+    async def test_recover_fails_running_and_wakes_for_pending(
+        self, test_db_engine: Any
+    ) -> None:
+        maker = _maker(test_db_engine)
+        async with maker() as session:
+            running = Job(progress=ProgressEnum.RUNNING)
+            pending = Job(progress=ProgressEnum.PENDING)
+            session.add(running)
+            session.add(pending)
+            await session.commit()
+            await session.refresh(running)
+            await session.refresh(pending)
+
+            assert not worker._wake_event.is_set()
+            await recover_route_generation_jobs(session)
+
+            await session.refresh(running)
+            await session.refresh(pending)
+            assert running.progress == ProgressEnum.FAILED
+            assert running.error_message == RECOVERY_ERROR_MESSAGE
+            assert running.finished_at is not None
+            assert pending.progress == ProgressEnum.PENDING
+            assert worker._wake_event.is_set()
+
+    @pytest.mark.asyncio
+    async def test_recover_does_not_wake_when_nothing_pending(
+        self, test_db_engine: Any
+    ) -> None:
+        maker = _maker(test_db_engine)
+        async with maker() as session:
+            session.add(Job(progress=ProgressEnum.RUNNING))
+            await session.commit()
+            await recover_route_generation_jobs(session)
+            assert not worker._wake_event.is_set()
+
+
+class TestEnqueueDoorbell:
+    @pytest.mark.asyncio
+    async def test_enqueue_pending_job_wakes_worker(
+        self, test_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        wakes: list[bool] = []
+        monkeypatch.setattr(
+            "app.services.implementations.route_generation_worker.wake_route_generation_worker",
+            lambda: wakes.append(True),
+        )
+
+        job = Job(progress=ProgressEnum.PENDING)
+        test_session.add(job)
+        await test_session.commit()
+        await test_session.refresh(job)
+
+        service = JobService(logger=logging.getLogger("test"), session=test_session)
+        await service.enqueue(job.job_id)
+
+        await test_session.refresh(job)
+        assert job.progress == ProgressEnum.PENDING
+        assert wakes == [True]
+
+    @pytest.mark.asyncio
+    async def test_enqueue_cancelled_job_does_not_wake(
+        self, test_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        wakes: list[bool] = []
+        monkeypatch.setattr(
+            "app.services.implementations.route_generation_worker.wake_route_generation_worker",
+            lambda: wakes.append(True),
+        )
+
+        job = Job(progress=ProgressEnum.CANCELLED)
+        test_session.add(job)
+        await test_session.commit()
+        await test_session.refresh(job)
+
+        service = JobService(logger=logging.getLogger("test"), session=test_session)
+        await service.enqueue(job.job_id)
+
+        await test_session.refresh(job)
+        assert job.progress == ProgressEnum.CANCELLED
+        assert wakes == []
+
+
+class TestWorkerLoop:
+    @pytest.mark.asyncio
+    async def test_worker_claims_and_completes_a_pending_job(
+        self, test_db_engine: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        maker = _maker(test_db_engine)
+        monkeypatch.setattr(worker, "async_session_maker_instance", maker)
+
+        group, location = await _seed_routable_group(maker)
+        job = await _queue_pending_job(maker, group)
+
+        algorithm = FakeRoutingAlgorithm(lambda locations: [locations])
+        monkeypatch.setattr(worker, "get_routing_algorithm", lambda: algorithm)
+
+        start_route_generation_worker()
+        wake_route_generation_worker()
+
+        async with maker() as session:
+            for _ in range(50):
+                refreshed = (
+                    await session.execute(select(Job).where(Job.job_id == job.job_id))
+                ).scalar_one()
+                if refreshed.progress in {
+                    ProgressEnum.COMPLETED,
+                    ProgressEnum.FAILED,
+                }:
+                    break
+                await asyncio.sleep(0.05)
+            else:
+                pytest.fail("worker did not finish the job in time")
+
+            assert refreshed.progress == ProgressEnum.COMPLETED
+            assert refreshed.route_group_id is not None
+            assert algorithm.calls == 1
+            assert (
+                await session.execute(
+                    select(RouteGroup).where(
+                        RouteGroup.route_group_id == refreshed.route_group_id
+                    )
+                )
+            ).scalar_one_or_none() is not None
+            assert location.latitude is not None
+
+        await stop_route_generation_worker()
+
+    @pytest.mark.asyncio
+    async def test_worker_drains_multiple_pending_jobs(
+        self, test_db_engine: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        maker = _maker(test_db_engine)
+        monkeypatch.setattr(worker, "async_session_maker_instance", maker)
+
+        group, _location = await _seed_routable_group(maker)
+        first = await _queue_pending_job(maker, group)
+        second = await _queue_pending_job(maker, group)
+
+        algorithm = FakeRoutingAlgorithm(lambda locations: [locations])
+        monkeypatch.setattr(worker, "get_routing_algorithm", lambda: algorithm)
+
+        start_route_generation_worker()
+        wake_route_generation_worker()
+
+        async with maker() as session:
+            for _ in range(80):
+                jobs = (
+                    (
+                        await session.execute(
+                            select(Job).where(
+                                Job.job_id.in_([first.job_id, second.job_id])
+                            )
+                        )
+                    )
+                    .scalars()
+                    .all()
+                )
+                if all(job.progress == ProgressEnum.COMPLETED for job in jobs):
+                    break
+                await asyncio.sleep(0.05)
+            else:
+                pytest.fail("worker did not drain both jobs in time")
+
+            assert algorithm.calls == 2
+
+        await stop_route_generation_worker()
+
+    @pytest.mark.asyncio
+    async def test_stop_cancels_an_idle_worker(self) -> None:
+        task = start_route_generation_worker()
+        assert not task.done()
+        await stop_route_generation_worker()
+        assert task.done()
+        assert worker._worker_task is None

--- a/backend/python/tests/test_route_generation_worker.py
+++ b/backend/python/tests/test_route_generation_worker.py
@@ -267,9 +267,7 @@ class TestWorkerLoop:
         self, test_db_engine: Any, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         maker = _maker(test_db_engine)
-        monkeypatch.setattr(
-            "app.models.async_session_maker_instance", maker
-        )
+        monkeypatch.setattr("app.models.async_session_maker_instance", maker)
 
         group, location = await _seed_routable_group(maker)
         job = await _queue_pending_job(maker, group)
@@ -314,9 +312,7 @@ class TestWorkerLoop:
         self, test_db_engine: Any, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         maker = _maker(test_db_engine)
-        monkeypatch.setattr(
-            "app.models.async_session_maker_instance", maker
-        )
+        monkeypatch.setattr("app.models.async_session_maker_instance", maker)
 
         group, _location = await _seed_routable_group(maker)
         first = await _queue_pending_job(maker, group)

--- a/backend/python/tests/test_route_generation_worker.py
+++ b/backend/python/tests/test_route_generation_worker.py
@@ -267,7 +267,9 @@ class TestWorkerLoop:
         self, test_db_engine: Any, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         maker = _maker(test_db_engine)
-        monkeypatch.setattr(worker, "async_session_maker_instance", maker)
+        monkeypatch.setattr(
+            "app.models.async_session_maker_instance", maker
+        )
 
         group, location = await _seed_routable_group(maker)
         job = await _queue_pending_job(maker, group)
@@ -280,6 +282,7 @@ class TestWorkerLoop:
 
         async with maker() as session:
             for _ in range(50):
+                session.expire_all()
                 refreshed = (
                     await session.execute(select(Job).where(Job.job_id == job.job_id))
                 ).scalar_one()
@@ -311,7 +314,9 @@ class TestWorkerLoop:
         self, test_db_engine: Any, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         maker = _maker(test_db_engine)
-        monkeypatch.setattr(worker, "async_session_maker_instance", maker)
+        monkeypatch.setattr(
+            "app.models.async_session_maker_instance", maker
+        )
 
         group, _location = await _seed_routable_group(maker)
         first = await _queue_pending_job(maker, group)
@@ -325,6 +330,7 @@ class TestWorkerLoop:
 
         async with maker() as session:
             for _ in range(80):
+                session.expire_all()
                 jobs = (
                     (
                         await session.execute(

--- a/backend/python/tests/test_routes.py
+++ b/backend/python/tests/test_routes.py
@@ -5735,7 +5735,7 @@ class TestJobRoutes:
     async def test_enqueue_cancelled_job_does_not_run(
         self, test_session: AsyncSession
     ) -> None:
-        """Queued work checks job state before moving to Running."""
+        """enqueue is only a doorbell: cancelled jobs stay cancelled."""
         from app.models.job import Job
         from app.services.implementations.job_service import JobService
 

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -5174,6 +5174,7 @@
     },
     "/jobs/generate": {
       "post": {
+        "description": "Accept a generation request: persist it as PENDING and wake the worker.",
         "operationId": "generate_job",
         "requestBody": {
           "content": {

--- a/frontend/src/api/generated/@tanstack/react-query.gen.ts
+++ b/frontend/src/api/generated/@tanstack/react-query.gen.ts
@@ -1055,6 +1055,8 @@ export const getJobsOptions = (options?: Options<GetJobsData>) =>
 
 /**
  * Generate Job
+ *
+ * Accept a generation request: persist it as PENDING and wake the worker.
  */
 export const generateJobMutation = (
   options?: Partial<Options<GenerateJobData>>

--- a/frontend/src/api/generated/sdk.gen.ts
+++ b/frontend/src/api/generated/sdk.gen.ts
@@ -723,6 +723,8 @@ export const getJobs = <ThrowOnError extends boolean = false>(
 
 /**
  * Generate Job
+ *
+ * Accept a generation request: persist it as PENDING and wake the worker.
  */
 export const generateJob = <ThrowOnError extends boolean = false>(
   options: Options<GenerateJobData, ThrowOnError>


### PR DESCRIPTION
## JIRA Ticket
[F4KRP-49](https://f4kblueprint.atlassian.net/browse/F4KRP-49)

## Implementation Description
<!-- Quick summary of what you built and why. Include design justifications if needed -->
### Route generation overview

1. **Choose a routing algorithm** -> call a single routing engine.
2. **Map engine output → DB** -> turn results into ordered `Route` / `RouteStop` rows (including polylines) and persist them under `RouteGroups`.

---

### Worker lifecycle

| Phase | Behavior |
| --- | --- |
| **Start** | Once on app lifespan via `start_route_generation_worker()` |
| **Stop** | On app shutdown |

**Loop**

1. Sleep on `_wake_event`
2. On wake (enqueue) → clear the event
3. Drain the queue: claim + run **one job at a time** until no `PENDING` jobs remain
4. Go back to sleep

**Claim**

- Atomically promote oldest `PENDING` → `RUNNING` in one `UPDATE … RETURNING`

**Dispatch**

- Resolve algorithm (`GoogleMapsFleetRoutingAlgorithm`)
- Call `run_generation_job(...)`

## Steps to Test
<!-- What should the reviewer do to verify your changes? Include expected results -->
1. POST /jobs/generate to enqueue a job
2. The in-process worker (started on app lifespan) claims it and runs the runner
3. HTTP returns 202 immediately; the worker does the rest in-process.
4. Check if the RouteGroup is added to the table

## What Should Reviewers Focus On?
<!-- Call out substantial changes or anything you want a second opinion on -->
*

## Checklist
- [x] PR name and commits are descriptive, imperative, and atomic (trivial commits squashed)
- [ ] I have requested a review from Claude, understood its suggestions, and implemented fixes where needed (or documented disagreements)
- [x] I have requested a review from the PL and relevant devs with background on this PR

**Frontend only — delete if not applicable:**
- [ ] Follows Tailwind/shadcn best practices per README; no hardcoded color or spacing values
- [ ] Implementation matches Zeplin designs and screenshots are attached above
- [ ] Screens render correctly on mobile and desktop; no console warnings or errors