### PR TITLE
Add Cancelled to the progressenum type in Postgres

### DIFF
--- a/backend/python/migrations/versions/f1a7c0d92b45_add_cancelled_to_progressenum.py
+++ b/backend/python/migrations/versions/f1a7c0d92b45_add_cancelled_to_progressenum.py
@@ -1,0 +1,45 @@
+"""add Cancelled to progressenum
+
+`ProgressEnum.CANCELLED` was added in Python when job cancellation landed, but
+the Postgres type has carried only PENDING/RUNNING/COMPLETED/FAILED since it was
+created. POST /jobs/{id}/cancel therefore fails on a migrated database with
+`invalid input value for enum progressenum: "CANCELLED"`. The test suite builds
+its schema from the models with `create_all`, so it never saw the gap.
+
+Revision ID: f1a7c0d92b45
+Revises: d4eefe397549
+Create Date: 2026-08-07 10:00:00.000000
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "f1a7c0d92b45"
+down_revision = "d4eefe397549"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # ALTER TYPE ... ADD VALUE cannot run inside a transaction block, so step
+    # outside Alembic's. BEFORE 'COMPLETED' keeps the type's sort order matching
+    # the declaration order in app/models/enum.py.
+    with op.get_context().autocommit_block():
+        op.execute("ALTER TYPE progressenum ADD VALUE 'CANCELLED' BEFORE 'COMPLETED'")
+
+
+def downgrade():
+    # Postgres cannot drop a value from an enum, so rebuild the type. Cancelled
+    # jobs become Failed: it is the only terminal state left that says the run
+    # did not produce routes.
+    op.execute("UPDATE jobs SET progress = 'FAILED' WHERE progress = 'CANCELLED'")
+    op.execute("ALTER TYPE progressenum RENAME TO progressenum_old")
+    op.execute(
+        "CREATE TYPE progressenum AS ENUM ('PENDING', 'RUNNING', 'COMPLETED', 'FAILED')"
+    )
+    op.execute(
+        "ALTER TABLE jobs ALTER COLUMN progress TYPE progressenum "
+        "USING progress::text::progressenum"
+    )
+    op.execute("DROP TYPE progressenum_old")


### PR DESCRIPTION
## Implementation Description

`ProgressEnum.CANCELLED` was added in Python when job cancellation landed (#203), but the Postgres type has carried only `PENDING`/`RUNNING`/`COMPLETED`/`FAILED` since it was created in `002_initial_db_migration.py`. Nothing ever ran `ALTER TYPE progressenum ADD VALUE`.

On any database built from migrations — staging, prod, the `boot` smoke job — that means:

- `POST /jobs/{id}/cancel` raises `invalid input value for enum progressenum: "CANCELLED"` on the UPDATE.
- `JobService.update_progress`'s `.where(progress != CANCELLED)` binds the same missing literal, so progress writes on that path fail too.

The tests never saw it: `tests/conftest.py` builds the schema with `SQLModel.metadata.create_all`, so the test database gets the enum straight from the Python model. `alembic check` didn't see it either — autogenerate does not diff enum labels.

This adds the one missing migration. `ADD VALUE ... BEFORE 'COMPLETED'` keeps the type's sort order matching the declaration order in `app/models/enum.py`, and the `autocommit_block` is required because `ALTER TYPE ... ADD VALUE` cannot run inside a transaction. The downgrade rebuilds the type (Postgres cannot drop an enum value) and maps any `CANCELLED` rows to `FAILED`.

Found while reviewing #251, whose runner and worker are built entirely around Running-only guards that a cancel is supposed to trip. Those guards can't be exercised until this lands, so this is worth merging ahead of it.

## Steps to Test

1. `alembic upgrade head` against a database migrated from scratch.
2. `POST /jobs/generate`, then `POST /jobs/{id}/cancel` — the job should come back `Cancelled` instead of a 500.
3. `alembic downgrade -1` then `upgrade head` round-trips cleanly.

I could not run these locally — Docker Desktop would not start on my machine, and there is no local Postgres. The `boot` job does exactly step 1 plus `alembic check` from scratch on postgres:17, so CI is the real verification here.

## What Should Reviewers Focus On?

The downgrade's `CANCELLED → FAILED` mapping is a judgement call — it is the only remaining terminal state that says "did not produce routes". Say so if you would rather the downgrade refuse to run when cancelled rows exist.

Separately: this class of bug is invisible to us because the test schema comes from the models and the migrated schema is only ever booted, never queried. Worth a ticket to run the suite against a migrated database, or at least to compare enum labels in the boot job.

## Checklist
- [x] PR name and commits are descriptive, imperative, and atomic (trivial commits squashed)
- [x] I have requested a review from Claude, understood its suggestions, and implemented fixes where needed (or documented disagreements)
- [ ] I have requested a review from the PL and relevant devs with background on this PR
