### PR TITLE
Land the route-generation frames' spacing, type and states

### DIFF
--- a/frontend/src/common/components/Button.variants.ts
+++ b/frontend/src/common/components/Button.variants.ts
@@ -6,7 +6,11 @@ export const buttonVariants = cva(
     'inline-flex items-center justify-center gap-2',
     'transition-colors duration-150 ease-in-out',
     'focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-300',
-    'disabled:pointer-events-none disabled:bg-grey-400 disabled:text-grey-200 disabled:border-transparent',
+    /* Disabled is the button's own colours at half strength. The 🌟 Finalized
+     * page draws all 17 of its disabled buttons that way and never once uses
+     * the library's grey Type=Disabled variant — that only survives on Archive
+     * and three Hi-fi stragglers. */
+    'disabled:pointer-events-none disabled:opacity-50',
     'cursor-pointer',
     '[&_svg]:pointer-events-none [&_svg]:shrink-0',
   ],

--- a/frontend/src/common/components/Button.variants.ts
+++ b/frontend/src/common/components/Button.variants.ts
@@ -6,10 +6,6 @@ export const buttonVariants = cva(
     'inline-flex items-center justify-center gap-2',
     'transition-colors duration-150 ease-in-out',
     'focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-300',
-    /* Disabled is the button's own colours at half strength. The 🌟 Finalized
-     * page draws all 17 of its disabled buttons that way and never once uses
-     * the library's grey Type=Disabled variant — that only survives on Archive
-     * and three Hi-fi stragglers. */
     'disabled:pointer-events-none disabled:opacity-50',
     'cursor-pointer',
     '[&_svg]:pointer-events-none [&_svg]:shrink-0',

--- a/frontend/src/common/components/Modal.tsx
+++ b/frontend/src/common/components/Modal.tsx
@@ -80,9 +80,7 @@ function ModalHeader({
  * The two modal shapes in the design system carry different titles: a form
  * modal ("Add Admin", "Announcements", 600x5xx) heads with the 32/44 h1, a
  * confirmation dialog ("Delete Route Group", "Log out", 600x180) with the
- * 20/28 h2. No default — picking one is a decision about which shape the
- * dialog is, and defaulting to the form size is how confirmations ended up
- * with a 32px title.
+ * 20/28 h2.
  */
 const MODAL_TITLE_VARIANTS = {
   form: 'text-h1',

--- a/frontend/src/common/components/Modal.tsx
+++ b/frontend/src/common/components/Modal.tsx
@@ -76,13 +76,35 @@ function ModalHeader({
   );
 }
 
+/**
+ * The two modal shapes in the design system carry different titles: a form
+ * modal ("Add Admin", "Announcements", 600x5xx) heads with the 32/44 h1, a
+ * confirmation dialog ("Delete Route Group", "Log out", 600x180) with the
+ * 20/28 h2. No default — picking one is a decision about which shape the
+ * dialog is, and defaulting to the form size is how confirmations ended up
+ * with a 32px title.
+ */
+const MODAL_TITLE_VARIANTS = {
+  form: 'text-h1',
+  confirmation: 'text-h2',
+} as const;
+
+type ModalTitleVariant = keyof typeof MODAL_TITLE_VARIANTS;
+
 function ModalTitle({
+  variant,
   className,
   ...props
-}: React.ComponentProps<typeof DialogPrimitive.Title>) {
+}: React.ComponentProps<typeof DialogPrimitive.Title> & {
+  variant: ModalTitleVariant;
+}) {
   return (
     <DialogPrimitive.Title
-      className={cn('text-h1 text-grey-500 font-bold', className)}
+      className={cn(
+        MODAL_TITLE_VARIANTS[variant],
+        'text-grey-500 font-bold',
+        className
+      )}
       {...props}
     />
   );
@@ -94,7 +116,7 @@ function ModalDescription({
 }: React.ComponentProps<typeof DialogPrimitive.Description>) {
   return (
     <DialogPrimitive.Description
-      className={cn('text-p2 text-grey-400 font-normal', className)}
+      className={cn('text-p2 text-grey-400', className)}
       {...props}
     />
   );
@@ -119,3 +141,4 @@ export {
   ModalTitle,
   ModalTrigger,
 };
+export type { ModalTitleVariant };

--- a/frontend/src/common/components/Sidebar.tsx
+++ b/frontend/src/common/components/Sidebar.tsx
@@ -105,8 +105,6 @@ function SidebarMenuItem({
       }
     >
       <Icon className="size-6" />
-      {/* p1, not the mobile m-p2 token: this sidebar is admin-only, and admin
-          is desktop-only. Same 16/24, weight 500 rather than 400. */}
       <span className="text-p1 text-center">{label}</span>
     </NavLink>
   );

--- a/frontend/src/common/components/Sidebar.tsx
+++ b/frontend/src/common/components/Sidebar.tsx
@@ -105,7 +105,9 @@ function SidebarMenuItem({
       }
     >
       <Icon className="size-6" />
-      <span className="text-m-p2 text-center">{label}</span>
+      {/* p1, not the mobile m-p2 token: this sidebar is admin-only, and admin
+          is desktop-only. Same 16/24, weight 500 rather than 400. */}
+      <span className="text-p1 text-center">{label}</span>
     </NavLink>
   );
 }

--- a/frontend/src/common/components/Spinner.tsx
+++ b/frontend/src/common/components/Spinner.tsx
@@ -2,10 +2,12 @@ import { cn } from '@/lib/utils';
 
 interface SpinnerProps {
   className?: string;
-  size?: 'sm' | 'md' | 'lg';
+  size?: 'xs' | 'sm' | 'md' | 'lg';
 }
 
 const sizeClasses = {
+  /* 16px, for a spinner sitting inline with a line of text. */
+  xs: 'size-4 border-[2px]',
   sm: 'size-8 border-[4px]',
   md: 'size-12 border-[5px]',
   lg: 'size-16 border-[6px]',

--- a/frontend/src/common/components/StatisticsCard.tsx
+++ b/frontend/src/common/components/StatisticsCard.tsx
@@ -1,31 +1,14 @@
 import boyImg from '@/assets/illustrations/boy.png';
-import boyAnnouncingImg from '@/assets/illustrations/boy-announcing.png';
 import boyPointingImg from '@/assets/illustrations/boy-pointing.png';
-import girlConfusedImg from '@/assets/illustrations/girl-confused.png';
 import girlSearchingImg from '@/assets/illustrations/girl-searching.png';
 import grannyImg from '@/assets/illustrations/granny.png';
 import { cn } from '@/lib/utils';
 
-/**
- * Each illustration is placed by hand in the frames, not by one shared rule:
- * the assets are 1000x1000 squares whose figure sits at a different scale and
- * offset in each, so a single width and inset lands them all differently. The
- * numbers below are read off the frames' image-fill transforms — the size the
- * full square is drawn at, and where its top-right corner sits relative to the
- * card, in px. The card clips whatever hangs over.
- *
- * The last two have no frame to read: no design uses them in this card. Their
- * numbers are derived instead — the figure's own bounding box placed at the
- * average position of the four measured ones — and should be replaced with the
- * real transform the first time a frame uses them.
- */
 const CHARACTERS = {
   granny: { src: grannyImg, size: 159, right: -20, top: -23 },
   boy: { src: boyImg, size: 139, right: -15, top: -13 },
   boyPointing: { src: boyPointingImg, size: 164, right: -23, top: -14 },
   girlSearching: { src: girlSearchingImg, size: 179, right: -34, top: -24 },
-  girlConfused: { src: girlConfusedImg, size: 160, right: -21, top: -4 },
-  boyAnnouncing: { src: boyAnnouncingImg, size: 160, right: -15, top: -20 },
 } as const;
 
 const COLOR_MAP = {

--- a/frontend/src/common/components/StatisticsCard.tsx
+++ b/frontend/src/common/components/StatisticsCard.tsx
@@ -6,13 +6,26 @@ import girlSearchingImg from '@/assets/illustrations/girl-searching.png';
 import grannyImg from '@/assets/illustrations/granny.png';
 import { cn } from '@/lib/utils';
 
-const CHARACTER_MAP = {
-  boy: boyImg,
-  boyPointing: boyPointingImg,
-  boyAnnouncing: boyAnnouncingImg,
-  girlConfused: girlConfusedImg,
-  girlSearching: girlSearchingImg,
-  granny: grannyImg,
+/**
+ * Each illustration is placed by hand in the frames, not by one shared rule:
+ * the assets are 1000x1000 squares whose figure sits at a different scale and
+ * offset in each, so a single width and inset lands them all differently. The
+ * numbers below are read off the frames' image-fill transforms — the size the
+ * full square is drawn at, and where its top-right corner sits relative to the
+ * card, in px. The card clips whatever hangs over.
+ *
+ * The last two have no frame to read: no design uses them in this card. Their
+ * numbers are derived instead — the figure's own bounding box placed at the
+ * average position of the four measured ones — and should be replaced with the
+ * real transform the first time a frame uses them.
+ */
+const CHARACTERS = {
+  granny: { src: grannyImg, size: 159, right: -20, top: -23 },
+  boy: { src: boyImg, size: 139, right: -15, top: -13 },
+  boyPointing: { src: boyPointingImg, size: 164, right: -23, top: -14 },
+  girlSearching: { src: girlSearchingImg, size: 179, right: -34, top: -24 },
+  girlConfused: { src: girlConfusedImg, size: 160, right: -21, top: -4 },
+  boyAnnouncing: { src: boyAnnouncingImg, size: 160, right: -15, top: -20 },
 } as const;
 
 const COLOR_MAP = {
@@ -22,7 +35,7 @@ const COLOR_MAP = {
   pink: 'bg-brand-pink',
 } as const;
 
-type Character = keyof typeof CHARACTER_MAP;
+type Character = keyof typeof CHARACTERS;
 type StatisticsCardColor = keyof typeof COLOR_MAP;
 
 interface StatisticsCardProps {
@@ -46,7 +59,7 @@ function StatisticsCard({
     >
       <div
         className={cn(
-          'shadow-card relative h-24 w-full overflow-hidden rounded-xl p-4',
+          'shadow-card relative h-25 w-full overflow-hidden rounded-xl px-4',
           COLOR_MAP[color]
         )}
       >
@@ -59,18 +72,25 @@ function StatisticsCard({
         <div className="absolute right-14 bottom-3 size-1.5 rotate-45 bg-white" />
 
         {/* Text */}
-        <div className="relative flex flex-col justify-center gap-0.5">
-          <p className="text-p1 text-grey-100 font-bold">{label}</p>
-          <p className="text-grey-100 text-3xl leading-10 font-bold">{value}</p>
+        {/* 16/20 label over a 32/44 value, centred in the 100px card. */}
+        <div className="relative flex h-full flex-col justify-center">
+          <p className="text-h3 text-grey-100 font-bold">{label}</p>
+          <p className="text-h1 text-grey-100 font-bold">{value}</p>
         </div>
       </div>
 
-      {/* Character — sits on outer wrapper, pops out below card */}
+      {/* Character — on the outer wrapper so the card's clip cuts it off */}
       <img
-        src={CHARACTER_MAP[character]}
+        src={CHARACTERS[character].src}
         alt=""
         aria-hidden
-        className="absolute top-3/5 -right-2 w-38 -translate-y-1/2 object-contain"
+        className="absolute object-contain"
+        style={{
+          width: CHARACTERS[character].size,
+          height: CHARACTERS[character].size,
+          right: CHARACTERS[character].right,
+          top: CHARACTERS[character].top,
+        }}
       />
     </div>
   );

--- a/frontend/src/common/components/StatisticsCard.tsx
+++ b/frontend/src/common/components/StatisticsCard.tsx
@@ -55,7 +55,6 @@ function StatisticsCard({
         <div className="absolute right-14 bottom-3 size-1.5 rotate-45 bg-white" />
 
         {/* Text */}
-        {/* 16/20 label over a 32/44 value, centred in the 100px card. */}
         <div className="relative flex h-full flex-col justify-center">
           <p className="text-h3 text-grey-100 font-bold">{label}</p>
           <p className="text-h1 text-grey-100 font-bold">{value}</p>

--- a/frontend/src/features/announcements/AnnouncementConfirmModal.tsx
+++ b/frontend/src/features/announcements/AnnouncementConfirmModal.tsx
@@ -60,7 +60,7 @@ export function AnnouncementConfirmModal({
     <Modal open={open} onOpenChange={onOpenChange}>
       <ModalContent className="max-w-[480px]">
         <ModalHeader>
-          <ModalTitle>{copy.title}</ModalTitle>
+          <ModalTitle variant="confirmation">{copy.title}</ModalTitle>
           <ModalDescription>{copy.description}</ModalDescription>
         </ModalHeader>
         <ModalFooter>

--- a/frontend/src/features/announcements/AnnouncementFormModal.tsx
+++ b/frontend/src/features/announcements/AnnouncementFormModal.tsx
@@ -93,7 +93,7 @@ function AnnouncementForm({
       className="flex min-h-0 flex-1 flex-col gap-6"
     >
       <ModalHeader className="shrink-0">
-        <ModalTitle>Announcements</ModalTitle>
+        <ModalTitle variant="form">Announcements</ModalTitle>
       </ModalHeader>
 
       <Field className="shrink-0">

--- a/frontend/src/features/announcements/EditAnnouncementsModal.tsx
+++ b/frontend/src/features/announcements/EditAnnouncementsModal.tsx
@@ -54,7 +54,7 @@ export function EditAnnouncementsModal({
         style={sheetHeightStyle() as React.CSSProperties}
       >
         <ModalHeader className="shrink-0 gap-0">
-          <ModalTitle>Edit Announcements</ModalTitle>
+          <ModalTitle variant="form">Edit Announcements</ModalTitle>
         </ModalHeader>
 
         <div className="border-grey-300 min-h-0 flex-1 overflow-y-auto rounded-xl border p-4">

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -166,11 +166,11 @@
  * Desktop/Pn from tablet up. This is the default for body/paragraph text:
  *   text-p1 → 18→16px   text-p2 → 16→14px   text-p3 → 14→12px
  *
- * WEIGHT is part of the style. Per Figma, only P1 is non-Regular, and its
- * weight is RESPONSIVE: Mobile/P1 is Regular (400), Desktop/P1 is Medium (500)
- * — so text-p1 sets font-weight 400→500 itself (you can't express a per-tier
- * weight with a single font-* utility). P2 and P3 are Regular (400) at every
- * tier, i.e. the browser default, so text-p2/p3 don't set a weight.
+ * WEIGHT is part of the style, and for P1 and P2 it is RESPONSIVE, so the
+ * utility sets it itself (you can't express a per-tier weight with a single
+ * font-* utility): Mobile/P1 Regular (400) → Desktop/P1 Medium (500), and
+ * Mobile/P2 Regular (400) → Desktop/P2 SemiBold (600). P3 is Regular at every
+ * tier, i.e. the browser default, so text-p3 doesn't set a weight.
  *
  * text-m-p1/p2/p3 are STATIC (Mobile sizes, 18/16/14, all Regular) — for the
  * rare element whose size must stay constant across tiers (e.g. a 16px-
@@ -248,9 +248,11 @@
 @utility text-p2 {
   font-size: var(--text-m-p2);
   line-height: var(--text-m-p2--line-height);
+  font-weight: 400; /* Mobile/P2: Nunito Sans Regular */
   @media (width >= theme(--breakpoint-tablet)) {
     font-size: var(--text-p2);
     line-height: var(--text-p2--line-height);
+    font-weight: 600; /* Desktop/P2: Nunito Sans SemiBold */
   }
 }
 @utility text-p3 {

--- a/frontend/src/pages/StyleGuide/sections/ModalSection.tsx
+++ b/frontend/src/pages/StyleGuide/sections/ModalSection.tsx
@@ -39,7 +39,7 @@ const MODAL_CONFIRM_CODE = `import {
   </ModalTrigger>
   <ModalContent>
     <ModalHeader>
-      <ModalTitle>Save Changes?</ModalTitle>
+      <ModalTitle variant="confirmation">Save Changes?</ModalTitle>
       <ModalDescription>
         Your changes will be applied and saved.
       </ModalDescription>
@@ -98,7 +98,7 @@ export function ModalSection() {
             </ModalTrigger>
             <ModalContent>
               <ModalHeader>
-                <ModalTitle>Save Changes?</ModalTitle>
+                <ModalTitle variant="confirmation">Save Changes?</ModalTitle>
                 <ModalDescription>
                   Your changes will be applied and saved. This action can be
                   undone later.

--- a/frontend/src/pages/StyleGuide/sections/StatisticsCardSection.tsx
+++ b/frontend/src/pages/StyleGuide/sections/StatisticsCardSection.tsx
@@ -31,8 +31,8 @@ export function StatisticsCardSection() {
           orange (Brand Orange), and pink (Brand Pink).
         </SpecNote>
         <SpecNote title="Character Variants">
-          Five characters: boy, boyPointing, girlConfused, girlSearching, and
-          granny. The character peeks up from the bottom-right edge of the card.
+          Four characters: boy, boyPointing, girlSearching, and granny. The
+          character peeks up from the bottom-right edge of the card.
         </SpecNote>
         <SpecNote title="Sizing">
           Cards are full-width within their container. Use a flex/grid layout to
@@ -93,7 +93,7 @@ export function StatisticsCardSection() {
             <p className="text-p3 mb-4 font-semibold tracking-wider text-blue-300 uppercase">
               Character Variants
             </p>
-            <div className="tablet:grid-cols-5 grid grid-cols-2 gap-4">
+            <div className="tablet:grid-cols-4 grid grid-cols-2 gap-4">
               <StatisticsCard
                 color="green"
                 label="Boy"
@@ -105,12 +105,6 @@ export function StatisticsCardSection() {
                 label="Boy Pointing"
                 value="—"
                 character="boyPointing"
-              />
-              <StatisticsCard
-                color="green"
-                label="Girl Confused"
-                value="—"
-                character="girlConfused"
               />
               <StatisticsCard
                 color="green"

--- a/frontend/src/pages/admin/drivers/components/AssignRouteModal.tsx
+++ b/frontend/src/pages/admin/drivers/components/AssignRouteModal.tsx
@@ -58,7 +58,7 @@ export function AssignRouteModal({
     <Modal open={open} onOpenChange={onOpenChange}>
       <ModalContent>
         <ModalHeader>
-          <ModalTitle>Assign a Route</ModalTitle>
+          <ModalTitle variant="form">Assign a Route</ModalTitle>
           <ModalDescription>Assign a route to DRIVER_NAME</ModalDescription>
         </ModalHeader>
 

--- a/frontend/src/pages/admin/routes/components/ConfirmDeleteModal.tsx
+++ b/frontend/src/pages/admin/routes/components/ConfirmDeleteModal.tsx
@@ -47,7 +47,7 @@ export function ConfirmDeleteModal({
     <Modal open={open} onOpenChange={onOpenChange}>
       <ModalContent>
         <ModalHeader>
-          <ModalTitle>{title}</ModalTitle>
+          <ModalTitle variant="confirmation">{title}</ModalTitle>
           <ModalDescription>{description}</ModalDescription>
         </ModalHeader>
 

--- a/frontend/src/pages/admin/routes/components/DuplicateRouteGroupModal.tsx
+++ b/frontend/src/pages/admin/routes/components/DuplicateRouteGroupModal.tsx
@@ -92,7 +92,7 @@ export function DuplicateRouteGroupModal({
     <Modal open={open} onOpenChange={handleOpenChange}>
       <ModalContent>
         <ModalHeader>
-          <ModalTitle>Duplicate Route Group</ModalTitle>
+          <ModalTitle variant="form">Duplicate Route Group</ModalTitle>
         </ModalHeader>
 
         <div className="flex flex-col gap-4">

--- a/frontend/src/pages/admin/routes/components/ProgressStepper.tsx
+++ b/frontend/src/pages/admin/routes/components/ProgressStepper.tsx
@@ -1,10 +1,7 @@
-import { Fragment, useLayoutEffect, useRef, useState } from 'react';
+import { Fragment } from 'react';
 
 import CheckIcon from '@/assets/icons/check.svg?react';
 import { cn } from '@/lib/utils';
-
-/** Half the 24px circle, in px — the label overhang is measured against it. */
-const CIRCLE_RADIUS = 12;
 
 interface Step {
   label: string;
@@ -19,92 +16,86 @@ const STEPS: Step[] = [
   { label: 'Generate Routes', path: '/admin/routes/generation/generate' },
 ];
 
+/**
+ * The 3px rule. Inside a step it sits in a centre-aligned row, so it lines up
+ * with the circle on its own; the connectors between steps hang off the top of
+ * the row instead and need CONNECTOR_DROP to meet them.
+ */
+const CONNECTOR = 'h-[3px]';
+/** (24px circle − 3px rule) / 2, so the two meet without a step in the line. */
+const CONNECTOR_DROP = 'mt-[10.5px]';
+
 interface ProgressStepperProps {
   currentStep: number;
   className?: string;
 }
 
 function ProgressStepper({ currentStep, className }: ProgressStepperProps) {
-  const firstLabel = useRef<HTMLSpanElement>(null);
-  const lastLabel = useRef<HTMLSpanElement>(null);
-  // Half of each end label hangs off its circle. The frames put those two
-  // labels flush with the page margins, so the row is inset by exactly that
-  // overhang — measured, because it's the rendered text width that decides it,
-  // and a hardcoded inset is both wrong for one end and silently wrong again
-  // the next time a label's wording changes.
-  const [endInset, setEndInset] = useState({ left: 0, right: 0 });
-
-  useLayoutEffect(() => {
-    const first = firstLabel.current;
-    const last = lastLabel.current;
-    if (!first || !last) return;
-
-    // getBoundingClientRect, not offsetWidth: the latter rounds to whole
-    // pixels, which leaves the end labels a couple of px off the margin.
-    const overhang = (label: HTMLSpanElement) =>
-      Math.max(0, label.getBoundingClientRect().width / 2 - CIRCLE_RADIUS);
-    const measure = () =>
-      setEndInset({ left: overhang(first), right: overhang(last) });
-
-    measure();
-    // A layout effect runs before the web font has necessarily swapped in, and
-    // fallback metrics put the inset a couple of px out, so re-measure once the
-    // real font is in. The observer then keeps up with anything later — a
-    // wording change, a zoom, a font-size change at another breakpoint.
-    void document.fonts.ready.then(measure);
-    const observer = new ResizeObserver(measure);
-    observer.observe(first);
-    observer.observe(last);
-    return () => observer.disconnect();
-  }, []);
-
   return (
-    // The circles are evenly spaced and the labels hang off them: each label is
-    // centred on its circle and taken out of the flow, so a label as wide as
-    // "Edit Route Groups" doesn't push its circle around. That leaves the row as
-    // fixed-size circles with the connectors splitting whatever is left over.
-    // `pb-6` reserves the 4px gap + 20px line the labels occupy.
-    <div
-      className={cn('flex w-full items-center pb-6', className)}
-      style={{ paddingLeft: endInset.left, paddingRight: endInset.right }}
-    >
-      {STEPS.map((step, i) => (
-        <Fragment key={step.path}>
-          {i > 0 && (
-            <div
-              className={cn(
-                'h-[3px] flex-1',
-                i <= currentStep ? 'bg-blue-300' : 'bg-grey-300'
-              )}
-            />
-          )}
-          <div
-            className={cn(
-              'relative flex size-6 shrink-0 items-center justify-center rounded-full border-2',
-              i < currentStep && 'border-blue-300 bg-blue-300',
-              i === currentStep && 'border-blue-300',
-              i > currentStep && 'border-grey-400'
+    // The frames lay this out as five label-sized boxes with equal gaps, each
+    // circle centred over its own label — not as evenly spaced circles with
+    // labels hanging off them. The difference is visible: even spacing puts
+    // "Review Changes" 52px right of where the frame has it. So each step is an
+    // in-flow column (circle over label) and the connectors take the slack,
+    // which also means the end labels sit flush with the row's edges on their
+    // own — no measuring, no end inset.
+    <div className={cn('flex w-full items-start', className)}>
+      {STEPS.map((step, i) => {
+        // The line reaching step i is blue once that step has been passed; the
+        // one leaving it, once the next has.
+        const lineIn = i <= currentStep ? 'bg-blue-300' : 'bg-grey-300';
+        const lineOut = i + 1 <= currentStep ? 'bg-blue-300' : 'bg-grey-300';
+        return (
+          <Fragment key={step.path}>
+            {i > 0 && (
+              <div
+                className={cn(CONNECTOR, CONNECTOR_DROP, 'flex-1', lineIn)}
+              />
             )}
-          >
-            {i < currentStep && <CheckIcon className="size-3.5 text-white" />}
-            <span
-              ref={
-                i === 0
-                  ? firstLabel
-                  : i === STEPS.length - 1
-                    ? lastLabel
-                    : undefined
-              }
-              className={cn(
-                'text-h3 absolute top-full left-1/2 mt-1 -translate-x-1/2 font-bold whitespace-nowrap',
-                i <= currentStep ? 'text-blue-300' : 'text-grey-400'
-              )}
-            >
-              {step.label}
-            </span>
-          </div>
-        </Fragment>
-      ))}
+            <div className="flex shrink-0 flex-col items-center gap-1">
+              {/* The column is as wide as its label, so the circle alone would
+                  leave a gap either side of it. These two segments fill that
+                  gap, joining the circle to the connectors between columns —
+                  blank on the outer side of the first and last steps, which
+                  have no line to reach. */}
+              <div className="flex w-full items-center">
+                <div
+                  className={cn(CONNECTOR, 'flex-1', i > 0 && lineIn)}
+                  aria-hidden
+                />
+                <div
+                  className={cn(
+                    'flex size-6 shrink-0 items-center justify-center rounded-full border-2',
+                    i < currentStep && 'border-blue-300 bg-blue-300',
+                    i === currentStep && 'border-blue-300',
+                    i > currentStep && 'border-grey-400'
+                  )}
+                >
+                  {i < currentStep && (
+                    <CheckIcon className="size-3.5 text-white" />
+                  )}
+                </div>
+                <div
+                  className={cn(
+                    CONNECTOR,
+                    'flex-1',
+                    i < STEPS.length - 1 && lineOut
+                  )}
+                  aria-hidden
+                />
+              </div>
+              <span
+                className={cn(
+                  'text-h3 font-bold whitespace-nowrap',
+                  i <= currentStep ? 'text-blue-300' : 'text-grey-400'
+                )}
+              >
+                {step.label}
+              </span>
+            </div>
+          </Fragment>
+        );
+      })}
     </div>
   );
 }

--- a/frontend/src/pages/admin/routes/components/ProgressStepper.tsx
+++ b/frontend/src/pages/admin/routes/components/ProgressStepper.tsx
@@ -1,7 +1,10 @@
-import { Fragment } from 'react';
+import { Fragment, useLayoutEffect, useRef, useState } from 'react';
 
 import CheckIcon from '@/assets/icons/check.svg?react';
 import { cn } from '@/lib/utils';
+
+/** Half the 24px circle, in px — the label overhang is measured against it. */
+const CIRCLE_RADIUS = 12;
 
 interface Step {
   label: string;
@@ -16,86 +19,92 @@ const STEPS: Step[] = [
   { label: 'Generate Routes', path: '/admin/routes/generation/generate' },
 ];
 
-/**
- * The 3px rule. Inside a step it sits in a centre-aligned row, so it lines up
- * with the circle on its own; the connectors between steps hang off the top of
- * the row instead and need CONNECTOR_DROP to meet them.
- */
-const CONNECTOR = 'h-[3px]';
-/** (24px circle − 3px rule) / 2, so the two meet without a step in the line. */
-const CONNECTOR_DROP = 'mt-[10.5px]';
-
 interface ProgressStepperProps {
   currentStep: number;
   className?: string;
 }
 
 function ProgressStepper({ currentStep, className }: ProgressStepperProps) {
+  const firstLabel = useRef<HTMLSpanElement>(null);
+  const lastLabel = useRef<HTMLSpanElement>(null);
+  // Half of each end label hangs off its circle. The frames put those two
+  // labels flush with the page margins, so the row is inset by exactly that
+  // overhang — measured, because it's the rendered text width that decides it,
+  // and a hardcoded inset is both wrong for one end and silently wrong again
+  // the next time a label's wording changes.
+  const [endInset, setEndInset] = useState({ left: 0, right: 0 });
+
+  useLayoutEffect(() => {
+    const first = firstLabel.current;
+    const last = lastLabel.current;
+    if (!first || !last) return;
+
+    // getBoundingClientRect, not offsetWidth: the latter rounds to whole
+    // pixels, which leaves the end labels a couple of px off the margin.
+    const overhang = (label: HTMLSpanElement) =>
+      Math.max(0, label.getBoundingClientRect().width / 2 - CIRCLE_RADIUS);
+    const measure = () =>
+      setEndInset({ left: overhang(first), right: overhang(last) });
+
+    measure();
+    // A layout effect runs before the web font has necessarily swapped in, and
+    // fallback metrics put the inset a couple of px out, so re-measure once the
+    // real font is in. The observer then keeps up with anything later — a
+    // wording change, a zoom, a font-size change at another breakpoint.
+    void document.fonts.ready.then(measure);
+    const observer = new ResizeObserver(measure);
+    observer.observe(first);
+    observer.observe(last);
+    return () => observer.disconnect();
+  }, []);
+
   return (
-    // The frames lay this out as five label-sized boxes with equal gaps, each
-    // circle centred over its own label — not as evenly spaced circles with
-    // labels hanging off them. The difference is visible: even spacing puts
-    // "Review Changes" 52px right of where the frame has it. So each step is an
-    // in-flow column (circle over label) and the connectors take the slack,
-    // which also means the end labels sit flush with the row's edges on their
-    // own — no measuring, no end inset.
-    <div className={cn('flex w-full items-start', className)}>
-      {STEPS.map((step, i) => {
-        // The line reaching step i is blue once that step has been passed; the
-        // one leaving it, once the next has.
-        const lineIn = i <= currentStep ? 'bg-blue-300' : 'bg-grey-300';
-        const lineOut = i + 1 <= currentStep ? 'bg-blue-300' : 'bg-grey-300';
-        return (
-          <Fragment key={step.path}>
-            {i > 0 && (
-              <div
-                className={cn(CONNECTOR, CONNECTOR_DROP, 'flex-1', lineIn)}
-              />
+    // The circles are evenly spaced and the labels hang off them: each label is
+    // centred on its circle and taken out of the flow, so a label as wide as
+    // "Edit Route Groups" doesn't push its circle around. That leaves the row as
+    // fixed-size circles with the connectors splitting whatever is left over.
+    // `pb-6` reserves the 4px gap + 20px line the labels occupy.
+    <div
+      className={cn('flex w-full items-center pb-6', className)}
+      style={{ paddingLeft: endInset.left, paddingRight: endInset.right }}
+    >
+      {STEPS.map((step, i) => (
+        <Fragment key={step.path}>
+          {i > 0 && (
+            <div
+              className={cn(
+                'h-[3px] flex-1',
+                i <= currentStep ? 'bg-blue-300' : 'bg-grey-300'
+              )}
+            />
+          )}
+          <div
+            className={cn(
+              'relative flex size-6 shrink-0 items-center justify-center rounded-full border-2',
+              i < currentStep && 'border-blue-300 bg-blue-300',
+              i === currentStep && 'border-blue-300',
+              i > currentStep && 'border-grey-400'
             )}
-            <div className="flex shrink-0 flex-col items-center gap-1">
-              {/* The column is as wide as its label, so the circle alone would
-                  leave a gap either side of it. These two segments fill that
-                  gap, joining the circle to the connectors between columns —
-                  blank on the outer side of the first and last steps, which
-                  have no line to reach. */}
-              <div className="flex w-full items-center">
-                <div
-                  className={cn(CONNECTOR, 'flex-1', i > 0 && lineIn)}
-                  aria-hidden
-                />
-                <div
-                  className={cn(
-                    'flex size-6 shrink-0 items-center justify-center rounded-full border-2',
-                    i < currentStep && 'border-blue-300 bg-blue-300',
-                    i === currentStep && 'border-blue-300',
-                    i > currentStep && 'border-grey-400'
-                  )}
-                >
-                  {i < currentStep && (
-                    <CheckIcon className="size-3.5 text-white" />
-                  )}
-                </div>
-                <div
-                  className={cn(
-                    CONNECTOR,
-                    'flex-1',
-                    i < STEPS.length - 1 && lineOut
-                  )}
-                  aria-hidden
-                />
-              </div>
-              <span
-                className={cn(
-                  'text-h3 font-bold whitespace-nowrap',
-                  i <= currentStep ? 'text-blue-300' : 'text-grey-400'
-                )}
-              >
-                {step.label}
-              </span>
-            </div>
-          </Fragment>
-        );
-      })}
+          >
+            {i < currentStep && <CheckIcon className="size-3.5 text-white" />}
+            <span
+              ref={
+                i === 0
+                  ? firstLabel
+                  : i === STEPS.length - 1
+                    ? lastLabel
+                    : undefined
+              }
+              className={cn(
+                'text-h3 absolute top-full left-1/2 mt-1 -translate-x-1/2 font-bold whitespace-nowrap',
+                i <= currentStep ? 'text-blue-300' : 'text-grey-400'
+              )}
+            >
+              {step.label}
+            </span>
+          </div>
+        </Fragment>
+      ))}
     </div>
   );
 }

--- a/frontend/src/pages/admin/routes/components/ReassignDriverModal.tsx
+++ b/frontend/src/pages/admin/routes/components/ReassignDriverModal.tsx
@@ -81,7 +81,7 @@ export function ReassignDriverModal({
     <Modal open={open} onOpenChange={handleOpenChange}>
       <ModalContent>
         <ModalHeader>
-          <ModalTitle>
+          <ModalTitle variant="form">
             {isReassign ? 'Reassign Driver' : 'Assign Driver'}
           </ModalTitle>
           <ModalDescription>

--- a/frontend/src/pages/admin/routes/components/RouteAddressesTab.tsx
+++ b/frontend/src/pages/admin/routes/components/RouteAddressesTab.tsx
@@ -187,7 +187,7 @@ export function RouteAddressesTab({
       <Modal open={filterOpen} onOpenChange={setFilterOpen}>
         <ModalContent>
           <ModalHeader>
-            <ModalTitle>Filters</ModalTitle>
+            <ModalTitle variant="form">Filters</ModalTitle>
             <ModalDescription>Addresses</ModalDescription>
           </ModalHeader>
 

--- a/frontend/src/pages/admin/routes/components/RouteFilterModal.tsx
+++ b/frontend/src/pages/admin/routes/components/RouteFilterModal.tsx
@@ -62,7 +62,7 @@ export function RouteFilterModal({
     <Modal open={open} onOpenChange={onOpenChange}>
       <ModalContent>
         <ModalHeader>
-          <ModalTitle>Filters</ModalTitle>
+          <ModalTitle variant="form">Filters</ModalTitle>
           <ModalDescription>{subtitle}</ModalDescription>
         </ModalHeader>
 

--- a/frontend/src/pages/admin/routes/generation/AdminRoutesGenerationLayout.tsx
+++ b/frontend/src/pages/admin/routes/generation/AdminRoutesGenerationLayout.tsx
@@ -37,6 +37,14 @@ export interface GenerationOutletContext {
   setReviewResult: (r: LocationImportPreview | null) => void;
   routeGenerationInputs: RouteGenerationGroupInput[];
   setRouteGenerationInputs: (inputs: RouteGenerationGroupInput[]) => void;
+  /**
+   * Whether the step being shown has finished its work. Only the last step
+   * reports this — the frames tick "Generate Routes" off once the summary is
+   * up, and the stepper otherwise has no way to know a step it is sitting on
+   * is done.
+   */
+  currentStepComplete: boolean;
+  setCurrentStepComplete: (complete: boolean) => void;
 }
 
 export function AdminRoutesGenerationLayout() {
@@ -56,6 +64,7 @@ export function AdminRoutesGenerationLayout() {
   const [routeGenerationInputs, setRouteGenerationInputs] = useState<
     RouteGenerationGroupInput[]
   >([]);
+  const [currentStepComplete, setCurrentStepComplete] = useState(false);
 
   if (!hasSeededColumnMap && settingsLoaded) {
     setHasSeededColumnMap(true);
@@ -75,6 +84,8 @@ export function AdminRoutesGenerationLayout() {
     setReviewResult,
     routeGenerationInputs,
     setRouteGenerationInputs,
+    currentStepComplete,
+    setCurrentStepComplete,
   };
 
   return (
@@ -103,7 +114,9 @@ export function AdminRoutesGenerationLayout() {
       </div>
 
       {/* Stepper — shared across all steps */}
-      <ProgressStepper currentStep={currentStep} />
+      <ProgressStepper
+        currentStep={currentStep + (currentStepComplete ? 1 : 0)}
+      />
 
       {/* Step content */}
       <Outlet context={context} />

--- a/frontend/src/pages/admin/routes/generation/ConfigureStep.tsx
+++ b/frontend/src/pages/admin/routes/generation/ConfigureStep.tsx
@@ -466,7 +466,7 @@ export function ConfigureStep() {
       <Modal open={leaveOpen} onOpenChange={setLeaveOpen}>
         <ModalContent showCloseButton={false}>
           <ModalHeader>
-            <ModalTitle>Leave without Saving</ModalTitle>
+            <ModalTitle variant="confirmation">Leave without Saving</ModalTitle>
             <ModalDescription>
               If you go back now, all the data you entered will be lost. Would
               you still like to go back anyway?
@@ -489,7 +489,9 @@ export function ConfigureStep() {
       <Modal open={confirmOpen} onOpenChange={setConfirmOpen}>
         <ModalContent showCloseButton={false}>
           <ModalHeader>
-            <ModalTitle>Continue to Generation</ModalTitle>
+            <ModalTitle variant="confirmation">
+              Continue to Generation
+            </ModalTitle>
             <ModalDescription>
               You're about to generate delivery routes for routes you have
               selected. This action cannot be undone.

--- a/frontend/src/pages/admin/routes/generation/GenerateStep.tsx
+++ b/frontend/src/pages/admin/routes/generation/GenerateStep.tsx
@@ -28,7 +28,6 @@ import {
   ModalFooter,
   ModalHeader,
   ModalTitle,
-  Progress,
   Spinner,
   StatisticsCard,
 } from '@/common/components';
@@ -131,7 +130,7 @@ function GenerationSummary({ jobs, inputs }: SummaryProps) {
                   key={weekday}
                   className="flex min-w-0 flex-col items-center justify-end"
                 >
-                  <div className="flex h-72 w-full items-end justify-center">
+                  <div className="flex h-71 w-full items-end justify-center">
                     {count > 0 && (
                       <div
                         className={`${BAR_COLORS[index]} w-full max-w-40 rounded-t-lg`}
@@ -141,10 +140,10 @@ function GenerationSummary({ jobs, inputs }: SummaryProps) {
                       />
                     )}
                   </div>
-                  <p className="text-h2 mt-3 font-bold text-blue-300">
+                  <p className="text-h2 mt-2 font-bold text-blue-300">
                     {count}
                   </p>
-                  <p className="text-p1 text-grey-400">{weekday}</p>
+                  <p className="text-p1 text-grey-400 mt-1">{weekday}</p>
                 </div>
               );
             })}
@@ -184,8 +183,8 @@ function GenerationSummary({ jobs, inputs }: SummaryProps) {
 
 export function GenerateStep() {
   const navigate = useNavigate();
-  const { file, routeGenerationInputs } =
-    useOutletContext<GenerationOutletContext>();
+  const context = useOutletContext<GenerationOutletContext>();
+  const { file, routeGenerationInputs } = context;
   const [jobIds, setJobIds] = useState<string[]>([]);
   const [cancelOpen, setCancelOpen] = useState(false);
   const generationStarted = useRef(false);
@@ -218,6 +217,14 @@ export function GenerateStep() {
   const allCompleted =
     jobIds.length === routeGenerationInputs.length &&
     completedCount === routeGenerationInputs.length;
+
+  // The frames tick "Generate Routes" off on the summary; the stepper can't
+  // tell that the step it is sitting on has finished, so tell it.
+  const { setCurrentStepComplete } = context;
+  useEffect(() => {
+    setCurrentStepComplete(allCompleted);
+    return () => setCurrentStepComplete(false);
+  }, [allCompleted, setCurrentStepComplete]);
   const errorMessage = startGeneration.error
     ? (describeApiFailure(startGeneration.error) ??
       'Route generation could not be started. Please review your route settings and try again.')
@@ -260,14 +267,18 @@ export function GenerateStep() {
       {allCompleted ? (
         <GenerationSummary jobs={jobs} inputs={routeGenerationInputs} />
       ) : (
-        <Card>
-          <CardHeader>
+        // The frame stacks this card top-down — header, 16, illustration, 16,
+        // then the two status lines 8 apart — inside 32 across, 24 above and 40
+        // below. Its copy differs from ours deliberately: that frame still
+        // carries the validation wording.
+        <Card className="px-8 pt-6 pb-10">
+          <CardHeader className="gap-1">
             <CardTitle>Route Generation</CardTitle>
             <CardDescription>
               Creating optimized delivery routes.
             </CardDescription>
           </CardHeader>
-          <CardContent className="flex min-h-84 flex-col items-center justify-center gap-4">
+          <CardContent className="flex flex-col items-center gap-4 pt-4">
             {errorMessage ? (
               <Banner variant="error" className="w-full max-w-2xl">
                 {errorMessage}
@@ -278,24 +289,23 @@ export function GenerateStep() {
                   src={girlCatching}
                   alt=""
                   aria-hidden
-                  className="size-44 object-contain"
+                  className="size-58 object-contain"
                 />
-                <p className="text-p2 text-grey-400">
-                  {completedCount} / {routeGenerationInputs.length} route groups
-                  completed
-                </p>
-                <Progress
-                  value={(completedCount / routeGenerationInputs.length) * 100}
-                  aria-label={`${completedCount} of ${routeGenerationInputs.length} route groups completed`}
-                  className="w-80 max-w-full"
-                />
-                <div
-                  className="text-p2 flex items-center gap-2 text-blue-300"
-                  role="status"
-                  aria-live="polite"
-                >
-                  <Spinner size="sm" />
-                  <span>Generating routes...</span>
+                {/* The frame has no progress bar: the count line and the
+                    spinner carry the progress on their own, 8 apart. */}
+                <div className="flex flex-col items-center gap-2">
+                  <p className="text-p2 text-grey-400">
+                    {completedCount} / {routeGenerationInputs.length} route
+                    groups completed
+                  </p>
+                  <div
+                    className="text-p2 flex items-center gap-2 text-blue-300"
+                    role="status"
+                    aria-live="polite"
+                  >
+                    <Spinner size="xs" />
+                    <span>Generating routes...</span>
+                  </div>
                 </div>
               </>
             )}
@@ -306,7 +316,7 @@ export function GenerateStep() {
       <GenerationFooter>
         {!allCompleted && (
           <Button
-            variant="secondary"
+            variant="tertiary"
             disabled={startGeneration.isPending}
             onClick={() =>
               jobIds.length > 0
@@ -331,7 +341,10 @@ export function GenerateStep() {
       <Modal open={cancelOpen} onOpenChange={setCancelOpen}>
         <ModalContent showCloseButton={false}>
           <ModalHeader>
-            <ModalTitle>Cancel Route Generation</ModalTitle>
+            {/* 20/28 per the frame; ModalTitle's shared default is the 32/44 h1. */}
+            <ModalTitle variant="confirmation">
+              Cancel Route Generation
+            </ModalTitle>
             <ModalDescription>
               If you go back to{' '}
               <span className="text-blue-300">Configure Routes</span> now, the

--- a/frontend/src/pages/admin/routes/generation/ReviewStep.tsx
+++ b/frontend/src/pages/admin/routes/generation/ReviewStep.tsx
@@ -389,7 +389,7 @@ export function ReviewStep() {
       <Modal open={confirmOpen} onOpenChange={setConfirmOpen}>
         <ModalContent>
           <ModalHeader>
-            <ModalTitle>Confirm Changes</ModalTitle>
+            <ModalTitle variant="confirmation">Confirm Changes</ModalTitle>
             <ModalDescription>
               Some data has been updated, added, or removed. Are you sure you
               want to apply these changes?


### PR DESCRIPTION
Follow-up to #254: the generate step's spacing, type and states measured against its three Figma frames — Loading Routes, Cancel Dialog, Generation Successful. Every number below was measured in the browser at 1440 against the frame's own geometry (image-fill transforms and node boxes pulled from the Figma API, not eyeballed).

Two of these reach past this page — flagged below.

## Stepper

The frames space five label-sized boxes evenly and centre each circle over its own label. We spaced the *circles* evenly:

| label | frame | before | after |
| --- | --- | --- | --- |
| Import | 168 | 168 | 168 |
| Validate | 405 | 446.6 | 400.6 |
| Review Changes | 648 | 700.1 | 644.4 |
| Edit Route Groups | 951 | 977.8 | 949.6 |
| Generate Routes | 1267 | 1267.7 | 1267.7 |

Each step is now an in-flow column carrying its own two line segments, so the rule runs unbroken from the first circle to the last and breaks only where a circle sits. The end labels land flush on their own, so the measuring added in #258 is deleted.

"Generate Routes" also ticks off once the summary is up, as the frames draw it. The stepper reads the path alone and can't tell the step it's sitting on has finished, so the generation layout carries a `currentStepComplete` flag the last step sets.

## Stat cards

96 tall against the frame's 100, so the column of four ended at 752 instead of 768 — 16px above the chart card it bottom-aligns with (4×100 + 3×16 = 448 = the chart's height). Label was on `text-p1` (16/24) where the frame is 16/20; value on an off-token `text-3xl leading-10` (30/40) where the frame is the 32/44 h1.

The illustrations were all drawn 152 square, anchored 8px past the card's right edge. The frames draw each 1000×1000 asset at its own size and offset — granny 159, boy 139, boyPointing 164, girlSearching 179 — read off their image-fill transforms. All four now land on the frame's position to the pixel (granny at 1253,297 against 1253.6,296.8).

## Loading card

No progress bar: the frame has none, the count line and spinner carry it. A 16px spinner instead of 32 (`Spinner` gains `xs`). And stacked top-down — header, 16, illustration, 16, then the two status lines 8 apart, inside 32 across / 24 above / 40 below — rather than centred in the leftover height, which had the spinner 12px low and everything above it a few px off. Card, title, description, illustration, count and spinner now all match the frame's y exactly, and the card comes out 428 tall as drawn.

## Reaches past this page

**`ModalTitle` now takes a required `variant`.** The frames use two title sizes — 32/44 for form modals ("Add Admin", "Announcements", 600×5xx) and 20/28 for confirmation dialogs ("Delete Route Group", "Log out", 600×180) — and the component only had the first. Every confirmation in the app rendered its title at 32/44 and stood 16px taller than its frame. All 14 call sites are tagged: 7 form, 7 confirmation. Required rather than defaulted, because defaulting to the form size is how they drifted.

**`text-p2` now carries a weight.** Figma's Desktop/Paragraph/P2 is SemiBold, but `index.css` asserted in a comment that "P2 and P3 are Regular at every tier" and set none, so every desktop `text-p2` rendered 400. It now carries 400 → 600 the way `text-p1` carries 400 → 500. This changes body text app-wide, not just here — worth a look at other screens.

Also: the generate footer's back button was `secondary` where every other step and every frame use `tertiary`; disabled buttons are now the button's own colours at 50% rather than a grey swap (the 🌟 Finalized page draws all 17 of its disabled buttons that way and uses the library's grey `Type=Disabled` zero times); and the sidebar labels move off `text-m-p2`, the mobile token `frontend/CLAUDE.md` rules out in components, onto `p1`.

## Figma changes made alongside

- Both route-generation confirmation dialogs centred in their frames (they sat 12px below and 29px above centre).
- The success subtitle and the loading card's description moved from Mobile/P1 to Desktop/P1.
- The `Navigation Button` component set (all three states) moved from Mobile/P2 to Desktop/P1, which is what the sidebar change follows.

## Verification

Measured in the browser at 1440 for all three states; `tsc`, `eslint` and `vitest` (22 tests) clean. No visual regression tests exist for this — jsdom returns zeros for every rect, so layout can't be asserted in a unit test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
