### PR TITLE
Use the shared now_est_naive() util everywhere

### DIFF
--- a/backend/python/app/models/base.py
+++ b/backend/python/app/models/base.py
@@ -2,19 +2,15 @@ from contextlib import contextmanager
 from contextvars import ContextVar
 from datetime import datetime
 from typing import Any, TypeVar
-from zoneinfo import ZoneInfo
 
 import sqlmodel as sm
 from sqlmodel import Field
 
+from app.utilities.datetime_utils import now_est_naive
+
 _ONGOING_MODEL_VALIDATE: ContextVar[bool] = ContextVar("_ONGOING_MODEL_VALIDATE")
 
 T = TypeVar("T", bound="BaseModel")
-
-
-def _now_est_naive() -> datetime:
-    """Current time in F4K's timezone (America/New_York), stored tz-naive."""
-    return datetime.now(ZoneInfo("America/New_York")).replace(tzinfo=None)
 
 
 @contextmanager
@@ -36,10 +32,10 @@ class BaseModel(sm.SQLModel):
     # `updated_at` is bumped by a column-level SQLAlchemy `onupdate`, which fires
     # for BOTH ORM flushes and Core `update()` statements — so bulk updates stay
     # accurate too — unless the statement sets `updated_at` itself.
-    created_at: datetime | None = Field(default_factory=_now_est_naive)
+    created_at: datetime | None = Field(default_factory=now_est_naive)
     updated_at: datetime | None = Field(
-        default_factory=_now_est_naive,
-        sa_column_kwargs={"onupdate": _now_est_naive},
+        default_factory=now_est_naive,
+        sa_column_kwargs={"onupdate": now_est_naive},
     )
 
     def __init_subclass__(cls, **kwargs: Any) -> None:

--- a/backend/python/app/seed_database.py
+++ b/backend/python/app/seed_database.py
@@ -12,7 +12,6 @@ import zlib
 from datetime import date, datetime, time, timedelta, timezone
 from itertools import pairwise
 from typing import cast
-from zoneinfo import ZoneInfo
 
 import faker
 import firebase_admin
@@ -48,6 +47,7 @@ from app.models.system_settings import (
 
 # Import all models to register them with SQLModel
 from app.models.user import User
+from app.utilities.datetime_utils import now_est_naive
 
 # Initialize Faker
 fake = faker.Faker()
@@ -1391,9 +1391,7 @@ def main(*, reset_passwords: bool = False) -> None:
                     attachments=[],
                 )
                 set_timestamps(announcement)
-                posted_at = datetime.now(ZoneInfo("America/New_York")).replace(
-                    tzinfo=None
-                ) - timedelta(days=days_ago)
+                posted_at = now_est_naive() - timedelta(days=days_ago)
                 announcement.created_at = posted_at
                 announcement.updated_at = posted_at
                 session.add(announcement)
@@ -1413,9 +1411,7 @@ def main(*, reset_passwords: bool = False) -> None:
                 if random.random() < 0.6:
                     read_entry = AnnouncementLastRead(
                         user_id=driver_user_row[0],
-                        last_read_at=datetime.now(ZoneInfo("America/New_York")).replace(
-                            tzinfo=None
-                        )
+                        last_read_at=now_est_naive()
                         - timedelta(hours=random.randint(0, 72)),
                     )
                     set_timestamps(read_entry)

--- a/backend/python/app/services/implementations/announcement_service.py
+++ b/backend/python/app/services/implementations/announcement_service.py
@@ -1,7 +1,6 @@
 import logging
 from datetime import datetime
 from uuid import UUID, uuid4
-from zoneinfo import ZoneInfo
 
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -17,6 +16,7 @@ from app.models.announcement_last_read import AnnouncementLastRead
 from app.models.driver import Driver
 from app.models.user import User
 from app.services.implementations.email_dispatcher import EmailDispatcher
+from app.utilities.datetime_utils import now_est_naive
 
 
 class AnnouncementService:
@@ -24,10 +24,6 @@ class AnnouncementService:
 
     def __init__(self, logger: logging.Logger):
         self.logger = logger
