### PR TITLE
F4KRP-49: Auto retry running jobs after a crash

### DIFF
--- a/backend/python/app/models/job.py
+++ b/backend/python/app/models/job.py
@@ -37,6 +37,7 @@ class Job(JobBase, BaseModel, table=True):
         default=None, sa_column=Column(JSON, nullable=True)
     )
     error_message: str | None = Field(default=None, sa_type=Text)
+    retry_count: int = Field(default=0)
     routes_created: int | None = Field(default=None)
     total_stops: int | None = Field(default=None)
     total_distance_km: float | None = Field(default=None)

--- a/backend/python/app/services/implementations/route_generation_runner.py
+++ b/backend/python/app/services/implementations/route_generation_runner.py
@@ -75,11 +75,6 @@ async def run_generation_job(
     summary recorded) or `FAILED` (with `error_message` set), unless it was
     cancelled along the way, in which case the cancellation stands and
     nothing is saved.
-
-    TODO(cancel): Honor POST /jobs/{id}/cancel cooperatively via the jobs row:
-    if progress is no longer Running at load/save/fail checkpoints, exit without
-    completing or overwriting Cancelled. Do not try to abort the in-flight
-    routing call — discard results instead.
     """
     started = time.perf_counter()
     try:
@@ -162,9 +157,6 @@ async def run_generation_job(
 
 async def _load_running_job(session: AsyncSession, job_id: UUID) -> Job | None:
     """Fetch the job, if it is still ours to run.
-
-    TODO(cancel): If POST /jobs/{id}/cancel flipped this job to Cancelled before
-    we start real work, return None here so generation never begins.
     """
     job = (
         await session.execute(select(Job).where(Job.job_id == job_id))
@@ -397,10 +389,6 @@ async def _save_or_discard(
     routing engine is working takes the routes with them, instead of leaving
     a RouteGroup attached to a cancelled job, `update_progress` would refuse
     to overwrite the cancellation, and the routes would be stranded.
-
-    TODO(cancel): When POST /jobs/{id}/cancel sets Cancelled mid-run, this
-    Running-only UPDATE must miss (rowcount 0), roll back the RouteGroup, and
-    leave the Cancelled row alone.
     """
     session.add(route_group)
     await session.flush()
@@ -454,9 +442,6 @@ async def _fail(session: AsyncSession, job_id: UUID, message: str) -> None:
 
     Guarded the same way `JobService.update_progress` is, so a job an admin
     already cancelled stays cancelled instead of resurfacing as a failure.
