### PR TITLE
Store all timestamps as timestamptz holding UTC

### DIFF
--- a/backend/python/app/models/announcement_last_read.py
+++ b/backend/python/app/models/announcement_last_read.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from uuid import UUID, uuid4
 
-from sqlalchemy import UniqueConstraint
+from sqlalchemy import Column, DateTime, UniqueConstraint
 from sqlmodel import Field, SQLModel
 
 from .base import BaseModel
@@ -19,7 +19,9 @@ class AnnouncementLastRead(BaseModel, table=True):
     user_id: UUID = Field(
         foreign_key="users.user_id", nullable=False, ondelete="CASCADE"
     )
-    last_read_at: datetime = Field(nullable=False)
+    last_read_at: datetime = Field(
+        sa_column=Column(DateTime(timezone=True), nullable=False)
+    )
 
 
 class AnnouncementLastReadResponse(SQLModel):

--- a/backend/python/app/models/base.py
+++ b/backend/python/app/models/base.py
@@ -6,7 +6,7 @@ from typing import Any, TypeVar
 import sqlmodel as sm
 from sqlmodel import Field
 
-from app.utilities.datetime_utils import now_est_naive
+from app.utilities.datetime_utils import now_utc
 
 _ONGOING_MODEL_VALIDATE: ContextVar[bool] = ContextVar("_ONGOING_MODEL_VALIDATE")
 
@@ -32,10 +32,19 @@ class BaseModel(sm.SQLModel):
     # `updated_at` is bumped by a column-level SQLAlchemy `onupdate`, which fires
     # for BOTH ORM flushes and Core `update()` statements — so bulk updates stay
     # accurate too — unless the statement sets `updated_at` itself.
-    created_at: datetime | None = Field(default_factory=now_est_naive)
+    #
+    # Both are `timestamptz` holding UTC. Storing a naive local time instead
+    # would leave the zone as convention rather than data, and Python reads a
+    # naive value back as the container's local time (UTC), silently shifting
+    # it by the EST offset.
+    created_at: datetime | None = Field(
+        default_factory=now_utc,
+        sa_type=sm.DateTime(timezone=True),  # type: ignore[call-overload]
+    )
     updated_at: datetime | None = Field(
-        default_factory=now_est_naive,
-        sa_column_kwargs={"onupdate": now_est_naive},
+        default_factory=now_utc,
+        sa_type=sm.DateTime(timezone=True),  # type: ignore[call-overload]
+        sa_column_kwargs={"onupdate": now_utc},
     )
 
     def __init_subclass__(cls, **kwargs: Any) -> None:

--- a/backend/python/app/models/job.py
+++ b/backend/python/app/models/job.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from typing import Any
 from uuid import UUID, uuid4
 
-from sqlalchemy import JSON, Column, Text
+from sqlalchemy import JSON, Column, DateTime, Text
 from sqlmodel import Field, SQLModel
 
 from .base import BaseModel
@@ -24,14 +24,17 @@ class Job(JobBase, BaseModel, table=True):
     __tablename__ = "jobs"
 
     job_id: UUID = Field(default_factory=uuid4, primary_key=True)
