### PR TITLE
Pass driver_id on login + refresh

### DIFF
--- a/backend/python/app/dependencies/auth.py
+++ b/backend/python/app/dependencies/auth.py
@@ -14,6 +14,7 @@ from app.config import settings
 from app.models import get_session
 from app.models.announcement import Announcement
 from app.models.route import Route
+from app.services.implementations.admin_service import AdminService
 from app.services.implementations.auth_service import AuthService
 from app.services.implementations.driver_service import DriverService
 from app.services.implementations.email_service import EmailService
@@ -21,6 +22,7 @@ from app.services.implementations.user_service import UserService
 
 # Initialize services
 logger = logging.getLogger(__name__)
+admin_service = AdminService(logger)
 driver_service = DriverService(logger)
 user_service = UserService(logger)
 email_service = EmailService(
@@ -34,7 +36,9 @@ email_service = EmailService(
     settings.mailer_user,
     "Food4Kids",
 )
-auth_service = AuthService(logger, user_service, driver_service, email_service)
+auth_service = AuthService(
+    logger, user_service, driver_service, admin_service, email_service
+)
 
 # Security scheme
 security = HTTPBearer()

--- a/backend/python/app/dependencies/services.py
+++ b/backend/python/app/dependencies/services.py
@@ -17,6 +17,7 @@ from functools import lru_cache
 from fastapi import Depends
 
 from app.config import settings
+from app.services.implementations.admin_service import AdminService
 from app.services.implementations.announcement_service import AnnouncementService
 from app.services.implementations.auth_service import AuthService
 from app.services.implementations.driver_service import DriverService
@@ -122,14 +123,22 @@ def get_driver_service() -> DriverService:
     return DriverService(logger)
 
 
+@lru_cache
+def get_admin_service() -> AdminService:
+    """Get admin service instance"""
+    logger = get_logger()
+    return AdminService(logger)
+
+
 def get_auth_service(
     user_service: UserService = Depends(get_user_service),
     driver_service: DriverService = Depends(get_driver_service),
+    admin_service: AdminService = Depends(get_admin_service),
     email_service: EmailService = Depends(get_email_service),
 ) -> AuthService:
     """Get auth service instance"""
     logger = get_logger()
-    return AuthService(logger, user_service, driver_service, email_service)
+    return AuthService(logger, user_service, driver_service, admin_service, email_service)
 
 
 @lru_cache

--- a/backend/python/app/dependencies/services.py
+++ b/backend/python/app/dependencies/services.py
@@ -138,7 +138,9 @@ def get_auth_service(
 ) -> AuthService:
     """Get auth service instance"""
     logger = get_logger()
-    return AuthService(logger, user_service, driver_service, admin_service, email_service)
+    return AuthService(
+        logger, user_service, driver_service, admin_service, email_service
+    )
 
 
 @lru_cache

--- a/backend/python/app/schemas/auth.py
+++ b/backend/python/app/schemas/auth.py
@@ -42,6 +42,7 @@ class AuthResponse(BaseModel):
     email: EmailStr
     role: str
     remember_me: bool
+    driver_id: UUID | None = None
 
     @computed_field  # type: ignore[prop-decorator]
     @property

--- a/backend/python/app/schemas/auth.py
+++ b/backend/python/app/schemas/auth.py
@@ -43,6 +43,7 @@ class AuthResponse(BaseModel):
     role: str
     remember_me: bool
     driver_id: UUID | None = None
+    admin_id: UUID | None = None
 
     @computed_field  # type: ignore[prop-decorator]
     @property

--- a/backend/python/app/services/implementations/admin_service.py
+++ b/backend/python/app/services/implementations/admin_service.py
@@ -1,0 +1,39 @@
+import logging
+from uuid import UUID
+
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+from sqlmodel import select
+
+from app.models.admin import Admin
+from app.models.user import User
+
+
+class AdminService:
+    """Service for managing admins with Firebase authentication integration"""
+
+    def __init__(self, logger: logging.Logger):
+        self.logger = logger
+
+    async def get_admin_id_by_auth_id(
+        self, session: AsyncSession, auth_id: str
+    ) -> UUID | None:
+        """Get admin_id by auth_id"""
+        try:
+            statement = (
+                select(Admin)
+                .options(selectinload(Admin.user))  # type: ignore[arg-type]
+                .join(Admin.user)  # type: ignore[arg-type]
+                .where(User.auth_id == auth_id)
+            )
+            result = await session.execute(statement)
+            admin = result.scalars().first()
+
+            if not admin:
+                self.logger.error(f"Admin with auth_id {auth_id} not found")
+                return None
+
+            return admin.admin_id
+        except Exception as e:
+            self.logger.error(f"Failed to get admin_id by auth_id: {e!s}")
+            raise e

--- a/backend/python/app/services/implementations/auth_service.py
+++ b/backend/python/app/services/implementations/auth_service.py
@@ -4,7 +4,9 @@ from typing import TYPE_CHECKING
 import firebase_admin.auth
 import jwt
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import select
 
+from app.models.driver import Driver
 from app.schemas.auth import AuthResponse
 from app.utilities.firebase_rest_client import FirebaseRestClient, FirebaseRestError
 
@@ -81,6 +83,9 @@ class AuthService:
                 raise ValueError("Invalid email or password")
 
             # Create AuthResponse with all required fields (refresh_token excluded - it goes in httpOnly cookie)
+            driver_id = await session.scalar(
+                select(Driver.driver_id).where(Driver.user_id == user.user_id)
+            )
             auth_response = AuthResponse(
                 access_token=token.access_token,
                 id=user.user_id,
@@ -89,6 +94,7 @@ class AuthService:
                 email=user.email,
                 role=user.role,
                 remember_me=remember_me,
+                driver_id=driver_id,
             )
             return auth_response, token.refresh_token
         except Exception as e:
@@ -160,6 +166,9 @@ class AuthService:
                 f"No user in the database for Firebase auth_id {auth_id}"
             )
 
