### PR TITLE
Align the route-generation stepper's end labels with the page margins

### DIFF
--- a/frontend/src/pages/admin/routes/components/ProgressStepper.tsx
+++ b/frontend/src/pages/admin/routes/components/ProgressStepper.tsx
@@ -1,7 +1,10 @@
-import { Fragment } from 'react';
+import { Fragment, useLayoutEffect, useRef, useState } from 'react';
 
 import CheckIcon from '@/assets/icons/check.svg?react';
 import { cn } from '@/lib/utils';
+
+/** Half the 24px circle, in px — the label overhang is measured against it. */
+const CIRCLE_RADIUS = 12;
 
 interface Step {
   label: string;
@@ -22,17 +25,49 @@ interface ProgressStepperProps {
 }
 
 function ProgressStepper({ currentStep, className }: ProgressStepperProps) {
+  const firstLabel = useRef<HTMLSpanElement>(null);
+  const lastLabel = useRef<HTMLSpanElement>(null);
+  // Half of each end label hangs off its circle. The frames put those two
+  // labels flush with the page margins, so the row is inset by exactly that
+  // overhang — measured, because it's the rendered text width that decides it,
+  // and a hardcoded inset is both wrong for one end and silently wrong again
+  // the next time a label's wording changes.
+  const [endInset, setEndInset] = useState({ left: 0, right: 0 });
+
+  useLayoutEffect(() => {
+    const first = firstLabel.current;
+    const last = lastLabel.current;
+    if (!first || !last) return;
+
+    // getBoundingClientRect, not offsetWidth: the latter rounds to whole
+    // pixels, which leaves the end labels a couple of px off the margin.
+    const overhang = (label: HTMLSpanElement) =>
+      Math.max(0, label.getBoundingClientRect().width / 2 - CIRCLE_RADIUS);
+    const measure = () =>
+      setEndInset({ left: overhang(first), right: overhang(last) });
+
+    measure();
+    // A layout effect runs before the web font has necessarily swapped in, and
+    // fallback metrics put the inset a couple of px out, so re-measure once the
+    // real font is in. The observer then keeps up with anything later — a
+    // wording change, a zoom, a font-size change at another breakpoint.
+    void document.fonts.ready.then(measure);
+    const observer = new ResizeObserver(measure);
+    observer.observe(first);
+    observer.observe(last);
+    return () => observer.disconnect();
+  }, []);
+
   return (
     // The circles are evenly spaced and the labels hang off them: each label is
     // centred on its circle and taken out of the flow, so a label as wide as
     // "Edit Route Groups" doesn't push its circle around. That leaves the row as
     // fixed-size circles with the connectors splitting whatever is left over.
-    // `pb-6` reserves the 4px gap + 20px line the labels occupy, and `px-14`
-    // the half-label that the first and last circles' labels hang off the row —
-    // without it they escape the page's side padding and cause a horizontal
-    // scroll. 56px clears the widest end label ("Generate Routes", 50.5px of
-    // overhang); bump it if the end labels get longer.
-    <div className={cn('flex w-full items-center px-14 pb-6', className)}>
+    // `pb-6` reserves the 4px gap + 20px line the labels occupy.
+    <div
+      className={cn('flex w-full items-center pb-6', className)}
+      style={{ paddingLeft: endInset.left, paddingRight: endInset.right }}
+    >
       {STEPS.map((step, i) => (
         <Fragment key={step.path}>
           {i > 0 && (
@@ -53,6 +88,13 @@ function ProgressStepper({ currentStep, className }: ProgressStepperProps) {
           >
             {i < currentStep && <CheckIcon className="size-3.5 text-white" />}
             <span
+              ref={
+                i === 0
+                  ? firstLabel
+                  : i === STEPS.length - 1
+                    ? lastLabel
+                    : undefined
+              }
               className={cn(
                 'text-h3 absolute top-full left-1/2 mt-1 -translate-x-1/2 font-bold whitespace-nowrap',
                 i <= currentStep ? 'text-blue-300' : 'text-grey-400'


### PR DESCRIPTION
The route-generation stepper's first label sits ~43px right of where the frames put it. Spotted while overlaying the generate step on PR #254; the cause is on main, not in that PR.

`ProgressStepper` takes the labels out of the flow and centres each on its circle, so the two end labels hang half off the row. [#234](https://github.com/uwblueprint/food4kids/pull/234) compensated with a fixed `px-14`, sized to clear the widest end label. 56px isn't what either end needs — measured at 1440:

| | frame | before | after |
| --- | --- | --- | --- |
| "Import" left edge | 168 | 210.9 | 168 |
| "Generate Routes" right edge | 1392 | 1386.1 | 1392 |

This insets each end by that end's own overhang — half the rendered label minus the circle radius — read off the labels themselves. The two ends then differ as they should, and the inset can't go stale the next time a label is reworded (the old comment ended "bump it if the end labels get longer").

Measuring means a layout effect: `getBoundingClientRect` rather than `offsetWidth` (whole-pixel rounding left the labels ~2px off), one re-measure on `document.fonts.ready` because a layout effect runs on fallback metrics, and a `ResizeObserver` for anything after that.

## Verification

Rendered at 1440 and measured in the DOM: both end labels land exactly on the page margin (48.00 and 1392.00 against a row spanning 48–1392), `scrollWidth === innerWidth`, so nothing overflows. No unit test — the whole behaviour is layout, and jsdom returns zeros for every rect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