-
-    @staticmethod
-    def _est_now_naive() -> datetime:
-        return datetime.now(ZoneInfo("America/New_York")).replace(tzinfo=None)
 
     async def _get_user_role(self, session: AsyncSession, user_id: UUID) -> str | None:
         statement = select(User.role).where(User.user_id == user_id)
@@ -121,7 +117,7 @@ class AnnouncementService:
                 setattr(announcement, field, value)
 
             if update_data:
-                announcement.updated_at = self._est_now_naive()
+                announcement.updated_at = now_est_naive()
 
             await session.commit()
             return await self.get_announcement(session, announcement_id)
@@ -223,7 +219,7 @@ class AnnouncementService:
             if not user_result.scalars().first():
                 raise ValueError(f"User with id {user_id} not found")
 
-            now = datetime.now(ZoneInfo("America/New_York")).replace(tzinfo=None)
+            now = now_est_naive()
             insert_stmt = pg_insert(AnnouncementLastRead).values(
                 announcement_last_read_id=uuid4(),
                 user_id=user_id,

--- a/backend/python/app/services/implementations/job_service.py
+++ b/backend/python/app/services/implementations/job_service.py
@@ -1,8 +1,6 @@
 import logging
-from datetime import datetime
 from typing import TYPE_CHECKING, Any, cast
 from uuid import UUID
-from zoneinfo import ZoneInfo
 
 from sqlalchemy import update
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -14,6 +12,7 @@ from app.schemas.route_generation import RouteGenerationGroupInput
 from app.services.implementations.route_generation_worker import (
     wake_route_generation_worker,
 )
+from app.utilities.datetime_utils import now_est_naive
 
 if TYPE_CHECKING:
     from sqlalchemy.engine import CursorResult
@@ -42,9 +41,6 @@ class JobService:
         result = await self.session.execute(statement)
         return list(result.scalars().all())
 
-    def est_now_naive(self) -> datetime:
-        return datetime.now(ZoneInfo("America/New_York")).replace(tzinfo=None)
-
     async def generate_job(self, req: RouteGenerationGroupInput | None = None) -> UUID:
         """Create a job, persisting the generation request for a worker to run later.
 
@@ -72,7 +68,7 @@ class JobService:
 
     async def update_progress(self, job_id: UUID, progress: ProgressEnum) -> None:
         try:
-            now = self.est_now_naive()
+            now = now_est_naive()
             values = {
                 "progress": progress,
                 "updated_at": now,
@@ -116,7 +112,7 @@ class JobService:
         no-ops and returned unchanged.
         """
         try:
-            now = self.est_now_naive()
+            now = now_est_naive()
             result = cast(
                 "CursorResult[Any]",
                 await self.session.execute(


### PR DESCRIPTION
## What

Follow-up to the review comment on [#251](https://github.com/uwblueprint/food4kids/pull/251): `now_est_naive()` landed in `app/utilities/datetime_utils.py`, but four other copies of the same expression were already in the tree. This points them all at the util so there's exactly one definition of "now, in F4K's timezone, stored tz-naive".

Removed copies:

| File | Was |
|---|---|
| `app/models/base.py` | private `_now_est_naive()` |
| `app/services/implementations/announcement_service.py` | `_est_now_naive()` static method + one inline copy |
| `app/services/implementations/job_service.py` | `est_now_naive()` method |
| `app/seed_database.py` | two inline copies |

Net −30/+14, no behaviour change: the util's body is byte-identical to every copy it replaces, so every call site returns exactly what it did before.

## One thing worth deciding separately

The util hardcodes `America/New_York`, but nine other places in the backend read `settings.scheduler_timezone` (whose default is also `America/New_York`, and which nothing currently overrides). So there are still two sources of truth for "the app's timezone" — they just can't disagree today. Unifying the util onto the setting would make `SCHEDULER_TIMEZONE` also move stored timestamps, which is a real semantic call, so I left it out of this PR rather than smuggling it in. Happy to do it as a one-liner if that's the intent.

## Testing

- `ruff check` and `ruff format --check` clean
- `mypy app` — success, 97 source files
- Docker daemon is down on my machine so I couldn't run the DB-backed suite locally; CI covers it. I did verify the affected modules import and that `now_est_naive()` returns the expected value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)