+        driver_id = await session.scalar(
+            select(Driver.driver_id).where(Driver.user_id == user.user_id)
+        )
         auth_response = AuthResponse(
             access_token=new_access_token,
             id=user.user_id,
@@ -168,5 +177,6 @@ class AuthService:
             email=user.email,
             role=user.role,
             remember_me=remember_me,
+            driver_id=driver_id,
         )
         return auth_response, token_response.refresh_token

--- a/backend/python/app/services/implementations/auth_service.py
+++ b/backend/python/app/services/implementations/auth_service.py
@@ -9,6 +9,7 @@ from app.schemas.auth import AuthResponse
 from app.utilities.firebase_rest_client import FirebaseRestClient, FirebaseRestError
 
 if TYPE_CHECKING:
+    from app.services.implementations.admin_service import AdminService
     from app.services.implementations.driver_service import DriverService
     from app.services.implementations.email_service import EmailService
     from app.services.implementations.user_service import UserService
@@ -46,6 +47,7 @@ class AuthService:
         logger: Logger,
         user_service: "UserService",
         driver_service: "DriverService",
+        admin_service: "AdminService",
         email_service: "EmailService | None" = None,
     ) -> None:
         """
@@ -55,12 +57,15 @@ class AuthService:
         :type logger: Logger
         :param user_service: a user_service instance
         :type user_service: IUserService
+        :param driver_service: a driver_service instance
+        :param admin_service: an admin_service instance
         :param email_service: an email_service instance
         :type email_service: Optional[IEmailService]
         """
         self.logger: Logger = logger
         self.user_service: UserService = user_service
         self.driver_service: DriverService = driver_service
+        self.admin_service: AdminService = admin_service
         self.email_service: EmailService | None = email_service
         self.firebase_rest_client: FirebaseRestClient = FirebaseRestClient(logger)
 
@@ -86,6 +91,11 @@ class AuthService:
                 driver_id = await self.driver_service.get_driver_id_by_auth_id(
                     session, user.auth_id
                 )
+            admin_id = None
+            if user.role.lower() == "admin" and user.auth_id:
+                admin_id = await self.admin_service.get_admin_id_by_auth_id(
+                    session, user.auth_id
+                )
             auth_response = AuthResponse(
                 access_token=token.access_token,
                 id=user.user_id,
@@ -95,6 +105,7 @@ class AuthService:
                 role=user.role,
                 remember_me=remember_me,
                 driver_id=driver_id,
+                admin_id=admin_id,
             )
             return auth_response, token.refresh_token
         except Exception as e:
@@ -171,6 +182,11 @@ class AuthService:
             driver_id = await self.driver_service.get_driver_id_by_auth_id(
                 session, auth_id
             )
