### PR TITLE
F4KRP-53: Route generation loading and confirmation screen

### DIFF
--- a/backend/python/app/models/job.py
+++ b/backend/python/app/models/job.py
@@ -53,6 +53,11 @@ class JobRead(JobBase):
     """Job response model"""
 
     job_id: UUID
+    error_message: str | None = None
+    routes_created: int | None = None
+    total_stops: int | None = None
+    total_distance_km: float | None = None
+    total_families: int | None = None
 
 
 class JobUpdate(SQLModel):

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -1134,6 +1134,17 @@
       "JobRead": {
         "description": "Job response model",
         "properties": {
+          "error_message": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error Message"
+          },
           "job_id": {
             "format": "uuid",
             "title": "Job Id",
@@ -1154,6 +1165,50 @@
               }
             ],
             "title": "Route Group Id"
+          },
+          "routes_created": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Routes Created"
+          },
+          "total_distance_km": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Total Distance Km"
+          },
+          "total_families": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Total Families"
+          },
+          "total_stops": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Total Stops"
           }
         },
         "required": [

--- a/frontend/src/api/generated/types.gen.ts
+++ b/frontend/src/api/generated/types.gen.ts
@@ -697,6 +697,10 @@ export type JobEnqueueResponse = {
  */
 export type JobRead = {
   /**
+   * Error Message
+   */
+  error_message?: string | null;
+  /**
    * Job Id
    */
   job_id: string;
@@ -705,6 +709,22 @@ export type JobRead = {
    * Route Group Id
    */
   route_group_id?: string | null;
+  /**
+   * Routes Created
+   */
+  routes_created?: number | null;
+  /**
+   * Total Distance Km
+   */
+  total_distance_km?: number | null;
+  /**
+   * Total Families
+   */
+  total_families?: number | null;
+  /**
+   * Total Stops
+   */
+  total_stops?: number | null;
 };
 
 /**

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -1,6 +1,11 @@
 export { useAddresses } from './addresses';
 export { useForgotPassword, useLogin } from './auth';
 export { describeApiFailure } from './errors';
+export {
+  useCancelGenerationJobs,
+  useGenerationJobs,
+  useStartGenerationJobs,
+} from './jobs';
 export { useLocationGroups } from './location-groups';
 export { useApplyLocationImport, usePreviewLocationImport } from './locations';
 export { useRouteGroups } from './route-groups';

--- a/frontend/src/api/jobs.ts
+++ b/frontend/src/api/jobs.ts
@@ -1,0 +1,74 @@
+import { useMutation, useQueries } from '@tanstack/react-query';
+
+import {
+  getJobOptions,
+  getJobQueryKey,
+} from './generated/@tanstack/react-query.gen';
+import { cancelJob, generateJob } from './generated/sdk.gen';
+import type { RouteGenerationGroupInput } from './generated/types.gen';
+
+const TERMINAL_JOB_STATES = new Set(['Cancelled', 'Completed', 'Failed']);
+
+export function useStartGenerationJobs() {
+  return useMutation({
+    mutationFn: async (inputs: RouteGenerationGroupInput[]) => {
+      const results = await Promise.allSettled(
+        inputs.map(async (body) => {
+          const { data } = await generateJob({ body, throwOnError: true });
+          return data.job_id;
+        })
+      );
+      const jobIds = results.flatMap((result) =>
+        result.status === 'fulfilled' ? [result.value] : []
+      );
+      const failed = results.find((result) => result.status === 'rejected');
+
+      if (failed) {
+        await Promise.allSettled(
+          jobIds.map((jobId) =>
+            cancelJob({ path: { job_id: jobId }, throwOnError: true })
+          )
+        );
+        throw failed.reason;
+      }
+
+      return jobIds;
+    },
+  });
+}
+
+export function useGenerationJobs(jobIds: string[]) {
+  return useQueries({
+    queries: jobIds.map((jobId) => ({
+      ...getJobOptions({ path: { job_id: jobId } }),
+      refetchInterval: (query: { state: { data?: { progress?: string } } }) =>
+        query.state.data?.progress &&
+        TERMINAL_JOB_STATES.has(query.state.data.progress)
+          ? false
+          : 1500,
+    })),
+  });
+}
+
+export function useCancelGenerationJobs() {
+  return useMutation({
+    mutationFn: async (jobIds: string[]) =>
+      Promise.all(
+        jobIds.map(async (jobId) => {
+          const { data } = await cancelJob({
+            path: { job_id: jobId },
+            throwOnError: true,
+          });
+          return data;
+        })
+      ),
+    onSuccess: (_jobs, jobIds, _context, { client }) =>
+      Promise.all(
+        jobIds.map((jobId) =>
+          client.invalidateQueries({
+            queryKey: getJobQueryKey({ path: { job_id: jobId } }),
+          })
+        )
+      ),
+  });
+}

--- a/frontend/src/pages/admin/routes/generation/ConfigureStep.tsx
+++ b/frontend/src/pages/admin/routes/generation/ConfigureStep.tsx
@@ -269,7 +269,6 @@ export function ConfigureStep() {
             ),
             num_routes: row.form.routeCount,
             return_to_warehouse: row.form.returnToWarehouse,
-            max_stops_per_route: null,
             max_boxes_per_driver: systemSettings?.boxes_per_car,
             children_per_box: systemSettings?.children_per_box,
             service_time_minutes: systemSettings?.dropoff_minutes,

--- a/frontend/src/pages/admin/routes/generation/GenerateStep.tsx
+++ b/frontend/src/pages/admin/routes/generation/GenerateStep.tsx
@@ -1,6 +1,19 @@
-import { useEffect, useState } from 'react';
-import { Link, Navigate, useOutletContext } from 'react-router-dom';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import {
+  Link,
+  Navigate,
+  useNavigate,
+  useOutletContext,
+} from 'react-router-dom';
 
+import {
+  describeApiFailure,
+  useCancelGenerationJobs,
+  useGenerationJobs,
+  useStartGenerationJobs,
+} from '@/api';
+import type { JobRead } from '@/api/generated/types.gen';
+import girlCatching from '@/assets/illustrations/girl-catching.png';
 import {
   Banner,
   Button,
@@ -9,116 +22,349 @@ import {
   CardDescription,
   CardHeader,
   CardTitle,
+  Modal,
+  ModalContent,
+  ModalDescription,
+  ModalFooter,
+  ModalHeader,
+  ModalTitle,
   Progress,
   Spinner,
   StatisticsCard,
 } from '@/common/components';
 
 import type { GenerationOutletContext } from './AdminRoutesGenerationLayout';
+import { GenerationFooter } from './GenerationFooter';
 
-// TODO: replace with actual values from API
-const MOCK_COMPLETED = 1;
-const MOCK_TOTAL = 3;
-const TOTAL_FAMILIES = 515;
-const AVERAGE_STOPS = 12;
-const LONGEST_ROUTE = 22;
+const WEEKDAYS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'] as const;
+const BAR_COLORS = [
+  'bg-blue-300',
+  'bg-brand-pink',
+  'bg-brand-orange',
+  'bg-brand-green',
+  'bg-brand-light-blue',
+  'bg-brand-pink',
+  'bg-brand-orange',
+] as const;
 
-export function GenerateStep() {
-  const { file } = useOutletContext<GenerationOutletContext>();
-  const percent = Math.round((MOCK_COMPLETED / MOCK_TOTAL) * 100);
+function getWeekday(dateTime: string): (typeof WEEKDAYS)[number] {
+  const [date] = dateTime.split('T');
+  const localDate = new Date(`${date}T00:00:00`);
+  return localDate.toLocaleDateString('en-US', {
+    weekday: 'short',
+  }) as (typeof WEEKDAYS)[number];
+}
 
-  // TODO: replace with actual response from API
-  const [success, setSuccess] = useState(false);
+function formatDistance(distance: number): string {
+  const rounded = Math.round(distance * 10) / 10;
+  return `${rounded.toLocaleString()} km`;
+}
 
-  // TODO: replace with actual response from API
-  // create a timer that makes the GENERATION_SUCCESS true after 5 seconds
-  useEffect(() => {
-    const id = setTimeout(() => {
-      setSuccess(true);
-    }, 5000);
-    return () => clearTimeout(id);
-  }, []);
+interface SummaryProps {
+  jobs: JobRead[];
+  inputs: GenerationOutletContext['routeGenerationInputs'];
+}
 
-  if (!file) {
-    return <Navigate to="/admin/routes/generation/import" replace />;
-  }
+function GenerationSummary({ jobs, inputs }: SummaryProps) {
+  const routesByDay = new Map<(typeof WEEKDAYS)[number], number>();
 
-  if (success) {
-    return (
-      <div className="flex flex-col gap-8">
-        <Banner
-          variant="success"
-          subtitle="Generated on Oct 20, 2025 at 10:42 AM by Emily"
-        >
-          Routes generated successfully and auto-saved successfully!
-        </Banner>
-        <div className="flex gap-8">
+  jobs.forEach((job, index) => {
+    const input = inputs[index];
+    if (!input) return;
+    const weekday = getWeekday(input.settings.route_start_time);
+    routesByDay.set(
+      weekday,
+      (routesByDay.get(weekday) ?? 0) +
+        (job.routes_created ?? input.settings.num_routes)
+    );
+  });
+
+  const visibleWeekdays = WEEKDAYS.filter(
+    (weekday) =>
+      WEEKDAYS.indexOf(weekday) < 5 || (routesByDay.get(weekday) ?? 0) > 0
+  );
+  const maxDayCount = Math.max(
+    1,
+    ...visibleWeekdays.map((weekday) => routesByDay.get(weekday) ?? 0)
+  );
+  const routesCreated = jobs.reduce(
+    (total, job) => total + (job.routes_created ?? 0),
+    0
+  );
+  const totalStops = jobs.reduce(
+    (total, job) => total + (job.total_stops ?? 0),
+    0
+  );
+  const totalDistance = jobs.reduce(
+    (total, job) => total + (job.total_distance_km ?? 0),
+    0
+  );
+  const totalFamilies = jobs.reduce(
+    (total, job) => total + (job.total_families ?? 0),
+    0
+  );
+
+  return (
+    <section className="flex flex-col gap-6">
+      <div className="flex flex-col gap-1">
+        <h2 className="text-grey-500">Routes Generated Successfully</h2>
+        <p className="text-p1 text-grey-500">
+          Your optimized delivery routes are ready!
+        </p>
+      </div>
+
+      <div className="desktop:grid-cols-[minmax(0,1fr)_272px] grid gap-6">
+        <Card className="min-h-112">
+          <CardHeader>
+            <CardTitle>Route Count by Day</CardTitle>
+          </CardHeader>
+          <CardContent
+            className="grid flex-1 gap-5 pt-3"
+            style={{
+              gridTemplateColumns: `repeat(${visibleWeekdays.length}, minmax(0, 1fr))`,
+            }}
+          >
+            {visibleWeekdays.map((weekday, index) => {
+              const count = routesByDay.get(weekday) ?? 0;
+              return (
+                <div
+                  key={weekday}
+                  className="flex min-w-0 flex-col items-center justify-end"
+                >
+                  <div className="flex h-72 w-full items-end justify-center">
+                    {count > 0 && (
+                      <div
+                        className={`${BAR_COLORS[index]} w-full max-w-40 rounded-t-lg`}
+                        style={{
+                          height: `${Math.max(18, (count / maxDayCount) * 100)}%`,
+                        }}
+                      />
+                    )}
+                  </div>
+                  <p className="text-h2 mt-3 font-bold text-blue-300">
+                    {count}
+                  </p>
+                  <p className="text-p1 text-grey-400">{weekday}</p>
+                </div>
+              );
+            })}
+          </CardContent>
+        </Card>
+
+        <div className="grid content-start gap-4">
           <StatisticsCard
             color="green"
             label="Routes Created"
-            value={MOCK_COMPLETED}
+            value={routesCreated}
             character="granny"
           />
           <StatisticsCard
             color="blue"
-            label="Total Families"
-            value={TOTAL_FAMILIES}
+            label="Total Stops"
+            value={totalStops}
             character="boy"
           />
           <StatisticsCard
             color="pink"
-            label="Average Stops"
-            value={AVERAGE_STOPS}
+            label="Total Distance"
+            value={formatDistance(totalDistance)}
             character="boyPointing"
           />
           <StatisticsCard
             color="orange"
-            label="Longest Route"
-            value={`${LONGEST_ROUTE} km`}
+            label="Total Families"
+            value={totalFamilies}
             character="girlSearching"
           />
         </div>
-        <div className="flex justify-end">
-          <Button asChild variant="primary">
-            <Link to="/admin/routes">View routes</Link>
-          </Button>
-        </div>
       </div>
-    );
+    </section>
+  );
+}
+
+export function GenerateStep() {
+  const navigate = useNavigate();
+  const { file, routeGenerationInputs } =
+    useOutletContext<GenerationOutletContext>();
+  const [jobIds, setJobIds] = useState<string[]>([]);
+  const [cancelOpen, setCancelOpen] = useState(false);
+  const generationStarted = useRef(false);
+  const startGeneration = useStartGenerationJobs();
+  const cancelGeneration = useCancelGenerationJobs();
+  const jobQueries = useGenerationJobs(jobIds);
+
+  useEffect(() => {
+    if (generationStarted.current || routeGenerationInputs.length === 0) return;
+    generationStarted.current = true;
+    void startGeneration
+      .mutateAsync(routeGenerationInputs)
+      .then(setJobIds)
+      .catch(() => undefined);
+  }, [routeGenerationInputs, startGeneration]);
+
+  const jobs = useMemo(
+    () =>
+      jobQueries
+        .map((query) => query.data)
+        .filter((job): job is JobRead => job !== undefined),
+    [jobQueries]
+  );
+  const completedCount = jobs.filter(
+    (job) => job.progress === 'Completed'
+  ).length;
+  const failedJob = jobs.find((job) => job.progress === 'Failed');
+  const cancelledJob = jobs.find((job) => job.progress === 'Cancelled');
+  const pollingError = jobQueries.find((query) => query.isError)?.error;
+  const allCompleted =
+    jobIds.length === routeGenerationInputs.length &&
+    completedCount === routeGenerationInputs.length;
+  const errorMessage = startGeneration.error
+    ? (describeApiFailure(startGeneration.error) ??
+      'Route generation could not be started. Please review your route settings and try again.')
+    : pollingError
+      ? (describeApiFailure(pollingError) ??
+        'Route generation status could not be loaded. Please try again.')
+      : failedJob
+        ? (failedJob.error_message ??
+          'A route group could not be generated. Please return to the previous step and try again.')
+        : cancelledJob
+          ? 'Route generation was cancelled. Return to the previous step to configure and try again.'
+          : null;
+
+  if (!file || routeGenerationInputs.length === 0) {
+    return <Navigate to="/admin/routes/generation/import" replace />;
   }
+
+  const handleCancel = async () => {
+    try {
+      await cancelGeneration.mutateAsync(
+        jobIds.filter((jobId) => {
+          const job = jobs.find((candidate) => candidate.job_id === jobId);
+          return (
+            !job ||
+            (job.progress !== 'Completed' &&
+              job.progress !== 'Cancelled' &&
+              job.progress !== 'Failed')
+          );
+        })
+      );
+      setCancelOpen(false);
+      navigate('/admin/routes/generation/configure');
+    } catch {
+      // The mutation error is rendered in the modal so the admin can retry.
+    }
+  };
 
   return (
     <>
-      <Card>
-        <CardHeader>
-          <CardTitle>Route Generation</CardTitle>
-          <CardDescription>Creating optimized delivery routes.</CardDescription>
-        </CardHeader>
+      {allCompleted ? (
+        <GenerationSummary jobs={jobs} inputs={routeGenerationInputs} />
+      ) : (
+        <Card>
+          <CardHeader>
+            <CardTitle>Route Generation</CardTitle>
+            <CardDescription>
+              Creating optimized delivery routes.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="flex min-h-84 flex-col items-center justify-center gap-4">
+            {errorMessage ? (
+              <Banner variant="error" className="w-full max-w-2xl">
+                {errorMessage}
+              </Banner>
+            ) : (
+              <>
+                <img
+                  src={girlCatching}
+                  alt=""
+                  aria-hidden
+                  className="size-44 object-contain"
+                />
+                <p className="text-p2 text-grey-400">
+                  {completedCount} / {routeGenerationInputs.length} route groups
+                  completed
+                </p>
+                <Progress
+                  value={(completedCount / routeGenerationInputs.length) * 100}
+                  aria-label={`${completedCount} of ${routeGenerationInputs.length} route groups completed`}
+                  className="w-80 max-w-full"
+                />
+                <div
+                  className="text-p2 flex items-center gap-2 text-blue-300"
+                  role="status"
+                  aria-live="polite"
+                >
+                  <Spinner size="sm" />
+                  <span>Generating routes...</span>
+                </div>
+              </>
+            )}
+          </CardContent>
+        </Card>
+      )}
 
-        {/* Loading content */}
-        <CardContent className="flex flex-col items-center gap-12 pt-6">
-          {/* Spinner + text */}
-          <div className="flex flex-col items-center gap-6">
-            <Spinner size="lg" />
-            <div className="flex flex-col items-center gap-1 text-center">
-              <p className="text-grey-500 text-base font-bold">
-                Generating Routes
-              </p>
-              <p className="text-grey-500 text-base">
-                This may take up to 5 minutes...
-              </p>
-            </div>
-          </div>
+      <GenerationFooter>
+        {!allCompleted && (
+          <Button
+            variant="secondary"
+            disabled={startGeneration.isPending}
+            onClick={() =>
+              jobIds.length > 0
+                ? setCancelOpen(true)
+                : navigate('/admin/routes/generation/configure')
+            }
+          >
+            Back to configure routes
+          </Button>
+        )}
+        {allCompleted ? (
+          <Button asChild variant="primary">
+            <Link to="/admin/routes">View routes</Link>
+          </Button>
+        ) : (
+          <Button variant="primary" disabled>
+            View routes
+          </Button>
+        )}
+      </GenerationFooter>
 
-          {/* Progress */}
-          <div className="flex flex-col items-center gap-2">
-            <Progress value={percent} className="h-2 w-80" />
-            <p className="text-grey-500 text-sm">
-              {MOCK_COMPLETED}/{MOCK_TOTAL} route groups completed
-            </p>
-          </div>
-        </CardContent>
-      </Card>
+      <Modal open={cancelOpen} onOpenChange={setCancelOpen}>
+        <ModalContent showCloseButton={false}>
+          <ModalHeader>
+            <ModalTitle>Cancel Route Generation</ModalTitle>
+            <ModalDescription>
+              If you go back to{' '}
+              <span className="text-blue-300">Configure Routes</span> now, the
+              current route generation will be cancelled and progress will be
+              lost. Do you still want to continue?
+            </ModalDescription>
+          </ModalHeader>
+          {cancelGeneration.isError && (
+            <Banner variant="error">
+              {describeApiFailure(cancelGeneration.error) ??
+                'Route generation could not be cancelled. Please try again.'}
+            </Banner>
+          )}
+          <ModalFooter className="justify-end">
+            <Button
+              variant="secondary"
+              disabled={cancelGeneration.isPending}
+              onClick={() => setCancelOpen(false)}
+            >
+              Keep generating
+            </Button>
+            <Button
+              variant="primary"
+              disabled={cancelGeneration.isPending}
+              onClick={() => void handleCancel()}
+            >
+              {cancelGeneration.isPending
+                ? 'Cancelling...'
+                : 'Cancel route generation'}
+            </Button>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
     </>
   );
 }


### PR DESCRIPTION
## Summary
- start one generation job per selected route group and poll live job status
- match the Figma loading, cancellation, and completion states
- show route counts by weekday plus routes, stops, distance, and family totals
- expose the existing persisted job summary fields through the job read contract
- cancel active jobs before returning to route configuration and handle partial enqueue failures

## Stack
- stacked on #251 (kerushani/wire-route-generation)
- includes the already-merged F4KRP-255 route configuration prerequisite because #251 has not yet rebased onto current main

## Validation
- Prettier
- ESLint
- TypeScript
- Vitest: 22 tests passed
- production build
- Ruff format and lint

Backend pytest could not start locally because the host Python environment does not have FastAPI installed. No Postman files are included.