+    # The job lifecycle timestamps are `timestamptz` holding UTC, like every
+    # other timestamp in the schema. They start null and are stamped as the job
+    # moves through Pending → Running → Completed/Failed.
     started_at: datetime | None = Field(
-        default=None,
+        default=None, sa_column=Column(DateTime(timezone=True), nullable=True)
     )
     updated_at: datetime | None = Field(
-        default=None,
+        default=None, sa_column=Column(DateTime(timezone=True), nullable=True)
     )
     finished_at: datetime | None = Field(
-        default=None,
+        default=None, sa_column=Column(DateTime(timezone=True), nullable=True)
     )
     input_payload: dict[str, Any] | None = Field(
         default=None, sa_column=Column(JSON, nullable=True)

--- a/backend/python/app/seed_database.py
+++ b/backend/python/app/seed_database.py
@@ -47,7 +47,7 @@ from app.models.system_settings import (
 
 # Import all models to register them with SQLModel
 from app.models.user import User
-from app.utilities.datetime_utils import now_est_naive
+from app.utilities.datetime_utils import from_local_wall_clock, now_utc
 
 # Initialize Faker
 fake = faker.Faker()
@@ -1300,11 +1300,18 @@ def main(*, reset_passwords: bool = False) -> None:
                 jobs_created = len(selected_groups)
 
                 for route_group_id, drive_date in selected_groups:
-                    started_at = datetime.combine(
-                        drive_date,
-                        time(
-                            hour=random.randint(JOB_START_HOUR_MIN, JOB_START_HOUR_MAX)
-                        ),
+                    # The hour is a wall-clock hour on the drive date, so read it
+                    # in the app's timezone rather than handing Postgres a naive
+                    # value it would resolve against the session timezone.
+                    started_at = from_local_wall_clock(
+                        datetime.combine(
+                            drive_date,
+                            time(
+                                hour=random.randint(
+                                    JOB_START_HOUR_MIN, JOB_START_HOUR_MAX
+                                )
+                            ),
+                        )
                     )
                     updated_at = started_at + timedelta(
                         hours=random.randint(JOB_UPDATE_HOUR_MIN, JOB_UPDATE_HOUR_MAX)
@@ -1391,7 +1398,7 @@ def main(*, reset_passwords: bool = False) -> None:
                     attachments=[],
                 )
                 set_timestamps(announcement)
-                posted_at = now_est_naive() - timedelta(days=days_ago)
+                posted_at = now_utc() - timedelta(days=days_ago)
                 announcement.created_at = posted_at
                 announcement.updated_at = posted_at
                 session.add(announcement)
@@ -1411,8 +1418,7 @@ def main(*, reset_passwords: bool = False) -> None:
                 if random.random() < 0.6:
                     read_entry = AnnouncementLastRead(
                         user_id=driver_user_row[0],
-                        last_read_at=now_est_naive()
-                        - timedelta(hours=random.randint(0, 72)),
+                        last_read_at=now_utc() - timedelta(hours=random.randint(0, 72)),
                     )
                     set_timestamps(read_entry)
                     session.add(read_entry)

--- a/backend/python/app/services/implementations/announcement_service.py
+++ b/backend/python/app/services/implementations/announcement_service.py
@@ -16,7 +16,7 @@ from app.models.announcement_last_read import AnnouncementLastRead
 from app.models.driver import Driver
 from app.models.user import User
 from app.services.implementations.email_dispatcher import EmailDispatcher
-from app.utilities.datetime_utils import now_est_naive
+from app.utilities.datetime_utils import now_utc
 
 
 class AnnouncementService:
@@ -117,7 +117,7 @@ class AnnouncementService:
                 setattr(announcement, field, value)
 
             if update_data:
-                announcement.updated_at = now_est_naive()
+                announcement.updated_at = now_utc()
 
             await session.commit()
             return await self.get_announcement(session, announcement_id)
@@ -219,7 +219,7 @@ class AnnouncementService:
             if not user_result.scalars().first():
                 raise ValueError(f"User with id {user_id} not found")
 
-            now = now_est_naive()
+            now = now_utc()
             insert_stmt = pg_insert(AnnouncementLastRead).values(
                 announcement_last_read_id=uuid4(),
                 user_id=user_id,

--- a/backend/python/app/services/implementations/job_service.py
+++ b/backend/python/app/services/implementations/job_service.py
@@ -12,7 +12,7 @@ from app.schemas.route_generation import RouteGenerationGroupInput
 from app.services.implementations.route_generation_worker import (
     wake_route_generation_worker,
 )
-from app.utilities.datetime_utils import now_est_naive
+from app.utilities.datetime_utils import now_utc
 
 if TYPE_CHECKING:
     from sqlalchemy.engine import CursorResult
@@ -68,7 +68,7 @@ class JobService:
 
     async def update_progress(self, job_id: UUID, progress: ProgressEnum) -> None:
         try:
-            now = now_est_naive()
+            now = now_utc()
             values = {
                 "progress": progress,
                 "updated_at": now,
@@ -112,7 +112,7 @@ class JobService:
         no-ops and returned unchanged.
         """
         try:
-            now = now_est_naive()
+            now = now_utc()
             result = cast(
                 "CursorResult[Any]",
                 await self.session.execute(

--- a/backend/python/app/services/implementations/route_generation_runner.py
+++ b/backend/python/app/services/implementations/route_generation_runner.py
@@ -185,7 +185,7 @@ async def _complete_already_saved(session: AsyncSession, job: Job) -> None:
     ``run_generation_job``). Kept as a defensive no-regenerate path if a job
     ever arrives Running with ``route_group_id`` already set.
     """
-    now = now_est_naive()
+    now = now_utc()
     result = cast(
         "CursorResult[Any]",
         await session.execute(

--- a/backend/python/app/services/implementations/route_generation_runner.py
+++ b/backend/python/app/services/implementations/route_generation_runner.py
@@ -38,7 +38,7 @@ from app.schemas.route_generation import RouteGenerationGroupInput
 from app.services.implementations.route_group_service import (
     ROUTE_GROUP_NAME_MAX_LENGTH,
 )
-from app.utilities.datetime_utils import now_est_naive
+from app.utilities.datetime_utils import now_utc
 from app.utilities.routes_utils import fetch_route_polyline
 
 if TYPE_CHECKING:
@@ -350,7 +350,7 @@ async def _save_or_discard(
     await session.flush()
 
     routes = route_group.routes
-    now = now_est_naive()
+    now = now_utc()
     result = cast(
         "CursorResult[Any]",
         await session.execute(
@@ -401,7 +401,7 @@ async def _fail(session: AsyncSession, job_id: UUID, message: str) -> None:
     logger.warning("Route generation job %s failed: %s", job_id, message)
 
     await session.rollback()
-    now = now_est_naive()
+    now = now_utc()
     result = cast(
         "CursorResult[Any]",
         await session.execute(

--- a/backend/python/app/services/implementations/route_generation_worker.py
+++ b/backend/python/app/services/implementations/route_generation_worker.py
@@ -29,7 +29,7 @@ from app.dependencies.services import get_routing_algorithm
 from app.models.enum import ProgressEnum
 from app.models.job import Job
 from app.services.implementations.route_generation_runner import run_generation_job
-from app.utilities.datetime_utils import now_est_naive
+from app.utilities.datetime_utils import now_utc
 
 if TYPE_CHECKING:
     from uuid import UUID
@@ -60,7 +60,7 @@ async def claim_next_pending_job(session: AsyncSession) -> UUID | None:
     racing the claim) cannot both start the same job: zero rows updated means
     someone else got there first.
     """
-    now = now_est_naive()
+    now = now_utc()
     oldest_pending = (
         select(Job.job_id)
         .where(col(Job.progress) == ProgressEnum.PENDING)
@@ -94,7 +94,7 @@ async def recover_route_generation_jobs(session: AsyncSession) -> None:
     A RUNNING job cannot be resumed: the Google call is gone with the old
     process. Leaving it RUNNING would make the UI wait forever.
     """
-    now = now_est_naive()
+    now = now_utc()
     result = cast(
         "CursorResult[Any]",
         await session.execute(

--- a/backend/python/app/utilities/datetime_utils.py
+++ b/backend/python/app/utilities/datetime_utils.py
@@ -1,7 +1,41 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from zoneinfo import ZoneInfo
 
+from app.config import settings
 
-def now_est_naive() -> datetime:
-    """Current time in F4K's timezone (America/New_York), stored tz-naive."""
-    return datetime.now(ZoneInfo("America/New_York")).replace(tzinfo=None)
+
+def now_utc() -> datetime:
+    """Current instant, timezone-aware in UTC.
+
+    Timestamps are stored as `timestamptz` and converted to
+    `settings.scheduler_timezone` at the edges (reports, emails, the API's
+    presentation layer) rather than at the point of writing.
+
+    Never store a naive datetime. A naive value keeps the wall-clock digits and
+    drops the offset, so the zone it was stamped in survives only as convention.
+    Python then reads it back as the container's local time — UTC in every
+    environment we run — which is four or five hours off from the EST the
+    caller meant, with no exception raised.
+    """
+    return datetime.now(timezone.utc)
+
+
+def from_local_wall_clock(wall_clock: datetime) -> datetime:
+    """Read a naive local wall-clock time as a real instant, in UTC.
+
+    For values that genuinely mean "08:00 in Waterloo" — a time typed by a
+    coordinator, a seeded schedule — as opposed to an instant already known in
+    UTC, which needs no conversion.
+
+    Unlike the migration's hardcoded zone, this reads
+    `settings.scheduler_timezone`: it interprets input arriving now, so it
+    should follow the timezone the app is configured to operate in.
+    """
+    if wall_clock.tzinfo is not None:
+        raise ValueError(
+            f"expected a naive wall-clock datetime, got {wall_clock!r} "
+            "which already carries a timezone"
+        )
+    return wall_clock.replace(tzinfo=ZoneInfo(settings.scheduler_timezone)).astimezone(
+        timezone.utc
+    )

--- a/backend/python/migrations/versions/a1c4e97b20df_audit_timestamps_to_timestamptz.py
+++ b/backend/python/migrations/versions/a1c4e97b20df_audit_timestamps_to_timestamptz.py
@@ -26,7 +26,7 @@ from collections.abc import Sequence
 from alembic import op
 
 revision: str = "a1c4e97b20df"
-down_revision: str | None = "f1a7c0d92b45"
+down_revision: str | None = "f2a8c1d4e6b0"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/backend/python/migrations/versions/a1c4e97b20df_audit_timestamps_to_timestamptz.py
+++ b/backend/python/migrations/versions/a1c4e97b20df_audit_timestamps_to_timestamptz.py
@@ -1,0 +1,99 @@
+"""Store audit timestamps as timestamptz holding UTC
+
+Every timestamp column outside the handful that were already `timestamptz`
+(`routes.polyline_updated_at`, `user_invites.expires_at`,
+`password_reset_tokens.expires_at`) held a *naive* local time: the wall clock
+in America/New_York with the offset discarded. The zone survived only as
+convention, and Python reads a naive value back as the container's local time
+(UTC in every environment we run), so the same column meant one thing to the
+code that wrote it and another to the code that read it.
+
+The `USING <col> AT TIME ZONE 'America/New_York'` clause is what makes this
+safe: it reinterprets each existing naive value as the EST it actually was and
+converts to the equivalent instant. Without it Postgres would assume the values
+were already UTC and silently shift everything by four or five hours.
+
+Values landing in the ambiguous 01:00-02:00 window of a DST fall-back are the
+one lossy case — Postgres picks one of the two possible instants. That is
+inherent to naive local storage and cannot be recovered from the data.
+
+Revision ID: a1c4e97b20df
+Revises: f1a7c0d92b45
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "a1c4e97b20df"
+down_revision: str | None = "f1a7c0d92b45"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+# The zone these naive values were stamped in. Hardcoded rather than read from
+# settings.scheduler_timezone: this is a statement about data already on disk,
+# so it must not change if that setting ever does.
+LEGACY_ZONE = "America/New_York"
+
+# (table, column) for every timestamp that was naive before this migration.
+COLUMNS: list[tuple[str, str]] = [
+    ("admin_info", "created_at"),
+    ("admin_info", "updated_at"),
+    ("announcement_last_reads", "created_at"),
+    ("announcement_last_reads", "last_read_at"),
+    ("announcement_last_reads", "updated_at"),
+    ("announcements", "created_at"),
+    ("announcements", "updated_at"),
+    ("drivers", "created_at"),
+    ("drivers", "updated_at"),
+    ("jobs", "created_at"),
+    ("jobs", "finished_at"),
+    ("jobs", "started_at"),
+    ("jobs", "updated_at"),
+    ("location_groups", "created_at"),
+    ("location_groups", "updated_at"),
+    ("locations", "created_at"),
+    ("locations", "updated_at"),
+    ("note_chains", "created_at"),
+    ("note_chains", "updated_at"),
+    ("notes", "created_at"),
+    ("notes", "updated_at"),
+    ("password_reset_tokens", "created_at"),
+    ("password_reset_tokens", "updated_at"),
+    ("route_groups", "created_at"),
+    ("route_groups", "updated_at"),
+    ("route_snapshots", "created_at"),
+    ("route_snapshots", "updated_at"),
+    ("route_stop_snapshots", "created_at"),
+    ("route_stop_snapshots", "updated_at"),
+    ("route_stops", "created_at"),
+    ("route_stops", "updated_at"),
+    ("routes", "created_at"),
+    ("routes", "updated_at"),
+    ("system_settings", "created_at"),
+    ("system_settings", "updated_at"),
+    ("user_invites", "created_at"),
+    ("user_invites", "updated_at"),
+    ("users", "created_at"),
+    ("users", "updated_at"),
+]
+
+
+def upgrade() -> None:
+    for table, column in COLUMNS:
+        op.execute(
+            f'ALTER TABLE "{table}" ALTER COLUMN "{column}" '
+            f"TYPE TIMESTAMP WITH TIME ZONE "
+            f"USING \"{column}\" AT TIME ZONE '{LEGACY_ZONE}'"
+        )
+
+
+def downgrade() -> None:
+    # The mirror image: render each instant back into EST wall-clock time and
+    # drop the offset, so a downgrade restores exactly what upgrade() read.
+    for table, column in COLUMNS:
+        op.execute(
+            f'ALTER TABLE "{table}" ALTER COLUMN "{column}" '
+            f"TYPE TIMESTAMP WITHOUT TIME ZONE "
+            f"USING \"{column}\" AT TIME ZONE '{LEGACY_ZONE}'"
+        )

--- a/backend/python/tests/test_base_timestamps.py
+++ b/backend/python/tests/test_base_timestamps.py
@@ -2,9 +2,13 @@
 are stamped on insert, and ``updated_at`` is bumped on every update — via a
 column-level ``onupdate`` that fires for both ORM flushes and Core ``update()``
 statements. ``Job`` overrides ``updated_at`` and is exempt.
+
+Every timestamp here is timezone-aware UTC, matching the ``timestamptz``
+columns. Comparing an aware value to a naive one silently returns False for
+``==`` and raises for ``<``/``>``, so the fixtures must carry a timezone.
 """
 
-from datetime import datetime
+from datetime import datetime, timezone
 
 import pytest
 from sqlalchemy import update
@@ -16,7 +20,7 @@ from app.models.system_settings import SystemSettings
 
 # A fixed past instant used to backdate rows deterministically, so "did
 # updated_at move to ~now?" doesn't hinge on sub-microsecond timing.
-_PAST = datetime(2000, 1, 1, 12, 0, 0)
+_PAST = datetime(2000, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
 
 
 async def _make_settings(session: AsyncSession) -> SystemSettings:
@@ -92,7 +96,7 @@ async def test_explicit_updated_at_wins_over_onupdate(
     """When a statement sets updated_at itself, onupdate does not override it."""
     settings = await _make_settings(test_session)
     await _backdate(test_session, settings)
-    explicit = datetime(2010, 6, 15, 8, 30, 0)
+    explicit = datetime(2010, 6, 15, 8, 30, 0, tzinfo=timezone.utc)
 
     await test_session.execute(
         update(SystemSettings)
@@ -115,7 +119,7 @@ async def test_job_updated_at_is_not_auto_bumped(test_session: AsyncSession) -> 
     await test_session.refresh(job)
     assert job.updated_at is None
 
-    job.started_at = datetime(2021, 3, 3, 3, 3, 3)
+    job.started_at = datetime(2021, 3, 3, 3, 3, 3, tzinfo=timezone.utc)
     await test_session.commit()
     await test_session.refresh(job)
 

--- a/backend/python/tests/test_datetime_utils.py
+++ b/backend/python/tests/test_datetime_utils.py
@@ -1,0 +1,112 @@
+"""Tests for the timestamp helpers in ``app.utilities.datetime_utils``.
+
+These need no database: they pin down the two conversions every timestamp in
+the schema depends on. The property that matters throughout is that a stored
+timestamp carries its offset, so it means the same instant to the code that
+writes it and the code that reads it back.
+"""
+
+from datetime import UTC, datetime, timedelta, timezone
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from app.config import settings
+from app.utilities.datetime_utils import from_local_wall_clock, now_utc
+
+APP_ZONE = ZoneInfo(settings.scheduler_timezone)
+
+
+class TestNowUtc:
+    def test_is_timezone_aware(self) -> None:
+        assert now_utc().tzinfo is not None
+
+    def test_is_utc(self) -> None:
+        assert now_utc().utcoffset() == timedelta(0)
+
+    def test_tracks_real_time(self) -> None:
+        """Sanity check that it returns *now*, not a fixed or local-shifted value."""
+        drift = abs((now_utc() - datetime.now(UTC)).total_seconds())
+        assert drift < 5
+
+    def test_comparable_with_other_aware_datetimes(self) -> None:
+        """The whole point: no TypeError against an aware value from the DB."""
+        assert now_utc() > datetime(2020, 1, 1, tzinfo=UTC)
+
+    def test_not_comparable_with_naive_datetimes(self) -> None:
+        """A naive value is now a loud failure rather than a silent 4-hour skew."""
+        with pytest.raises(TypeError):
+            _ = now_utc() > datetime(2020, 1, 1)
+
+
+class TestFromLocalWallClock:
+    @pytest.mark.parametrize(
+        ("wall_clock", "expected_offset_hours"),
+        [
+            # EST (no DST): Waterloo is UTC-5, so 08:00 local is 13:00 UTC.
+            (datetime(2026, 1, 15, 8, 0), 5),
+            # EDT (DST): UTC-4, so 08:00 local is 12:00 UTC.
+            (datetime(2026, 7, 15, 8, 0), 4),
+        ],
+    )
+    def test_offset_follows_dst(
+        self, wall_clock: datetime, expected_offset_hours: int
+    ) -> None:
+        result = from_local_wall_clock(wall_clock)
+
+        assert result.tzinfo is not None
+        assert result.utcoffset() == timedelta(0)
+        assert result.hour == wall_clock.hour + expected_offset_hours
+
+    def test_preserves_the_wall_clock_reading_in_the_app_zone(self) -> None:
+        """Converting back into the app's zone returns the original digits."""
+        wall_clock = datetime(2026, 3, 20, 14, 37, 12)
+
+        round_tripped = from_local_wall_clock(wall_clock).astimezone(APP_ZONE)
+
+        assert round_tripped.replace(tzinfo=None) == wall_clock
+
+    def test_midnight_boundary_lands_on_the_previous_utc_day(self) -> None:
+        """Local midnight is the prior day in UTC — the case a naive value hides."""
+        result = from_local_wall_clock(datetime(2026, 2, 1, 0, 30))
+
+        assert result.date() == datetime(2026, 2, 1).date()
+        assert result.hour == 5
+
+    def test_ordering_is_preserved(self) -> None:
+        earlier = from_local_wall_clock(datetime(2026, 5, 1, 9, 0))
+        later = from_local_wall_clock(datetime(2026, 5, 1, 17, 0))
+
+        assert earlier < later
+
+    def test_rejects_an_already_aware_datetime(self) -> None:
+        """Passing an instant would double-apply the offset, so it must fail."""
+        with pytest.raises(ValueError, match="naive wall-clock"):
+            from_local_wall_clock(datetime(2026, 1, 15, 8, 0, tzinfo=UTC))
+
+    def test_rejects_an_aware_datetime_even_in_the_app_zone(self) -> None:
+        with pytest.raises(ValueError, match="naive wall-clock"):
+            from_local_wall_clock(datetime(2026, 1, 15, 8, 0, tzinfo=APP_ZONE))
+
+    def test_result_is_comparable_with_now_utc(self) -> None:
+        past = from_local_wall_clock(datetime(2020, 1, 1, 0, 0))
+
+        assert past < now_utc()
+
+    def test_dst_spring_forward_gap_resolves_without_raising(self) -> None:
+        """02:30 on the spring-forward date does not exist locally; zoneinfo
+        resolves it rather than failing, which is the documented behaviour."""
+        result = from_local_wall_clock(datetime(2026, 3, 8, 2, 30))
+
+        assert result.tzinfo is not None
+        assert result.utcoffset() == timedelta(0)
+
+    def test_dst_fall_back_ambiguity_picks_the_first_instant(self) -> None:
+        """01:30 on the fall-back date happens twice; zoneinfo picks fold=0.
+        This is the one lossy case inherent to naive local storage."""
+        ambiguous = datetime(2026, 11, 1, 1, 30)
+
+        result = from_local_wall_clock(ambiguous)
+        expected = ambiguous.replace(tzinfo=APP_ZONE, fold=0).astimezone(timezone.utc)
+
+        assert result == expected

--- a/backend/python/tests/test_models.py
+++ b/backend/python/tests/test_models.py
@@ -3,7 +3,7 @@ Streamlined comprehensive tests for SQLModel models focusing on business-critica
 Reduced from 92 tests to ~60 tests by removing redundancy and focusing on core business logic.
 """
 
-from datetime import date, datetime, time
+from datetime import date, datetime, time, timezone
 from uuid import uuid4
 
 import pytest
@@ -522,8 +522,8 @@ class TestCoreModels:
 
         job_update = JobUpdate(
             progress=ProgressEnum.COMPLETED,
-            started_at=datetime(2024, 1, 15, 8, 0),
-            finished_at=datetime(2024, 1, 15, 10, 0),
+            started_at=datetime(2024, 1, 15, 8, 0, tzinfo=timezone.utc),
+            finished_at=datetime(2024, 1, 15, 10, 0, tzinfo=timezone.utc),
         )
         assert job_update.progress == ProgressEnum.COMPLETED
         assert ProgressEnum.CANCELLED.value == "Cancelled"

--- a/backend/python/tests/test_routes.py
+++ b/backend/python/tests/test_routes.py
@@ -1413,22 +1413,22 @@ class TestLocationRoutes:
                     note_chain_id=chain.note_chain_id,
                     message="Old note",
                     is_system=False,
-                    created_at=datetime(2026, 1, 1),
-                    updated_at=datetime(2026, 1, 1),
+                    created_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+                    updated_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
                 ),
                 Note(
                     note_chain_id=chain.note_chain_id,
                     message="Gate code 2736",
                     is_system=False,
-                    created_at=datetime(2026, 2, 1),
-                    updated_at=datetime(2026, 2, 1),
+                    created_at=datetime(2026, 2, 1, tzinfo=timezone.utc),
+                    updated_at=datetime(2026, 2, 1, tzinfo=timezone.utc),
                 ),
                 Note(
                     note_chain_id=chain.note_chain_id,
                     message="System event",
                     is_system=True,
-                    created_at=datetime(2026, 3, 1),
-                    updated_at=datetime(2026, 3, 1),
+                    created_at=datetime(2026, 3, 1, tzinfo=timezone.utc),
+                    updated_at=datetime(2026, 3, 1, tzinfo=timezone.utc),
                 ),
             ]
         )
@@ -5225,14 +5225,14 @@ class TestNoteFeedRoutes:
             location_name="Beta Family",
             message="Older note",
             user=test_admin_user,
-            created_at=datetime(2026, 1, 1, 9, 0),
+            created_at=datetime(2026, 1, 1, 9, 0, tzinfo=timezone.utc),
         )
         await self._seed_location_note(
             test_session,
             location_name="Alpha Family",
             message="Newer note",
             user=test_admin_user,
-            created_at=datetime(2026, 1, 2, 9, 0),
+            created_at=datetime(2026, 1, 2, 9, 0, tzinfo=timezone.utc),
         )
 
         response = await async_client.get("/notes?page_size=1&sort=recent")
@@ -5268,7 +5268,7 @@ class TestNoteFeedRoutes:
             location_name="System Family",
             message="Automated note",
             user=None,
-            created_at=datetime(2026, 1, 1, 9, 0),
+            created_at=datetime(2026, 1, 1, 9, 0, tzinfo=timezone.utc),
         )
 
         response = await async_client.get("/notes?sort=recent")
@@ -5306,21 +5306,21 @@ class TestNoteFeedRoutes:
             location_name="Charlie Location",
             message="Admin middle",
             user=test_admin_user,
-            created_at=datetime(2026, 1, 2, 9, 0),
+            created_at=datetime(2026, 1, 2, 9, 0, tzinfo=timezone.utc),
         )
         await self._seed_location_note(
             test_session,
             location_name="Alpha Location",
             message="Driver newest",
             user=driver_user,
-            created_at=datetime(2026, 1, 3, 9, 0),
+            created_at=datetime(2026, 1, 3, 9, 0, tzinfo=timezone.utc),
         )
         await self._seed_location_note(
             test_session,
             location_name="Bravo Location",
             message="Admin oldest",
             user=test_admin_user,
-            created_at=datetime(2026, 1, 1, 9, 0),
+            created_at=datetime(2026, 1, 1, 9, 0, tzinfo=timezone.utc),
         )
 
         oldest_response = await async_client.get("/notes?sort=oldest")


### PR DESCRIPTION
## Why

The schema had two timestamp conventions running side by side:

- **tz-aware UTC** — `expires_at`, `polyline_updated_at`, password reset tokens, user invites. Columns declared `timezone=True`, written with `datetime.now(timezone.utc)`. Consistent, no bug.
- **naive local** — `created_at`/`updated_at` from `BaseModel`, plus the `Job` lifecycle timestamps and `announcement_last_reads.last_read_at`. The wall clock in America/New_York with the offset thrown away.

They collide inside single files: [route_generation_runner.py:320](https://github.com/uwblueprint/food4kids/blob/main/backend/python/app/services/implementations/route_generation_runner.py#L320) writes `polyline_updated_at=datetime.now(timezone.utc)`, then fifty lines later writes `updated_at=now` where `now` was naive EST. Whether a timestamp meant UTC or EST depended on which column you picked, and nothing in the types said which.

That split is the actual hazard. The containers set no `TZ`, so they run UTC — meaning `datetime.now()`, what anyone types by reflex, is UTC, and comparing it to a naive-EST `created_at` is silently four or five hours off with no exception, no failing test. Verified:

```
naive interpreted as -> 2026-08-09 17:25:40+00:00
actual instant       -> 2026-08-09 21:25:40+00:00
```

Storing the offset turns that into a `TypeError` at the comparison. The invariant moves out of tribal knowledge and into the type system, which matters with per-term turnover.

This finishes the convention the newer code already follows rather than introducing a third one.

## What changed

- `now_est_naive()` → `now_utc()`. Added `from_local_wall_clock()` for values that genuinely mean "08:00 in Waterloo" (seeded schedules, coordinator-typed times); it raises on aware input rather than double-applying an offset.
- `BaseModel.created_at`/`updated_at`, `Job.started_at`/`updated_at`/`finished_at`, and `announcement_last_reads.last_read_at` are now `timestamptz`.
- One migration converts all **39** previously-naive columns using `USING <col> AT TIME ZONE 'America/New_York'`. That clause is the whole correctness story — it reinterprets existing values as the EST they actually were. Without it Postgres assumes UTC and shifts everything. Downgrade mirrors it exactly.
- Seed data built job start times via `datetime.combine()` with no zone, which would have handed Postgres a naive value to resolve against the session timezone. Now goes through `from_local_wall_clock()`.
- Test fixtures carry timezones. `aware == naive` silently returns `False` (only `<`/`>` raise), so the existing assertions would have failed rather than misled — but they needed updating either way.

## Deliberately unchanged

`drive_date` (plain `date`) and route `start_time` (plain `time`) — settled by [#110](https://github.com/uwblueprint/food4kids/pull/110), and correct as-is: they describe a calendar day and a wall-clock departure, not instants.

The migration's zone is hardcoded, unlike `from_local_wall_clock()` which reads `settings.scheduler_timezone`. Intentional: the migration is a statement about data already on disk, so it must not change if that setting ever does.

## Known lossy case

Values in the ambiguous 01:00–02:00 window of a DST fall-back convert to one of the two possible instants (zoneinfo picks `fold=0`). Inherent to naive local storage and unrecoverable from the data. There's a test pinning the behaviour so it's a documented choice rather than a surprise.

## Testing

- New `tests/test_datetime_utils.py` — 15 cases covering both sides of DST, the fall-back ambiguity, the local-midnight boundary, ordering, round-tripping, and aware-input rejection. **All 15 pass locally.**
- `ruff check .`, `ruff format --check .`, and `mypy app` (97 files) all clean.
- **I could not run the DB-backed suite locally** — the Docker daemon on my machine is returning 500s on every API call, so neither `f4k_backend` nor a throwaway Postgres would come up. The migration and every ORM-level change are therefore unverified outside CI. `test` and `boot` are the real gates here; please don't merge on my say-so if either is red.

No prod exists yet, so the migration's reinterpretation only touches dev and seed data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)