+        admin_id = None
+        if user.role.lower() == "admin" and auth_id:
+            admin_id = await self.admin_service.get_admin_id_by_auth_id(
+                session, auth_id
+            )
         auth_response = AuthResponse(
             access_token=new_access_token,
             id=user.user_id,
@@ -180,5 +196,6 @@ class AuthService:
             role=user.role,
             remember_me=remember_me,
             driver_id=driver_id,
+            admin_id=admin_id,
         )
         return auth_response, token_response.refresh_token

--- a/backend/python/app/services/implementations/auth_service.py
+++ b/backend/python/app/services/implementations/auth_service.py
@@ -4,9 +4,7 @@ from typing import TYPE_CHECKING
 import firebase_admin.auth
 import jwt
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlmodel import select
 
-from app.models.driver import Driver
 from app.schemas.auth import AuthResponse
 from app.utilities.firebase_rest_client import FirebaseRestClient, FirebaseRestError
 
@@ -83,9 +81,11 @@ class AuthService:
                 raise ValueError("Invalid email or password")
 
             # Create AuthResponse with all required fields (refresh_token excluded - it goes in httpOnly cookie)
-            driver_id = await session.scalar(
-                select(Driver.driver_id).where(Driver.user_id == user.user_id)
-            )
+            driver_id = None
+            if user.role.lower() == "driver" and user.auth_id:
+                driver_id = await self.driver_service.get_driver_id_by_auth_id(
+                    session, user.auth_id
+                )
             auth_response = AuthResponse(
                 access_token=token.access_token,
                 id=user.user_id,
@@ -166,9 +166,11 @@ class AuthService:
                 f"No user in the database for Firebase auth_id {auth_id}"
             )
 
-        driver_id = await session.scalar(
-            select(Driver.driver_id).where(Driver.user_id == user.user_id)
-        )
+        driver_id = None
+        if user.role.lower() == "driver" and auth_id:
+            driver_id = await self.driver_service.get_driver_id_by_auth_id(
+                session, auth_id
+            )
         auth_response = AuthResponse(
             access_token=new_access_token,
             id=user.user_id,

--- a/backend/python/tests/test_auth_routes.py
+++ b/backend/python/tests/test_auth_routes.py
@@ -305,7 +305,7 @@ class TestRenewTokenSessionExpiry:
     ) -> AuthService:
         user_service = MagicMock()
         user_service.get_user_by_auth_id = AsyncMock(return_value=user)
-        service = AuthService(getLogger(__name__), user_service, MagicMock())
+        service = AuthService(getLogger(__name__), user_service, MagicMock(), MagicMock())
         firebase_client: Any = MagicMock()
         if refresh_error is not None:
             firebase_client.refresh_token.side_effect = refresh_error

--- a/backend/python/tests/test_auth_routes.py
+++ b/backend/python/tests/test_auth_routes.py
@@ -305,7 +305,9 @@ class TestRenewTokenSessionExpiry:
     ) -> AuthService:
         user_service = MagicMock()
         user_service.get_user_by_auth_id = AsyncMock(return_value=user)
-        service = AuthService(getLogger(__name__), user_service, MagicMock(), MagicMock())
+        service = AuthService(
+            getLogger(__name__), user_service, MagicMock(), MagicMock()
+        )
         firebase_client: Any = MagicMock()
         if refresh_error is not None:
             firebase_client.refresh_token.side_effect = refresh_error

--- a/backend/python/tests/test_auth_service.py
+++ b/backend/python/tests/test_auth_service.py
@@ -2,7 +2,6 @@
 
 from logging import getLogger
 from types import SimpleNamespace
-from typing import Any
 from unittest.mock import MagicMock
 
 import jwt