-
-    TODO(cancel): If POST /jobs/{id}/cancel already set Cancelled, this
-    Running-only failure UPDATE must no-op so Cancelled is not overwritten.
     """
     logger.warning("Route generation job %s failed: %s", job_id, message)
 

--- a/backend/python/app/services/implementations/route_generation_runner.py
+++ b/backend/python/app/services/implementations/route_generation_runner.py
@@ -82,8 +82,10 @@ async def run_generation_job(
         if job is None:
             return
 
-        # Idempotency: a prior attempt may have saved the RouteGroup before the
-        # process died. Do not call the routing engine again.
+        # Belt-and-suspenders: _save_or_discard commits the RouteGroup and the
+        # COMPLETED status in one transaction, and recovery only requeues jobs
+        # with route_group_id IS NULL, so this should not be reachable today.
+        # Keep the guard in case that atomicity assumption changes later.
         if job.route_group_id is not None:
             await _complete_already_saved(session, job)
             return
@@ -177,10 +179,11 @@ async def _load_running_job(session: AsyncSession, job_id: UUID) -> Job | None:
 
 
 async def _complete_already_saved(session: AsyncSession, job: Job) -> None:
-    """Mark a job Completed when its RouteGroup was already persisted.
+    """Mark a job Completed when its RouteGroup is already linked.
 
-    Used when a crash happened after save but before the status flip, or when
-    a requeued job is claimed again despite already having a route_group_id.
+    Not expected under today's save/recovery atomicity (see the guard in
+    ``run_generation_job``). Kept as a defensive no-regenerate path if a job
+    ever arrives Running with ``route_group_id`` already set.
     """
     now = now_est_naive()
     result = cast(

--- a/backend/python/app/services/implementations/route_generation_runner.py
+++ b/backend/python/app/services/implementations/route_generation_runner.py
@@ -156,8 +156,7 @@ async def run_generation_job(
 
 
 async def _load_running_job(session: AsyncSession, job_id: UUID) -> Job | None:
-    """Fetch the job, if it is still ours to run.
-    """
+    """Fetch the job, if it is still ours to run."""
     job = (
         await session.execute(select(Job).where(Job.job_id == job_id))
     ).scalar_one_or_none()
@@ -183,7 +182,7 @@ async def _complete_already_saved(session: AsyncSession, job: Job) -> None:
     Used when a crash happened after save but before the status flip, or when
     a requeued job is claimed again despite already having a route_group_id.
     """
-    now = _now_est_naive()
+    now = now_est_naive()
     result = cast(
         "CursorResult[Any]",
         await session.execute(

--- a/backend/python/app/services/implementations/route_generation_runner.py
+++ b/backend/python/app/services/implementations/route_generation_runner.py
@@ -75,6 +75,11 @@ async def run_generation_job(
     summary recorded) or `FAILED` (with `error_message` set), unless it was
     cancelled along the way, in which case the cancellation stands and
     nothing is saved.
+
+    TODO(cancel): Honor POST /jobs/{id}/cancel cooperatively via the jobs row:
+    if progress is no longer Running at load/save/fail checkpoints, exit without
+    completing or overwriting Cancelled. Do not try to abort the in-flight
+    routing call — discard results instead.
     """
     started = time.perf_counter()
     try:
@@ -150,7 +155,11 @@ async def run_generation_job(
 
 
 async def _load_running_job(session: AsyncSession, job_id: UUID) -> Job | None:
-    """Fetch the job, if it is still ours to run."""
+    """Fetch the job, if it is still ours to run.
+
+    TODO(cancel): If POST /jobs/{id}/cancel flipped this job to Cancelled before
+    we start real work, return None here so generation never begins.
+    """
     job = (
         await session.execute(select(Job).where(Job.job_id == job_id))
     ).scalar_one_or_none()
@@ -345,6 +354,10 @@ async def _save_or_discard(
     routing engine is working takes the routes with them, instead of leaving
     a RouteGroup attached to a cancelled job, `update_progress` would refuse
     to overwrite the cancellation, and the routes would be stranded.
+
+    TODO(cancel): When POST /jobs/{id}/cancel sets Cancelled mid-run, this
+    Running-only UPDATE must miss (rowcount 0), roll back the RouteGroup, and
+    leave the Cancelled row alone.
     """
     session.add(route_group)
     await session.flush()
@@ -397,6 +410,9 @@ async def _fail(session: AsyncSession, job_id: UUID, message: str) -> None:
 
     Guarded the same way `JobService.update_progress` is, so a job an admin
     already cancelled stays cancelled instead of resurfacing as a failure.
+
+    TODO(cancel): If POST /jobs/{id}/cancel already set Cancelled, this
+    Running-only failure UPDATE must no-op so Cancelled is not overwritten.
     """
     logger.warning("Route generation job %s failed: %s", job_id, message)
 

--- a/backend/python/app/services/implementations/route_generation_runner.py
+++ b/backend/python/app/services/implementations/route_generation_runner.py
@@ -87,6 +87,12 @@ async def run_generation_job(
         if job is None:
             return
 
+        # Idempotency: a prior attempt may have saved the RouteGroup before the
+        # process died. Do not call the routing engine again.
+        if job.route_group_id is not None:
+            await _complete_already_saved(session, job)
+            return
+
         request = _parse_request(job)
         group, locations = await _resolve_locations(session, request.location_group)
         warehouse_lat, warehouse_lon = await _resolve_warehouse(session)
@@ -177,6 +183,43 @@ async def _load_running_job(session: AsyncSession, job_id: UUID) -> Job | None:
         return None
 
     return job
+
+
+async def _complete_already_saved(session: AsyncSession, job: Job) -> None:
+    """Mark a job Completed when its RouteGroup was already persisted.
+
+    Used when a crash happened after save but before the status flip, or when
+    a requeued job is claimed again despite already having a route_group_id.
+    """
+    now = _now_est_naive()
+    result = cast(
+        "CursorResult[Any]",
+        await session.execute(
+            update(Job)
+            .where(col(Job.job_id) == job.job_id)
+            .where(col(Job.progress) == ProgressEnum.RUNNING)
+            .values(
+                progress=ProgressEnum.COMPLETED,
+                error_message=None,
+                updated_at=now,
+                finished_at=now,
+            )
+        ),
+    )
+    if result.rowcount:
+        await session.commit()
+        logger.info(
+            "Job %s completed without regenerating: route_group=%s already saved.",
+            job.job_id,
+            job.route_group_id,
+        )
+        return
+
+    await session.rollback()
+    logger.info(
+        "Job %s already had a RouteGroup but was no longer Running; left unchanged.",
+        job.job_id,
+    )
 
 
 def _parse_request(job: Job) -> RouteGenerationGroupInput:
@@ -373,6 +416,7 @@ async def _save_or_discard(
             .values(
                 progress=ProgressEnum.COMPLETED,
                 route_group_id=route_group.route_group_id,
+                error_message=None,
                 routes_created=len(routes),
                 total_stops=sum(len(route.route_stops) for route in routes),
                 total_distance_km=sum(route.length for route in routes),

--- a/backend/python/app/services/implementations/route_generation_worker.py
+++ b/backend/python/app/services/implementations/route_generation_worker.py
@@ -4,8 +4,8 @@ One long-lived asyncio task sleeps on a wake event until
 ``POST /jobs/generate`` wakes the worker, then claims ``PENDING`` jobs one
 at a time and hands each to ``run_generation_job``. The ``jobs`` table is the
 durable queue; the event is only an in-memory signal, so a process restart
-needs the startup sweep to fail orphaned ``RUNNING`` rows and re-ring if any
-``PENDING`` work is waiting.
+needs the startup sweep to repair orphaned ``RUNNING`` rows (complete,
+requeue, or fail) and re-ring if any ``PENDING`` work is waiting.
 
 Assumes a single process runs this worker. The drain loop treats a failed claim
 (``None``) as "queue empty" and stops. With multiple uvicorn/gunicorn workers
@@ -41,6 +41,9 @@ logger = logging.getLogger(__name__)
 
 _wake_event = asyncio.Event()
 _worker_task: asyncio.Task[None] | None = None
+
+# One automatic return to PENDING after a crash; a second orphan fails.
+MAX_AUTO_REQUEUE_ATTEMPTS = 1
 
 RECOVERY_ERROR_MESSAGE = (
     "Route generation was interrupted because the server restarted and "
@@ -103,12 +106,58 @@ async def recover_route_generation_jobs(session: AsyncSession) -> None:
     Leaving orphans in RUNNING would make the UI wait forever.
     """
     now = now_est_naive()
-    result = cast(
+
+    completed = cast(
+        "CursorResult[Any]",
+        await session.execute(
+            update(Job)
+            .where(col(Job.progress) == ProgressEnum.RUNNING)
+            .where(col(Job.route_group_id).is_not(None))
+            .values(
+                progress=ProgressEnum.COMPLETED,
+                error_message=None,
+                updated_at=now,
+                finished_at=now,
+            )
+        ),
+    )
+    if completed.rowcount:
+        logger.info(
+            "Marked %d interrupted route generation job(s) as Completed after "
+            "restart (RouteGroup already saved).",
+            completed.rowcount,
+        )
+
+    requeued = cast(
         "CursorResult[Any]",
         await session.execute(
             update(Job)
             .where(col(Job.progress) == ProgressEnum.RUNNING)
             .where(col(Job.route_group_id).is_(None))
+            .where(col(Job.retry_count) < MAX_AUTO_REQUEUE_ATTEMPTS)
+            .values(
+                progress=ProgressEnum.PENDING,
+                retry_count=col(Job.retry_count) + 1,
+                started_at=None,
+                error_message=None,
+                updated_at=now,
+                finished_at=None,
+            )
+        ),
+    )
+    if requeued.rowcount:
+        logger.warning(
+            "Requeued %d interrupted route generation job(s) as Pending after restart.",
+            requeued.rowcount,
+        )
+
+    failed = cast(
+        "CursorResult[Any]",
+        await session.execute(
+            update(Job)
+            .where(col(Job.progress) == ProgressEnum.RUNNING)
+            .where(col(Job.route_group_id).is_(None))
+            .where(col(Job.retry_count) >= MAX_AUTO_REQUEUE_ATTEMPTS)
             .values(
                 progress=ProgressEnum.FAILED,
                 error_message=RECOVERY_ERROR_MESSAGE,

--- a/backend/python/app/services/implementations/route_generation_worker.py
+++ b/backend/python/app/services/implementations/route_generation_worker.py
@@ -59,6 +59,10 @@ async def claim_next_pending_job(session: AsyncSession) -> UUID | None:
     The progress check is in the UPDATE itself, so two workers (or a cancel
     racing the claim) cannot both start the same job: zero rows updated means
     someone else got there first.
+
+    TODO(cancel): When POST /jobs/{id}/cancel marks a job Cancelled, this claim
+    must keep skipping non-Pending rows so a cancelled Pending job is never
+    started. No wake/interrupt is needed here — cancel is honored by not claiming.
     """
     now = now_est_naive()
     oldest_pending = (

--- a/backend/python/app/services/implementations/route_generation_worker.py
+++ b/backend/python/app/services/implementations/route_generation_worker.py
@@ -43,8 +43,8 @@ _wake_event = asyncio.Event()
 _worker_task: asyncio.Task[None] | None = None
 
 RECOVERY_ERROR_MESSAGE = (
-    "Route generation was interrupted because the server restarted. "
-    "Enqueue the job again."
+    "Route generation was interrupted because the server restarted and "
+    "could not be automatically retried. Enqueue the job again."
 )
 
 
@@ -93,10 +93,18 @@ async def claim_next_pending_job(session: AsyncSession) -> UUID | None:
 
 
 async def recover_route_generation_jobs(session: AsyncSession) -> None:
-    """Fail jobs left RUNNING across a restart, and wake if PENDING remain.
+    """Repair jobs left RUNNING across a restart, and wake if PENDING remain.
 
-    A RUNNING job cannot be resumed: the Google call is gone with the old
-    process. Leaving it RUNNING would make the UI wait forever.
+    A RUNNING job cannot resume its in-flight Google call — that connection is
+    gone. Recovery instead:
+
+    1. If ``route_group_id`` is already set, mark COMPLETED (save finished;
+       only the status flip was lost).
+    2. Else if ``retry_count`` is under the auto-requeue cap, return the job
+       to PENDING so the worker retries from ``input_payload``.
+    3. Else mark FAILED so a crash loop cannot requeue forever.
+
+    Leaving orphans in RUNNING would make the UI wait forever.
     """
     now = now_est_naive()
     result = cast(
@@ -104,6 +112,7 @@ async def recover_route_generation_jobs(session: AsyncSession) -> None:
         await session.execute(
             update(Job)
             .where(col(Job.progress) == ProgressEnum.RUNNING)
+            .where(col(Job.route_group_id).is_(None))
             .values(
                 progress=ProgressEnum.FAILED,
                 error_message=RECOVERY_ERROR_MESSAGE,
@@ -112,11 +121,13 @@ async def recover_route_generation_jobs(session: AsyncSession) -> None:
             )
         ),
     )
-    if result.rowcount:
+    if failed.rowcount:
         logger.warning(
-            "Marked %d interrupted route generation job(s) as Failed after restart.",
-            result.rowcount,
+            "Marked %d interrupted route generation job(s) as Failed after "
+            "restart (automatic retry already used).",
+            failed.rowcount,
         )
+
     await session.commit()
 
     pending = (

--- a/backend/python/app/services/implementations/route_generation_worker.py
+++ b/backend/python/app/services/implementations/route_generation_worker.py
@@ -97,8 +97,9 @@ async def recover_route_generation_jobs(session: AsyncSession) -> None:
     A RUNNING job cannot resume its in-flight Google call — that connection is
     gone. Recovery instead:
 
-    1. If ``route_group_id`` is already set, mark COMPLETED (save finished;
-       only the status flip was lost).
+    1. If ``route_group_id`` is already set, mark COMPLETED. Unreachable while
+       ``_save_or_discard`` commits the RouteGroup and status together; kept as
+       a belt-and-suspenders guard if that assumption changes.
     2. Else if ``retry_count`` is under the auto-requeue cap, return the job
        to PENDING so the worker retries from ``input_payload``.
     3. Else mark FAILED so a crash loop cannot requeue forever.
@@ -110,6 +111,7 @@ async def recover_route_generation_jobs(session: AsyncSession) -> None:
     completed = cast(
         "CursorResult[Any]",
         await session.execute(
+            # Defensive: not expected while RouteGroup + COMPLETED share one commit.
             update(Job)
             .where(col(Job.progress) == ProgressEnum.RUNNING)
             .where(col(Job.route_group_id).is_not(None))
@@ -191,7 +193,7 @@ async def route_generation_worker_loop() -> None:
     """Sleep until woken, then drain PENDING jobs one at a time.
 
     Single-process assumption: ``_claim_and_run_one`` returning False means the
-    queue is empty. That is an unsafe assumptionif multiple processes claim concurrently.
+    queue is empty. That is an unsafe assumption if multiple processes claim concurrently.
     """
     logger.info("Route generation worker started")
     try:

--- a/backend/python/app/services/implementations/route_generation_worker.py
+++ b/backend/python/app/services/implementations/route_generation_worker.py
@@ -59,10 +59,6 @@ async def claim_next_pending_job(session: AsyncSession) -> UUID | None:
     The progress check is in the UPDATE itself, so two workers (or a cancel
     racing the claim) cannot both start the same job: zero rows updated means
     someone else got there first.
-
-    TODO(cancel): When POST /jobs/{id}/cancel marks a job Cancelled, this claim
-    must keep skipping non-Pending rows so a cancelled Pending job is never
-    started. No wake/interrupt is needed here — cancel is honored by not claiming.
     """
     now = now_est_naive()
     oldest_pending = (

--- a/backend/python/migrations/versions/d4eefe397549_add_input_payload_error_message_and_.py
+++ b/backend/python/migrations/versions/d4eefe397549_add_input_payload_error_message_and_.py
@@ -1,7 +1,11 @@
 """add input payload, error message and summary columns to jobs
 
 Revision ID: d4eefe397549
+<<<<<<< HEAD
 Revises: a1c2e3f4b5d6
+=======
+Revises: bc7876e56dd1
+>>>>>>> 6ed58b7 (add changes to the jobs table)
 Create Date: 2026-07-28 02:26:20.612153
 
 """
@@ -11,7 +15,11 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = 'd4eefe397549'
+<<<<<<< HEAD
 down_revision = 'a1c2e3f4b5d6'
+=======
+down_revision = 'bc7876e56dd1'
+>>>>>>> 6ed58b7 (add changes to the jobs table)
 branch_labels = None
 depends_on = None
 

--- a/backend/python/migrations/versions/d4eefe397549_add_input_payload_error_message_and_.py
+++ b/backend/python/migrations/versions/d4eefe397549_add_input_payload_error_message_and_.py
@@ -1,11 +1,7 @@
 """add input payload, error message and summary columns to jobs
 
 Revision ID: d4eefe397549
-<<<<<<< HEAD
 Revises: a1c2e3f4b5d6
-=======
-Revises: bc7876e56dd1
->>>>>>> 6ed58b7 (add changes to the jobs table)
 Create Date: 2026-07-28 02:26:20.612153
 
 """
@@ -15,11 +11,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = 'd4eefe397549'
-<<<<<<< HEAD
 down_revision = 'a1c2e3f4b5d6'
-=======
-down_revision = 'bc7876e56dd1'
->>>>>>> 6ed58b7 (add changes to the jobs table)
 branch_labels = None
 depends_on = None
 

--- a/backend/python/migrations/versions/f2a8c1d4e6b0_add_jobs_retry_count.py
+++ b/backend/python/migrations/versions/f2a8c1d4e6b0_add_jobs_retry_count.py
@@ -5,7 +5,7 @@ orphaned RUNNING job to PENDING. Caps crash-loop retries at one automatic
 requeue (see recover_route_generation_jobs).
 
 Revision ID: f2a8c1d4e6b0
-Revises: d4eefe397549
+Revises: f1a7c0d92b45
 Create Date: 2026-08-08 00:00:00.000000
 
 """
@@ -15,7 +15,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "f2a8c1d4e6b0"
-down_revision = "d4eefe397549"
+down_revision = "f1a7c0d92b45"
 branch_labels = None
 depends_on = None
 

--- a/backend/python/migrations/versions/f2a8c1d4e6b0_add_jobs_retry_count.py
+++ b/backend/python/migrations/versions/f2a8c1d4e6b0_add_jobs_retry_count.py
@@ -1,0 +1,36 @@
+"""Add jobs.retry_count for one-shot restart requeue
+
+Tracks how many times startup recovery has automatically returned an
+orphaned RUNNING job to PENDING. Caps crash-loop retries at one automatic
+requeue (see recover_route_generation_jobs).
+
+Revision ID: f2a8c1d4e6b0
+Revises: d4eefe397549
+Create Date: 2026-08-08 00:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "f2a8c1d4e6b0"
+down_revision = "d4eefe397549"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "jobs",
+        sa.Column(
+            "retry_count",
+            sa.Integer(),
+            nullable=False,
+            server_default="0",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("jobs", "retry_count")

--- a/backend/python/tests/test_route_generation_runner.py
+++ b/backend/python/tests/test_route_generation_runner.py
@@ -221,6 +221,34 @@ class TestSuccessfulGeneration:
         ]
 
     @pytest.mark.asyncio
+    async def test_does_not_regenerate_when_route_group_already_saved(
+        self, test_session: AsyncSession
+    ) -> None:
+        """Idempotency: if the job already points at a RouteGroup, complete
+        without calling the routing engine again."""
+        group = await _add_group(test_session)
+        await _add_warehouse(test_session)
+        existing = RouteGroup(name="Already Saved", drive_date=DRIVE_DATE.date())
+        test_session.add(existing)
+        await test_session.commit()
+        await test_session.refresh(existing)
+
+        job = await _queue_running_job(test_session, group, num_routes=1)
+        job.route_group_id = existing.route_group_id
+        job.routes_created = 1
+        test_session.add(job)
+        await test_session.commit()
+
+        algorithm = FakeRoutingAlgorithm(lambda locations: [locations])
+        await run_generation_job(job.job_id, test_session, algorithm)
+
+        await test_session.refresh(job)
+        assert job.progress == ProgressEnum.COMPLETED
+        assert job.route_group_id == existing.route_group_id
+        assert algorithm.calls == 0
+        assert len(await _route_groups(test_session)) == 1
+
+    @pytest.mark.asyncio
     async def test_finds_the_group_by_name_when_the_id_is_made_up(
         self, test_session: AsyncSession
     ) -> None:

--- a/backend/python/tests/test_route_generation_worker.py
+++ b/backend/python/tests/test_route_generation_worker.py
@@ -30,6 +30,7 @@ from app.services.implementations import route_generation_runner as runner
 from app.services.implementations import route_generation_worker as worker
 from app.services.implementations.job_service import JobService
 from app.services.implementations.route_generation_worker import (
+    MAX_AUTO_REQUEUE_ATTEMPTS,
     RECOVERY_ERROR_MESSAGE,
     claim_next_pending_job,
     recover_route_generation_jobs,
@@ -47,7 +48,7 @@ DRIVE_DATE = datetime(2026, 6, 1, 8, 0)
 
 
 class FakeRoutingAlgorithm:
-    def __init__(self, plan: Callable[[list[Location]], Any]) -> None:
+    def __init__(self, plan: Callable[[list[Location]], list[list[Location]]]) -> None:
         self._plan = plan
         self.calls = 0
 
@@ -179,12 +180,12 @@ class TestClaimAndRecover:
             assert await claim_next_pending_job(session) is None
 
     @pytest.mark.asyncio
-    async def test_recover_fails_running_and_wakes_for_pending(
+    async def test_recover_requeues_running_once_and_wakes(
         self, test_db_engine: Any
     ) -> None:
         maker = _maker(test_db_engine)
         async with maker() as session:
-            running = Job(progress=ProgressEnum.RUNNING)
+            running = Job(progress=ProgressEnum.RUNNING, retry_count=0)
             pending = Job(progress=ProgressEnum.PENDING)
             session.add(running)
             session.add(pending)
@@ -197,21 +198,61 @@ class TestClaimAndRecover:
 
             await session.refresh(running)
             await session.refresh(pending)
-            assert running.progress == ProgressEnum.FAILED
-            assert running.error_message == RECOVERY_ERROR_MESSAGE
-            assert running.finished_at is not None
+            assert running.progress == ProgressEnum.PENDING
+            assert running.retry_count == 1
+            assert running.started_at is None
+            assert running.error_message is None
             assert pending.progress == ProgressEnum.PENDING
             assert worker._wake_event.is_set()
 
     @pytest.mark.asyncio
-    async def test_recover_does_not_wake_when_nothing_pending(
+    async def test_recover_completes_running_job_that_already_saved_routes(
         self, test_db_engine: Any
     ) -> None:
         maker = _maker(test_db_engine)
         async with maker() as session:
-            session.add(Job(progress=ProgressEnum.RUNNING))
+            group = RouteGroup(name="Saved Group", drive_date=DRIVE_DATE.date())
+            session.add(group)
             await session.commit()
+            await session.refresh(group)
+
+            running = Job(
+                progress=ProgressEnum.RUNNING,
+                route_group_id=group.route_group_id,
+                routes_created=1,
+            )
+            session.add(running)
+            await session.commit()
+            await session.refresh(running)
+
             await recover_route_generation_jobs(session)
+
+            await session.refresh(running)
+            assert running.progress == ProgressEnum.COMPLETED
+            assert running.route_group_id == group.route_group_id
+            assert running.finished_at is not None
+            assert not worker._wake_event.is_set()
+
+    @pytest.mark.asyncio
+    async def test_recover_fails_running_after_auto_requeue_exhausted(
+        self, test_db_engine: Any
+    ) -> None:
+        maker = _maker(test_db_engine)
+        async with maker() as session:
+            running = Job(
+                progress=ProgressEnum.RUNNING,
+                retry_count=MAX_AUTO_REQUEUE_ATTEMPTS,
+            )
+            session.add(running)
+            await session.commit()
+            await session.refresh(running)
+
+            await recover_route_generation_jobs(session)
+
+            await session.refresh(running)
+            assert running.progress == ProgressEnum.FAILED
+            assert running.error_message == RECOVERY_ERROR_MESSAGE
+            assert running.finished_at is not None
             assert not worker._wake_event.is_set()
 
 

--- a/backend/python/tests/test_route_generation_worker.py
+++ b/backend/python/tests/test_route_generation_worker.py
@@ -61,7 +61,7 @@ class FakeRoutingAlgorithm:
         timeout_seconds: float | None = None,  # noqa: ARG002
     ) -> list[list[Location]]:
         self.calls += 1
-        return cast("list[list[Location]]", self._plan(locations))
+        return self._plan(locations)
 
 
 def _maker(test_db_engine: Any) -> async_sessionmaker[AsyncSession]:

--- a/backend/python/tests/test_route_generation_worker.py
+++ b/backend/python/tests/test_route_generation_worker.py
@@ -209,6 +209,7 @@ class TestClaimAndRecover:
     async def test_recover_completes_running_job_that_already_saved_routes(
         self, test_db_engine: Any
     ) -> None:
+        """Defensive path: RUNNING + route_group_id is not expected from saves."""
         maker = _maker(test_db_engine)
         async with maker() as session:
             group = RouteGroup(name="Saved Group", drive_date=DRIVE_DATE.date())


### PR DESCRIPTION
## JIRA Ticket
[F4KRP-49](https://f4kblueprint.atlassian.net/browse/F4KRP-49)

## Implementation Description
<!-- Quick summary of what you built and why. Include design justifications if needed -->
* When the server crashes, RUNNING jobs should either be `FAILED` or requeued to `PENDING`. 
* Jobs are marked with `PENDING` if it doesn't have a related `route_group_id`
* Before marking it as `FAILED`, we retry once again. If retries > 1, we also mark it as `FAILED`.

## Steps to Test
<!-- What should the reviewer do to verify your changes? Include expected results -->
1.

## What Should Reviewers Focus On?
<!-- Call out substantial changes or anything you want a second opinion on -->
* Is there a better way to go about retrying RUNNING jobs on failure?

## Checklist
- [x] PR name and commits are descriptive, imperative, and atomic (trivial commits squashed)
- [x] I have requested a review from Claude, understood its suggestions, and implemented fixes where needed (or documented disagreements)
- [x] I have requested a review from the PL and relevant devs with background on this PR

**Frontend only — delete if not applicable:**
- [ ] Follows Tailwind/shadcn best practices per README; no hardcoded color or spacing values
- [ ] Implementation matches Zeplin designs and screenshots are attached above
- [ ] Screens render correctly on mobile and desktop; no console warnings or errors