### PR TITLE
Apply the import from Continue instead of a confirm modal

### DIFF
--- a/frontend/src/pages/admin/routes/generation/ReviewStep.tsx
+++ b/frontend/src/pages/admin/routes/generation/ReviewStep.tsx
@@ -9,17 +9,7 @@ import {
 import { useApplyLocationImport } from '@/api';
 import type { ChangedEntry, StaleEntry } from '@/api/generated/types.gen';
 import type { Column } from '@/common/components';
-import {
-  Banner,
-  Button,
-  DataTable,
-  Modal,
-  ModalContent,
-  ModalDescription,
-  ModalFooter,
-  ModalHeader,
-  ModalTitle,
-} from '@/common/components';
+import { Banner, Button, DataTable } from '@/common/components';
 import { cn } from '@/lib/utils';
 
 import { EmptyState } from '../components';
@@ -118,7 +108,6 @@ export function ReviewStep() {
   const [reviewedRemoved, setReviewedRemoved] = useState<Set<string>>(
     new Set()
   );
-  const [confirmOpen, setConfirmOpen] = useState(false);
   const [ingestError, setIngestError] = useState<string | null>(null);
 
   if (!file || !reviewResult || !selectedDeliveryType) {
@@ -156,7 +145,9 @@ export function ReviewStep() {
     reviewedChanged.size === changedEntries.length &&
     reviewedRemoved.size === staleRows.length;
 
-  const handleConfirm = async () => {
+  // Checking every row off *is* the confirmation, so Continue applies the
+  // import directly rather than asking again in a modal.
+  const handleContinue = async () => {
     setIngestError(null);
     try {
       // The same file and mapping the preview ran on: the backend replans it
@@ -167,13 +158,8 @@ export function ReviewStep() {
         columnMap,
         deliveryType: selectedDeliveryType,
       });
-      setConfirmOpen(false);
       navigate('/admin/routes/generation/configure');
     } catch {
-      // Close first: Radix marks the rest of the page aria-hidden and locks
-      // body scroll while the modal is open, so a banner set behind it is
-      // unreachable both visually and to screen readers.
-      setConfirmOpen(false);
       setIngestError('Could not apply the import changes — please try again.');
     }
   };
@@ -379,36 +365,12 @@ export function ReviewStep() {
         </Button>
         <Button
           variant="primary"
-          disabled={!allReviewed}
-          onClick={() => setConfirmOpen(true)}
+          disabled={!allReviewed || isIngesting}
+          onClick={handleContinue}
         >
-          Continue to edit route groups
+          {isIngesting ? 'Applying…' : 'Continue to edit route groups'}
         </Button>
       </GenerationFooter>
-
-      <Modal open={confirmOpen} onOpenChange={setConfirmOpen}>
-        <ModalContent>
-          <ModalHeader>
-            <ModalTitle variant="confirmation">Confirm Changes</ModalTitle>
-            <ModalDescription>
-              Some data has been updated, added, or removed. Are you sure you
-              want to apply these changes?
-            </ModalDescription>
-          </ModalHeader>
-          <ModalFooter>
-            <Button variant="secondary" onClick={() => setConfirmOpen(false)}>
-              Cancel
-            </Button>
-            <Button
-              variant="primary"
-              disabled={isIngesting}
-              onClick={handleConfirm}
-            >
-              {isIngesting ? 'Applying…' : 'Apply changes'}
-            </Button>
-          </ModalFooter>
-        </ModalContent>
-      </Modal>
     </>
   );
 }


### PR DESCRIPTION
The review step ends with a "Confirm Changes" modal — *"Are you sure you want to apply these changes?"* — after the admin has already checked off every changed row and every removed row. The checkboxes are the confirmation; the modal asks for the same affirmation a second time.

So `Continue to edit route groups` now applies the import directly:

- Removed the modal, its `confirmOpen` state, and the `Modal*` imports.
- `handleConfirm` → `handleContinue`, wired to the footer button.
- The button carries the pending state the modal's button used to: `disabled={!allReviewed || isIngesting}`, label swaps to "Applying…" — the same shape as the import step's Continue at `ImportStep.tsx:315`.
- Dropped the comment about closing the modal before setting the error banner (it existed because Radix marks the page `aria-hidden` while the modal is open — with no modal, the banner just renders).

Net −38 lines. `Modal` and `ModalTitle variant="confirmation"` stay in use by the delete modals and the announcements board, so nothing is orphaned.

## Verification

`tsc -b` exit 0, `eslint src` clean, prettier clean. No test referenced the dialog.

The Figma frames still show the Confirm Changes modal, so the design and the code now disagree — writing to Figma needs the plugin channel from Colin, so that's a separate step, not something this PR can do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)