--- a/backend/python/tests/test_auth_service.py
+++ b/backend/python/tests/test_auth_service.py
@@ -1,0 +1,150 @@
+"""Tests for AuthService — token generation, renewal, and driver_id propagation.
+"""
+
+from logging import getLogger
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock
+
+import jwt
+import pytest
+
+from app.models.driver import DriverCreate
+from app.models.user import User
+from app.schemas.auth import TokenResponse
+from app.services.implementations.driver_service import DriverService
+from app.services.implementations.user_service import UserService
+from app.services.implementations.auth_service import AuthService
+
+
+class TestAuthServiceDriverId:
+    @pytest.mark.asyncio
+    async def test_generate_token_includes_driver_id_for_driver(self, test_session: Any) -> None:
+        user = User(
+            first_name="Test",
+            last_name="Driver",
+            email="testdriver@example.com",
+            role="driver",
+            auth_id="auth-driver-123",
+        )
+        test_session.add(user)
+        await test_session.flush()
+
+        driver_service = DriverService(getLogger(__name__))
+        driver = await driver_service.create_driver(
+            test_session,
+            DriverCreate(
+                user_id=user.user_id,
+                phone="+12125551234",
+                license_plate="ABC123",
+                car_make_model="Toyota Camry",
+                address="123 Main St, City, State 12345",
+            ),
+        )
+        await test_session.commit()
+
+        user_service = UserService(getLogger(__name__))
+        auth_service = AuthService(getLogger(__name__), user_service, driver_service)
+
+        token_response = SimpleNamespace(access_token="fake-access-token", refresh_token="fake-refresh-token")
+        auth_service.firebase_rest_client = MagicMock()
+        auth_service.firebase_rest_client.sign_in_with_password.return_value = token_response
+
+        auth_response, _ = await auth_service.generate_token(
+            test_session, "testdriver@example.com", "Password123!", remember_me=False
+        )
+
+        assert auth_response.driver_id == driver.driver_id
+
+    @pytest.mark.asyncio
+    async def test_generate_token_driver_id_none_for_admin(self, test_session: Any) -> None:
+        user = User(
+            first_name="Test",
+            last_name="Admin",
+            email="testadmin@example.com",
+            role="admin",
+            auth_id="auth-admin-123",
+        )
+        test_session.add(user)
+        await test_session.commit()
+
+        user_service = UserService(getLogger(__name__))
+        driver_service = DriverService(getLogger(__name__))
+        auth_service = AuthService(getLogger(__name__), user_service, driver_service)
+
+        token_response = SimpleNamespace(access_token="fake-access-token", refresh_token="fake-refresh-token")
+        auth_service.firebase_rest_client = MagicMock()
+        auth_service.firebase_rest_client.sign_in_with_password.return_value = token_response
+
+        auth_response, _ = await auth_service.generate_token(
+            test_session, "testadmin@example.com", "Password123!", remember_me=False
+        )
+
+        assert auth_response.driver_id is None
+
+    @pytest.mark.asyncio
+    async def test_renew_token_includes_driver_id_for_driver(self, test_session: Any) -> None:
+        user = User(
+            first_name="Test",
+            last_name="Driver",
+            email="testdriver@example.com",
+            role="driver",
+            auth_id="auth-driver-456",
+        )
+        test_session.add(user)
+        await test_session.flush()
+
+        driver_service = DriverService(getLogger(__name__))
+        driver = await driver_service.create_driver(
+            test_session,
+            DriverCreate(
+                user_id=user.user_id,
+                phone="+12125555678",
+                license_plate="XYZ789",
+                car_make_model="Honda Civic",
+                address="456 Oak St, City, State 12345",
+            ),
+        )
+        await test_session.commit()
+
+        user_service = UserService(getLogger(__name__))
+        auth_service = AuthService(getLogger(__name__), user_service, driver_service)
+
+        access_token = jwt.encode({"sub": "auth-driver-456"}, "k" * 32, "HS256")
+        token_response = TokenResponse(access_token=access_token, refresh_token="new-refresh-token")
+        auth_service.firebase_rest_client = MagicMock()
+        auth_service.firebase_rest_client.refresh_token.return_value = token_response
+
+        auth_response, _ = await auth_service.renew_token(
+            test_session, "stub-refresh-token", remember_me=True
+        )
+
+        assert auth_response.driver_id == driver.driver_id
+        assert auth_response.remember_me is True
+
+    @pytest.mark.asyncio
+    async def test_renew_token_driver_id_none_for_admin(self, test_session: Any) -> None:
+        user = User(
+            first_name="Test",
+            last_name="Admin",
+            email="testadmin@example.com",
+            role="admin",
+            auth_id="auth-admin-456",
+        )
+        test_session.add(user)
+        await test_session.commit()
+
+        user_service = UserService(getLogger(__name__))
+        driver_service = DriverService(getLogger(__name__))
+        auth_service = AuthService(getLogger(__name__), user_service, driver_service)
+
+        access_token = jwt.encode({"sub": "auth-admin-456"}, "k" * 32, "HS256")
+        token_response = TokenResponse(access_token=access_token, refresh_token="new-refresh-token")
+        auth_service.firebase_rest_client = MagicMock()
+        auth_service.firebase_rest_client.refresh_token.return_value = token_response
+
+        auth_response, _ = await auth_service.renew_token(
+            test_session, "stub-refresh-token", remember_me=False
+        )
+
+        assert auth_response.driver_id is None

--- a/backend/python/tests/test_auth_service.py
+++ b/backend/python/tests/test_auth_service.py
@@ -1,4 +1,4 @@
-"""Tests for AuthService — token generation, renewal, and driver_id propagation."""
+"""Tests for AuthService — token generation, renewal, driver_id, and admin_id propagation."""
 
 from logging import getLogger
 from types import SimpleNamespace
@@ -8,9 +8,11 @@ import jwt
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.models.admin import Admin
 from app.models.driver import DriverCreate
 from app.models.user import User
 from app.schemas.auth import TokenResponse
+from app.services.implementations.admin_service import AdminService
 from app.services.implementations.auth_service import AuthService
 from app.services.implementations.driver_service import DriverService
 from app.services.implementations.user_service import UserService
@@ -45,7 +47,8 @@ class TestAuthServiceDriverId:
         await test_session.commit()
 
         user_service = UserService(getLogger(__name__))
-        auth_service = AuthService(getLogger(__name__), user_service, driver_service)
+        admin_service = AdminService(getLogger(__name__))
+        auth_service = AuthService(getLogger(__name__), user_service, driver_service, admin_service)
 
         token_response = SimpleNamespace(
             access_token="fake-access-token", refresh_token="fake-refresh-token"
@@ -60,6 +63,7 @@ class TestAuthServiceDriverId:
         )
 
         assert auth_response.driver_id == driver.driver_id
+        assert auth_response.admin_id is None
 
     @pytest.mark.asyncio
     async def test_generate_token_driver_id_none_for_admin(
@@ -73,11 +77,18 @@ class TestAuthServiceDriverId:
             auth_id="auth-admin-123",
         )
         test_session.add(user)
+        admin = Admin(
+            user_id=user.user_id,
+            admin_phone="+12125551234",
+            receive_email_notifications=True,
+        )
+        test_session.add(admin)
         await test_session.commit()
 
         user_service = UserService(getLogger(__name__))
         driver_service = DriverService(getLogger(__name__))
-        auth_service = AuthService(getLogger(__name__), user_service, driver_service)
+        admin_service = AdminService(getLogger(__name__))
+        auth_service = AuthService(getLogger(__name__), user_service, driver_service, admin_service)
 
         token_response = SimpleNamespace(
             access_token="fake-access-token", refresh_token="fake-refresh-token"
@@ -92,6 +103,7 @@ class TestAuthServiceDriverId:
         )
 
         assert auth_response.driver_id is None
+        assert auth_response.admin_id == admin.admin_id
 
     @pytest.mark.asyncio
     async def test_renew_token_includes_driver_id_for_driver(
@@ -121,7 +133,8 @@ class TestAuthServiceDriverId:
         await test_session.commit()
 
         user_service = UserService(getLogger(__name__))
-        auth_service = AuthService(getLogger(__name__), user_service, driver_service)
+        admin_service = AdminService(getLogger(__name__))
+        auth_service = AuthService(getLogger(__name__), user_service, driver_service, admin_service)
 
         access_token = jwt.encode({"sub": "auth-driver-456"}, "k" * 32, "HS256")
         token_response = TokenResponse(
@@ -135,6 +148,7 @@ class TestAuthServiceDriverId:
         )
 
         assert auth_response.driver_id == driver.driver_id
+        assert auth_response.admin_id is None
         assert auth_response.remember_me is True
 
     @pytest.mark.asyncio
@@ -149,11 +163,18 @@ class TestAuthServiceDriverId:
             auth_id="auth-admin-456",
         )
         test_session.add(user)
+        admin = Admin(
+            user_id=user.user_id,
+            admin_phone="+12125551234",
+            receive_email_notifications=True,
+        )
+        test_session.add(admin)
         await test_session.commit()
 
         user_service = UserService(getLogger(__name__))
         driver_service = DriverService(getLogger(__name__))
-        auth_service = AuthService(getLogger(__name__), user_service, driver_service)
+        admin_service = AdminService(getLogger(__name__))
+        auth_service = AuthService(getLogger(__name__), user_service, driver_service, admin_service)
 
         access_token = jwt.encode({"sub": "auth-admin-456"}, "k" * 32, "HS256")
         token_response = TokenResponse(
@@ -167,3 +188,4 @@ class TestAuthServiceDriverId:
         )
 
         assert auth_response.driver_id is None
+        assert auth_response.admin_id == admin.admin_id

--- a/backend/python/tests/test_auth_service.py
+++ b/backend/python/tests/test_auth_service.py
@@ -1,5 +1,4 @@
-"""Tests for AuthService — token generation, renewal, and driver_id propagation.
-"""
+"""Tests for AuthService — token generation, renewal, and driver_id propagation."""
 
 from logging import getLogger
 from types import SimpleNamespace
@@ -12,14 +11,16 @@ import pytest
 from app.models.driver import DriverCreate
 from app.models.user import User
 from app.schemas.auth import TokenResponse
+from app.services.implementations.auth_service import AuthService
 from app.services.implementations.driver_service import DriverService
 from app.services.implementations.user_service import UserService
-from app.services.implementations.auth_service import AuthService
 
 
 class TestAuthServiceDriverId:
     @pytest.mark.asyncio
-    async def test_generate_token_includes_driver_id_for_driver(self, test_session: Any) -> None:
+    async def test_generate_token_includes_driver_id_for_driver(
+        self, test_session: Any
+    ) -> None:
         user = User(
             first_name="Test",
             last_name="Driver",
@@ -46,9 +47,13 @@ class TestAuthServiceDriverId:
         user_service = UserService(getLogger(__name__))
         auth_service = AuthService(getLogger(__name__), user_service, driver_service)
 
-        token_response = SimpleNamespace(access_token="fake-access-token", refresh_token="fake-refresh-token")
+        token_response = SimpleNamespace(
+            access_token="fake-access-token", refresh_token="fake-refresh-token"
+        )
         auth_service.firebase_rest_client = MagicMock()
-        auth_service.firebase_rest_client.sign_in_with_password.return_value = token_response
+        auth_service.firebase_rest_client.sign_in_with_password.return_value = (
+            token_response
+        )
 
         auth_response, _ = await auth_service.generate_token(
             test_session, "testdriver@example.com", "Password123!", remember_me=False
@@ -57,7 +62,9 @@ class TestAuthServiceDriverId:
         assert auth_response.driver_id == driver.driver_id
 
     @pytest.mark.asyncio
-    async def test_generate_token_driver_id_none_for_admin(self, test_session: Any) -> None:
+    async def test_generate_token_driver_id_none_for_admin(
+        self, test_session: Any
+    ) -> None:
         user = User(
             first_name="Test",
             last_name="Admin",
@@ -72,9 +79,13 @@ class TestAuthServiceDriverId:
         driver_service = DriverService(getLogger(__name__))
         auth_service = AuthService(getLogger(__name__), user_service, driver_service)
 
-        token_response = SimpleNamespace(access_token="fake-access-token", refresh_token="fake-refresh-token")
+        token_response = SimpleNamespace(
+            access_token="fake-access-token", refresh_token="fake-refresh-token"
+        )
         auth_service.firebase_rest_client = MagicMock()
-        auth_service.firebase_rest_client.sign_in_with_password.return_value = token_response
+        auth_service.firebase_rest_client.sign_in_with_password.return_value = (
+            token_response
+        )
 
         auth_response, _ = await auth_service.generate_token(
             test_session, "testadmin@example.com", "Password123!", remember_me=False
@@ -83,7 +94,9 @@ class TestAuthServiceDriverId:
         assert auth_response.driver_id is None
 
     @pytest.mark.asyncio
-    async def test_renew_token_includes_driver_id_for_driver(self, test_session: Any) -> None:
+    async def test_renew_token_includes_driver_id_for_driver(
+        self, test_session: Any
+    ) -> None:
         user = User(
             first_name="Test",
             last_name="Driver",
@@ -111,7 +124,9 @@ class TestAuthServiceDriverId:
         auth_service = AuthService(getLogger(__name__), user_service, driver_service)
 
         access_token = jwt.encode({"sub": "auth-driver-456"}, "k" * 32, "HS256")
-        token_response = TokenResponse(access_token=access_token, refresh_token="new-refresh-token")
+        token_response = TokenResponse(
+            access_token=access_token, refresh_token="new-refresh-token"
+        )
         auth_service.firebase_rest_client = MagicMock()
         auth_service.firebase_rest_client.refresh_token.return_value = token_response
 
@@ -123,7 +138,9 @@ class TestAuthServiceDriverId:
         assert auth_response.remember_me is True
 
     @pytest.mark.asyncio
-    async def test_renew_token_driver_id_none_for_admin(self, test_session: Any) -> None:
+    async def test_renew_token_driver_id_none_for_admin(
+        self, test_session: Any
+    ) -> None:
         user = User(
             first_name="Test",
             last_name="Admin",
@@ -139,7 +156,9 @@ class TestAuthServiceDriverId:
         auth_service = AuthService(getLogger(__name__), user_service, driver_service)
 
         access_token = jwt.encode({"sub": "auth-admin-456"}, "k" * 32, "HS256")
-        token_response = TokenResponse(access_token=access_token, refresh_token="new-refresh-token")
+        token_response = TokenResponse(
+            access_token=access_token, refresh_token="new-refresh-token"
+        )
         auth_service.firebase_rest_client = MagicMock()
         auth_service.firebase_rest_client.refresh_token.return_value = token_response
 

--- a/backend/python/tests/test_auth_service.py
+++ b/backend/python/tests/test_auth_service.py
@@ -48,7 +48,9 @@ class TestAuthServiceDriverId:
 
         user_service = UserService(getLogger(__name__))
         admin_service = AdminService(getLogger(__name__))
-        auth_service = AuthService(getLogger(__name__), user_service, driver_service, admin_service)
+        auth_service = AuthService(
+            getLogger(__name__), user_service, driver_service, admin_service
+        )
 
         token_response = SimpleNamespace(
             access_token="fake-access-token", refresh_token="fake-refresh-token"
@@ -88,7 +90,9 @@ class TestAuthServiceDriverId:
         user_service = UserService(getLogger(__name__))
         driver_service = DriverService(getLogger(__name__))
         admin_service = AdminService(getLogger(__name__))
-        auth_service = AuthService(getLogger(__name__), user_service, driver_service, admin_service)
+        auth_service = AuthService(
+            getLogger(__name__), user_service, driver_service, admin_service
+        )
 
         token_response = SimpleNamespace(
             access_token="fake-access-token", refresh_token="fake-refresh-token"
@@ -134,7 +138,9 @@ class TestAuthServiceDriverId:
 
         user_service = UserService(getLogger(__name__))
         admin_service = AdminService(getLogger(__name__))
-        auth_service = AuthService(getLogger(__name__), user_service, driver_service, admin_service)
+        auth_service = AuthService(
+            getLogger(__name__), user_service, driver_service, admin_service
+        )
 
         access_token = jwt.encode({"sub": "auth-driver-456"}, "k" * 32, "HS256")
         token_response = TokenResponse(
@@ -174,7 +180,9 @@ class TestAuthServiceDriverId:
         user_service = UserService(getLogger(__name__))
         driver_service = DriverService(getLogger(__name__))
         admin_service = AdminService(getLogger(__name__))
-        auth_service = AuthService(getLogger(__name__), user_service, driver_service, admin_service)
+        auth_service = AuthService(
+            getLogger(__name__), user_service, driver_service, admin_service
+        )
 
         access_token = jwt.encode({"sub": "auth-admin-456"}, "k" * 32, "HS256")
         token_response = TokenResponse(

--- a/backend/python/tests/test_auth_service.py
+++ b/backend/python/tests/test_auth_service.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock
 
 import jwt
 import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.driver import DriverCreate
 from app.models.user import User
@@ -19,7 +20,7 @@ from app.services.implementations.user_service import UserService
 class TestAuthServiceDriverId:
     @pytest.mark.asyncio
     async def test_generate_token_includes_driver_id_for_driver(
-        self, test_session: Any
+        self, test_session: AsyncSession
     ) -> None:
         user = User(
             first_name="Test",
@@ -63,7 +64,7 @@ class TestAuthServiceDriverId:
 
     @pytest.mark.asyncio
     async def test_generate_token_driver_id_none_for_admin(
-        self, test_session: Any
+        self, test_session: AsyncSession
     ) -> None:
         user = User(
             first_name="Test",
@@ -95,7 +96,7 @@ class TestAuthServiceDriverId:
 
     @pytest.mark.asyncio
     async def test_renew_token_includes_driver_id_for_driver(
-        self, test_session: Any
+        self, test_session: AsyncSession
     ) -> None:
         user = User(
             first_name="Test",
@@ -139,7 +140,7 @@ class TestAuthServiceDriverId:
 
     @pytest.mark.asyncio
     async def test_renew_token_driver_id_none_for_admin(
-        self, test_session: Any
+        self, test_session: AsyncSession
     ) -> None:
         user = User(
             first_name="Test",

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -231,6 +231,18 @@
             "title": "Access Token",
             "type": "string"
           },
+          "driver_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Driver Id"
+          },
           "email": {
             "format": "email",
             "title": "Email",

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -231,6 +231,18 @@
             "title": "Access Token",
             "type": "string"
           },
+          "admin_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Admin Id"
+          },
           "driver_id": {
             "anyOf": [
               {

--- a/frontend/src/api/authStore.ts
+++ b/frontend/src/api/authStore.ts
@@ -49,7 +49,7 @@ export const useAuthStore = create<AuthState>((set) => ({
         email: authData.email,
         fullName: authData.full_name,
         role: authData.role,
-        driverId: authData.driver_id,
+        driverId: authData.driver_id ?? null,
       },
       isAuthenticated: true,
       isRestoringSession: false,

--- a/frontend/src/api/authStore.ts
+++ b/frontend/src/api/authStore.ts
@@ -12,6 +12,7 @@ interface AuthState {
     fullName: string;
     role: string;
     driverId: string | null; // Populated if they are a driver
+    adminId: string | null; // Populated if they are an admin
   } | null;
   isAuthenticated: boolean;
   isRestoringSession: boolean;
@@ -50,6 +51,7 @@ export const useAuthStore = create<AuthState>((set) => ({
         fullName: authData.full_name,
         role: authData.role,
         driverId: authData.driver_id ?? null,
+        adminId: authData.admin_id ?? null,
       },
       isAuthenticated: true,
       isRestoringSession: false,
@@ -70,6 +72,7 @@ export const useAuthStore = create<AuthState>((set) => ({
         fullName: registerData.auth.full_name,
         role: registerData.driver.role,
         driverId: registerData.driver.driver_id,
+        adminId: registerData.auth.admin_id ?? null,
       },
       isAuthenticated: true,
       isRestoringSession: false,

--- a/frontend/src/api/authStore.ts
+++ b/frontend/src/api/authStore.ts
@@ -11,7 +11,7 @@ interface AuthState {
     email: string;
     fullName: string;
     role: string;
-    driverId?: string; // Populated if they are a driver
+    driverId: string | null; // Populated if they are a driver
   } | null;
   isAuthenticated: boolean;
   isRestoringSession: boolean;
@@ -49,6 +49,7 @@ export const useAuthStore = create<AuthState>((set) => ({
         email: authData.email,
         fullName: authData.full_name,
         role: authData.role,
+        driverId: authData.driver_id,
       },
       isAuthenticated: true,
       isRestoringSession: false,

--- a/frontend/src/api/generated/types.gen.ts
+++ b/frontend/src/api/generated/types.gen.ts
@@ -155,6 +155,10 @@ export type AuthResponse = {
    */
   access_token: string;
   /**
+   * Driver Id
+   */
+  driver_id?: string | null;
+  /**
    * Email
    */
   email: string;
@@ -2322,6 +2326,10 @@ export type AuthResponseWritable = {
    * Access Token
    */
   access_token: string;
+  /**
+   * Driver Id
+   */
+  driver_id?: string | null;
   /**
    * Email
    */

--- a/frontend/src/api/generated/types.gen.ts
+++ b/frontend/src/api/generated/types.gen.ts
@@ -155,6 +155,10 @@ export type AuthResponse = {
    */
   access_token: string;
   /**
+   * Admin Id
+   */
+  admin_id?: string | null;
+  /**
    * Driver Id
    */
   driver_id?: string | null;
@@ -2326,6 +2330,10 @@ export type AuthResponseWritable = {
    * Access Token
    */
   access_token: string;
+  /**
+   * Admin Id
+   */
+  admin_id?: string | null;
   /**
    * Driver Id
    */


### PR DESCRIPTION
## Implementation Description
<!-- Quick summary of what you built and why. Include design justifications if needed -->
* Update /login and /refresh to pass driver_id so that authStore can save it
* Other endpoints need this since they require driver_id in their request body and currently frontend can only access this either via another backend call to get the driver id, or if the driver had just signed up

## Steps to Test
<!-- What should the reviewer do to verify your changes? Include expected results -->
1. Just login and check the network tab to see if driver id was passed or not

## What Should Reviewers Focus On?
<!-- Call out substantial changes or anything you want a second opinion on -->
*

## Checklist
- [ ] PR name and commits are descriptive, imperative, and atomic (trivial commits squashed)
- [ ] I have requested a review from Claude, understood its suggestions, and implemented fixes where needed (or documented disagreements)
- [ ] I have requested a review from the PL and relevant devs with background on this PR