### PR TITLE
Seed note attachments with real images

### DIFF
--- a/backend/python/app/seed_database.py
+++ b/backend/python/app/seed_database.py
@@ -5,6 +5,7 @@ Comprehensive database seeding script with advanced features.
 
 import argparse
 import csv
+import logging
 import os
 import random
 import uuid
@@ -24,6 +25,7 @@ from sqlalchemy import create_engine, text
 from sqlmodel import Session, select
 
 from app import initialize_firebase
+from app.config import settings
 from app.models.admin import Admin
 from app.models.announcement import Announcement
 from app.models.announcement_last_read import AnnouncementLastRead
@@ -48,6 +50,8 @@ from app.models.system_settings import (
 # Import all models to register them with SQLModel
 from app.models.user import User
 from app.utilities.datetime_utils import from_local_wall_clock, now_utc
+from app.utilities.gcp_client import GCPStorageClient
+from app.utilities.seed_images import render_seed_image
 
 # Initialize Faker
 fake = faker.Faker()
@@ -82,6 +86,24 @@ MAX_LOCATION_CHAIN_NOTES = 3
 MAX_ROUTE_CHAIN_NOTES = 2
 # Max notes per driver chain
 MAX_DRIVER_CHAIN_NOTES = 3
+# Probability that a location note carries image attachments. Only location
+# notes get them: that chain is what the driver's route page renders, so it is
+# the only place a thumbnail is ever seen.
+PROBABILITY_LOCATION_NOTE_IMAGES = 0.35
+# Max images per note. Matches the frontend's own cap (NOTE_IMAGE_MAX) and the
+# NoteCreate limit, so the seed can't produce a note the API would reject.
+MAX_NOTE_IMAGES = 3
+# Number of distinct placeholder images uploaded once and shared across notes.
+# Re-using a small pool keeps seeding to a handful of uploads instead of one
+# per note, and the bucket to a fixed, known set of objects.
+SEED_NOTE_IMAGE_COUNT = 6
+# Stable key prefix for those objects, so a re-seed overwrites the previous
+# run's images rather than orphaning them.
+SEED_NOTE_IMAGE_PREFIX = "seed/note-images"
+# Signed URL lifetime for seeded images. Note reads re-sign from the stored
+# filename, so this only has to outlive the seed run itself; a week is the
+# ceiling GCS V4 signing allows and costs nothing to ask for.
+SEED_NOTE_IMAGE_URL_HOURS = 24 * 7
 # Assignment ratio constants
 # Ratio of past routes that should be assigned to drivers (1.0 = 100%)
 ASSIGNMENT_RATIO_PAST_ROUTES = 1.0
@@ -246,6 +268,47 @@ def set_timestamps(instance: BaseModel) -> None:
     """Set updated_at to match created_at for seed data"""
     if instance.created_at is not None and instance.updated_at is None:
         instance.updated_at = instance.created_at
+
+
+def upload_seed_note_images() -> list[dict[str, str]]:
+    """Upload the shared placeholder images and return them as attachments.
+
+    Writes to fixed keys under ``SEED_NOTE_IMAGE_PREFIX``, so running the seed
+    twice replaces the same objects instead of leaving the previous run's
+    behind. Returns plain dicts because that is what the attachments column
+    stores.
+
+    Like the Firebase helpers above, this talks to a real external service and
+    is patched out in tests rather than faked here.
+    """
+    client = GCPStorageClient(logging.getLogger(__name__), settings.gcp_bucket_name)
+
+    attachments: list[dict[str, str]] = []
+    for index in range(SEED_NOTE_IMAGE_COUNT):
+        filename, contents = render_seed_image(index)
+        result = client.upload_file(
+            contents,
+            filename,
+            "image/png",
+            expiration_hours=SEED_NOTE_IMAGE_URL_HOURS,
+            key=f"{SEED_NOTE_IMAGE_PREFIX}/{index:02d}-{filename}",
+        )
+        attachments.append({"filename": result.filename, "url": result.url})
+
+    return attachments
+
+
+def pick_note_attachments(pool: list[dict[str, str]]) -> list[dict[str, str]]:
+    """Choose the attachments for one note: usually none, sometimes up to three.
+
+    Returns copies so two notes sharing an image can never alias the same dict
+    into two JSON columns.
+    """
+    if not pool or random.random() >= PROBABILITY_LOCATION_NOTE_IMAGES:
+        return []
+
+    count = random.randint(1, min(MAX_NOTE_IMAGES, len(pool)))
+    return [dict(attachment) for attachment in random.sample(pool, count)]
 
 
 def ensure_firebase_user(
@@ -1199,8 +1262,13 @@ def main(*, reset_passwords: bool = False) -> None:
 
             # Create note chains for locations
             print("Creating note chains for locations...")
+            print("Uploading placeholder note images...")
+            note_image_pool = upload_seed_note_images()
+            print(f"Uploaded {len(note_image_pool)} placeholder note images")
+
             location_chains_created = 0
             location_notes_created = 0
+            location_notes_with_images = 0
             all_locations = list(session.exec(select(Location)).all())
             location_author_ids = admin_author_ids + driver_author_ids
 
@@ -1225,20 +1293,25 @@ def main(*, reset_passwords: bool = False) -> None:
                             random.choice(location_author_ids) for _ in range(num_notes)
                         ]
                     for author_id in note_authors:
+                        attachments = pick_note_attachments(note_image_pool)
                         note = Note(
                             note_chain_id=note_chain.note_chain_id,
                             user_id=author_id,
                             message=fake.sentence(),
                             is_system=False,
+                            attachments=attachments,
                         )
                         set_timestamps(note)
                         session.add(note)
                         location_notes_created += 1
+                        if attachments:
+                            location_notes_with_images += 1
 
             session.commit()
             print(
                 f"Created {location_chains_created} location note chains "
-                f"with {location_notes_created} notes"
+                f"with {location_notes_created} notes "
+                f"({location_notes_with_images} carrying images)"
             )
 
             # Create note chains for routes (only a sample, since the per-day

--- a/backend/python/app/seed_database.py
+++ b/backend/python/app/seed_database.py
@@ -280,7 +280,16 @@ def upload_seed_note_images() -> list[dict[str, str]]:
 
     Like the Firebase helpers above, this talks to a real external service and
     is patched out in tests rather than faked here.
+
+    Returns no attachments when GCS isn't configured — the boot smoke job seeds
+    with no GCP credentials at all, and placeholder note images aren't what it
+    is testing. A failure with credentials *present* is a real error and is left
+    to propagate.
     """
+    if not (settings.gcp_bucket_name and settings.gcp_service_account_private_key):
+        print("  GCS is not configured — seeding notes without images")
+        return []
+
     client = GCPStorageClient(logging.getLogger(__name__), settings.gcp_bucket_name)
 
     attachments: list[dict[str, str]] = []
@@ -1264,7 +1273,8 @@ def main(*, reset_passwords: bool = False) -> None:
             print("Creating note chains for locations...")
             print("Uploading placeholder note images...")
             note_image_pool = upload_seed_note_images()
-            print(f"Uploaded {len(note_image_pool)} placeholder note images")
+            if note_image_pool:
+                print(f"Uploaded {len(note_image_pool)} placeholder note images")
 
             location_chains_created = 0
             location_notes_created = 0

--- a/backend/python/app/utilities/gcp_client.py
+++ b/backend/python/app/utilities/gcp_client.py
@@ -53,14 +53,25 @@ class GCPStorageClient:
         filename: str,
         content_type: str,
         expiration_hours: int = 1,
+        key: str | None = None,
     ) -> UploadResult:
-        """Upload a file to GCS and return a signed URL"""
-        key = f"{uuid.uuid4()}-{filename}"
-        blob = self.bucket.blob(key)
+        """Upload a file to GCS and return a signed URL
+
+        :param key: Object key to write, instead of the default
+            ``<uuid>-<filename>``. User uploads must keep the default so two
+            people uploading ``photo.jpg`` don't collide. A caller that owns
+            its whole keyspace and wants writes to be repeatable — the seed
+            script, which would otherwise orphan a fresh copy of every image
+            on each run — passes one explicitly.
+        """
+        object_key = key if key is not None else f"{uuid.uuid4()}-{filename}"
+        blob = self.bucket.blob(object_key)
         try:
             blob.upload_from_string(contents, content_type=content_type)
 
-            url = self.generate_signed_url(key, expiration_hours=expiration_hours)
+            url = self.generate_signed_url(
+                object_key, expiration_hours=expiration_hours
+            )
         except gcp_exceptions.Forbidden as e:
             raise GCSStorageError("Storage upload failed: permission denied.") from e
         except gcp_exceptions.NotFound as e:
@@ -74,7 +85,7 @@ class GCPStorageClient:
             ) from e
 
         return UploadResult(
-            filename=key,
+            filename=object_key,
             url=url,
             content_type=content_type,
             size_bytes=len(contents),

--- a/backend/python/app/utilities/seed_images.py
+++ b/backend/python/app/utilities/seed_images.py
@@ -1,0 +1,100 @@
+"""Generate placeholder note attachment images for the seed script.
+
+Seeded notes need real bytes in the bucket, not fabricated URLs: reads re-sign
+from the stored ``filename``, and signing is an offline operation, so a made-up
+key yields a perfectly valid URL that 404s the moment a thumbnail renders. The
+images therefore have to exist.
+
+They are drawn here rather than committed as fixtures so the repo carries no
+binaries and no photo licensing question, and rather than fetched at seed time
+so seeding needs no network beyond the bucket itself. Each is a flat-coloured
+tile with a simple silhouette, which is enough to tell three thumbnails apart
+in a note card and to show one is not square.
+"""
+
+import struct
+import zlib
+
+# Distinct hues so a note's three thumbnails are visibly different from each
+# other, and from any real photo, at the 64px the note card renders them at.
+SEED_IMAGE_PALETTE: list[tuple[str, tuple[int, int, int], tuple[int, int, int]]] = [
+    ("front-door", (214, 222, 233), (61, 90, 128)),
+    ("porch", (233, 226, 214), (147, 108, 71)),
+    ("package", (222, 233, 216), (78, 122, 63)),
+    ("gate", (233, 214, 222), (140, 61, 90)),
+    ("driveway", (219, 219, 224), (86, 86, 110)),
+    ("side-entrance", (233, 231, 210), (150, 140, 55)),
+]
+
+# Deliberately not square: the design lays thumbnails out in a fixed 64px box,
+# so a non-square source is what proves the object-fit crop is right.
+SEED_IMAGE_WIDTH = 160
+SEED_IMAGE_HEIGHT = 120
+
+
+def _png_chunk(tag: bytes, payload: bytes) -> bytes:
+    """Serialize one PNG chunk: length, tag, payload, CRC over tag+payload."""
+    return (
+        struct.pack(">I", len(payload))
+        + tag
+        + payload
+        + struct.pack(">I", zlib.crc32(tag + payload) & 0xFFFFFFFF)
+    )
+
+
+def encode_png(rows: list[list[tuple[int, int, int]]]) -> bytes:
+    """Encode RGB pixel rows as an 8-bit truecolour PNG.
+
+    Each scanline is prefixed with filter type 0 (None), which is what the
+    format requires even when no filtering is applied.
+    """
+    if not rows or not rows[0]:
+        raise ValueError("Cannot encode a PNG with no pixels.")
+
+    width = len(rows[0])
+    if any(len(row) != width for row in rows):
+        raise ValueError("Every PNG row must have the same width.")
+
+    raw = bytearray()
+    for row in rows:
+        raw.append(0)
+        for red, green, blue in row:
+            raw.extend((red, green, blue))
+
+    header = struct.pack(">IIBBBBB", width, len(rows), 8, 2, 0, 0, 0)
+    return (
+        b"\x89PNG\r\n\x1a\n"
+        + _png_chunk(b"IHDR", header)
+        + _png_chunk(b"IDAT", zlib.compress(bytes(raw), 9))
+        + _png_chunk(b"IEND", b"")
+    )
+
+
+def render_seed_image(index: int) -> tuple[str, bytes]:
+    """Build the ``index``-th placeholder image, wrapping around the palette.
+
+    Deterministic: the same index always yields identical bytes, so re-seeding
+    overwrites each object with the same content instead of accumulating new
+    ones.
+    """
+    if index < 0:
+        raise ValueError(f"Seed image index must be non-negative, got {index}.")
+
+    name, background, foreground = SEED_IMAGE_PALETTE[index % len(SEED_IMAGE_PALETTE)]
+
+    # A centred rounded-ish block reads as a door/parcel silhouette at
+    # thumbnail size, and off-centre proves the crop is not mirroring.
+    left = SEED_IMAGE_WIDTH // 3
+    right = SEED_IMAGE_WIDTH - SEED_IMAGE_WIDTH // 4
+    top = SEED_IMAGE_HEIGHT // 4
+    bottom = SEED_IMAGE_HEIGHT - SEED_IMAGE_HEIGHT // 8
+
+    rows: list[list[tuple[int, int, int]]] = []
+    for y in range(SEED_IMAGE_HEIGHT):
+        row: list[tuple[int, int, int]] = []
+        for x in range(SEED_IMAGE_WIDTH):
+            inside = left <= x < right and top <= y < bottom
+            row.append(foreground if inside else background)
+        rows.append(row)
+
+    return f"{name}.png", encode_png(rows)

--- a/backend/python/tests/test_seed_database.py
+++ b/backend/python/tests/test_seed_database.py
@@ -34,6 +34,7 @@ from app.models.driver import Driver
 from app.models.job import Job
 from app.models.location import Location
 from app.models.location_group import LocationGroup
+from app.models.note import Note
 from app.models.route import Route
 from app.models.route_group import RouteGroup
 from app.models.route_stop import RouteStop
@@ -44,11 +45,23 @@ EMAIL_PATTERN = re.compile(r"^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$")
 
 TEST_CSV_PATH = os.path.join(os.path.dirname(__file__), "data", "test_locations.csv")
 
+# Stands in for the real upload: same shape (stored object key + signed URL),
+# no bucket required.
+FAKE_NOTE_IMAGES: list[dict[str, str]] = [
+    {
+        "filename": f"seed/note-images/{index:02d}-placeholder.png",
+        "url": f"https://storage.example/signed/{index}",
+    }
+    for index in range(seed_module.SEED_NOTE_IMAGE_COUNT)
+]
+
 
 def _run_seed_script() -> None:
     """Run the synchronous seed script against the test database.
 
-    Firebase calls are mocked so tests don't need real credentials.
+    Firebase and GCS calls are mocked so tests don't need real credentials.
+    The image upload is patched to return the same attachment shape a real
+    upload would, so the notes still exercise the JSON attachments column.
     ``LOCATIONS_CSV_PATH`` is read at runtime inside ``main()``, so an env
     patch is fine for it.
     """
@@ -69,6 +82,10 @@ def _run_seed_script() -> None:
         patch.dict(os.environ, {"LOCATIONS_CSV_PATH": TEST_CSV_PATH}),
         patch("app.seed_database.initialize_firebase"),
         patch("app.seed_database.ensure_firebase_user"),
+        patch(
+            "app.seed_database.upload_seed_note_images",
+            return_value=FAKE_NOTE_IMAGES,
+        ),
     ):
         seed_module.main()
 
@@ -382,3 +399,104 @@ class TestAnnouncements:
     async def _role_by_user_id(session: AsyncSession) -> dict[Any, str]:
         users = (await session.execute(select(User))).scalars().all()
         return {user.user_id: user.role for user in users}
+
+
+@pytest.mark.slow
+class TestNoteAttachments:
+    """Some seeded location notes carry image attachments.
+
+    Location notes are the ones the driver's route page renders, so they are
+    the only place a thumbnail is ever seen — and before this, every seeded
+    note was text-only, leaving the attachment layout untested against data.
+    """
+
+    @staticmethod
+    async def _location_notes(session: AsyncSession) -> "Sequence[Note]":
+        chain_ids = (
+            (
+                await session.execute(
+                    select(Location.note_chain_id).where(
+                        Location.note_chain_id.is_not(None)  # type: ignore[union-attr]
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        return (
+            (
+                await session.execute(
+                    select(Note).where(Note.note_chain_id.in_(chain_ids))  # type: ignore[attr-defined]
+                )
+            )
+            .scalars()
+            .all()
+        )
+
+    @pytest.mark.asyncio
+    async def test_some_location_notes_have_attachments(
+        self, test_session: AsyncSession
+    ) -> None:
+        notes = await self._location_notes(test_session)
+        with_images = [note for note in notes if note.attachments]
+        assert with_images, (
+            "Expected at least one seeded location note to carry images; "
+            "the thumbnail layout has no data to render without them"
+        )
+
+    @pytest.mark.asyncio
+    async def test_not_every_note_has_attachments(
+        self, test_session: AsyncSession
+    ) -> None:
+        # Text-only notes are the common case in production, so the seed has to
+        # produce both shapes.
+        notes = await self._location_notes(test_session)
+        assert any(not note.attachments for note in notes), (
+            "Expected some seeded location notes to remain text-only"
+        )
+
+    @pytest.mark.asyncio
+    async def test_attachments_respect_the_frontend_cap(
+        self, test_session: AsyncSession
+    ) -> None:
+        for note in await self._location_notes(test_session):
+            assert len(note.attachments or []) <= seed_module.MAX_NOTE_IMAGES
+
+    @pytest.mark.asyncio
+    async def test_attachments_round_trip_through_the_json_column(
+        self, test_session: AsyncSession
+    ) -> None:
+        # Reading back from Postgres is the real assertion here: attachments are
+        # a JSON column, so a non-serializable value would only fail on write.
+        for note in await self._location_notes(test_session):
+            for attachment in note.attachments or []:
+                assert attachment.filename and attachment.url
+
+    @pytest.mark.asyncio
+    async def test_attachments_come_from_the_uploaded_pool(
+        self, test_session: AsyncSession
+    ) -> None:
+        known = {image["filename"] for image in FAKE_NOTE_IMAGES}
+        for note in await self._location_notes(test_session):
+            for attachment in note.attachments or []:
+                assert attachment.filename in known
+
+    @pytest.mark.asyncio
+    async def test_no_note_repeats_an_image(self, test_session: AsyncSession) -> None:
+        for note in await self._location_notes(test_session):
+            filenames = [attachment.filename for attachment in note.attachments or []]
+            assert len(set(filenames)) == len(filenames)
+
+    @pytest.mark.asyncio
+    async def test_route_and_driver_notes_stay_text_only(
+        self, test_session: AsyncSession
+    ) -> None:
+        # Only the location chain surfaces on a screen that renders thumbnails;
+        # attaching images elsewhere would be seed data nothing can display.
+        location_note_ids = {
+            note.note_id for note in await self._location_notes(test_session)
+        }
+        all_notes = (await test_session.execute(select(Note))).scalars().all()
+        for note in all_notes:
+            if note.note_id not in location_note_ids:
+                assert not note.attachments

--- a/backend/python/tests/test_seed_images.py
+++ b/backend/python/tests/test_seed_images.py
@@ -1,0 +1,146 @@
+"""Tests for the placeholder note images used by the seed script.
+
+The point of these images is that they are *real* decodable bytes sitting in
+the bucket — a note whose thumbnail 404s is exactly the state seeding is meant
+to fix — so these tests decode what we generate rather than trusting the
+encoder.
+"""
+
+import struct
+import zlib
+
+import pytest
+
+from app.utilities.seed_images import (
+    SEED_IMAGE_HEIGHT,
+    SEED_IMAGE_PALETTE,
+    SEED_IMAGE_WIDTH,
+    encode_png,
+    render_seed_image,
+)
+
+PNG_SIGNATURE = b"\x89PNG\r\n\x1a\n"
+
+
+def iter_chunks(png: bytes) -> list[tuple[bytes, bytes]]:
+    """Walk a PNG's chunk stream, verifying each chunk's declared CRC."""
+    assert png.startswith(PNG_SIGNATURE)
+
+    chunks: list[tuple[bytes, bytes]] = []
+    offset = len(PNG_SIGNATURE)
+    while offset < len(png):
+        (length,) = struct.unpack(">I", png[offset : offset + 4])
+        tag = png[offset + 4 : offset + 8]
+        payload = png[offset + 8 : offset + 8 + length]
+        (declared_crc,) = struct.unpack(
+            ">I", png[offset + 8 + length : offset + 12 + length]
+        )
+        assert declared_crc == zlib.crc32(tag + payload) & 0xFFFFFFFF, (
+            f"CRC mismatch on {tag!r} chunk"
+        )
+        chunks.append((tag, payload))
+        offset += 12 + length
+
+    return chunks
+
+
+def decode_pixels(png: bytes) -> list[list[tuple[int, int, int]]]:
+    """Decode an unfiltered 8-bit truecolour PNG back to RGB rows."""
+    chunks = dict(iter_chunks(png))
+    width, height, depth, colour_type = struct.unpack(">IIBB", chunks[b"IHDR"][:10])
+    assert (depth, colour_type) == (8, 2), "expected 8-bit truecolour"
+
+    raw = zlib.decompress(chunks[b"IDAT"])
+    stride = width * 3 + 1
+
+    rows: list[list[tuple[int, int, int]]] = []
+    for y in range(height):
+        line = raw[y * stride : (y + 1) * stride]
+        assert line[0] == 0, "every scanline must use filter type 0 (None)"
+        pixels = line[1:]
+        rows.append(
+            [
+                (pixels[x * 3], pixels[x * 3 + 1], pixels[x * 3 + 2])
+                for x in range(width)
+            ]
+        )
+
+    return rows
+
+
+class TestEncodePng:
+    def test_round_trips_pixels_exactly(self) -> None:
+        original = [
+            [(255, 0, 0), (0, 255, 0)],
+            [(0, 0, 255), (16, 32, 48)],
+        ]
+        assert decode_pixels(encode_png(original)) == original
+
+    def test_emits_signature_and_required_chunks_in_order(self) -> None:
+        tags = [tag for tag, _ in iter_chunks(encode_png([[(1, 2, 3)]]))]
+        assert tags == [b"IHDR", b"IDAT", b"IEND"]
+
+    def test_header_records_dimensions(self) -> None:
+        png = encode_png([[(0, 0, 0)] * 5 for _ in range(3)])
+        chunks = dict(iter_chunks(png))
+        width, height = struct.unpack(">II", chunks[b"IHDR"][:8])
+        assert (width, height) == (5, 3)
+
+    def test_single_pixel_is_valid(self) -> None:
+        assert decode_pixels(encode_png([[(9, 9, 9)]])) == [[(9, 9, 9)]]
+
+    @pytest.mark.parametrize("rows", [[], [[]]])
+    def test_rejects_empty_image(self, rows: list[list[tuple[int, int, int]]]) -> None:
+        with pytest.raises(ValueError, match="no pixels"):
+            encode_png(rows)
+
+    def test_rejects_ragged_rows(self) -> None:
+        with pytest.raises(ValueError, match="same width"):
+            encode_png([[(0, 0, 0), (1, 1, 1)], [(2, 2, 2)]])
+
+
+class TestRenderSeedImage:
+    def test_decodes_at_the_declared_size(self) -> None:
+        _, contents = render_seed_image(0)
+        rows = decode_pixels(contents)
+        assert len(rows) == SEED_IMAGE_HEIGHT
+        assert all(len(row) == SEED_IMAGE_WIDTH for row in rows)
+
+    def test_is_not_square_so_the_thumbnail_crop_is_exercised(self) -> None:
+        assert SEED_IMAGE_WIDTH != SEED_IMAGE_HEIGHT
+
+    def test_is_deterministic_so_reseeding_overwrites_identical_bytes(self) -> None:
+        assert render_seed_image(3) == render_seed_image(3)
+
+    def test_uses_both_palette_colours(self) -> None:
+        _, background, foreground = SEED_IMAGE_PALETTE[0]
+        present = {
+            pixel for row in decode_pixels(render_seed_image(0)[1]) for pixel in row
+        }
+        assert present == {background, foreground}, (
+            "a flat image would not show the crop; expected a foreground shape"
+        )
+
+    def test_consecutive_images_are_visually_distinct(self) -> None:
+        first, second = render_seed_image(0)[1], render_seed_image(1)[1]
+        assert first != second
+
+    def test_wraps_around_the_palette(self) -> None:
+        size = len(SEED_IMAGE_PALETTE)
+        assert render_seed_image(0) == render_seed_image(size)
+        assert render_seed_image(1) == render_seed_image(size + 1)
+
+    @pytest.mark.parametrize("index", range(len(SEED_IMAGE_PALETTE)))
+    def test_every_palette_entry_renders(self, index: int) -> None:
+        filename, contents = render_seed_image(index)
+        assert filename.endswith(".png")
+        assert filename == f"{SEED_IMAGE_PALETTE[index][0]}.png"
+        assert decode_pixels(contents)
+
+    def test_filenames_are_unique_across_the_palette(self) -> None:
+        names = [render_seed_image(i)[0] for i in range(len(SEED_IMAGE_PALETTE))]
+        assert len(set(names)) == len(names)
+
+    def test_rejects_a_negative_index(self) -> None:
+        with pytest.raises(ValueError, match="non-negative"):
+            render_seed_image(-1)

--- a/backend/python/tests/test_seed_note_attachments.py
+++ b/backend/python/tests/test_seed_note_attachments.py
@@ -1,0 +1,227 @@
+"""Tests for how the seed script attaches images to notes.
+
+These cover the pure selection logic and the stable-key upload contract, so
+they need neither a database nor a bucket. The end-to-end assertion that
+seeded notes actually carry attachments lives in ``test_seed_database.py``.
+"""
+
+import logging
+import random
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import app.seed_database as seed_module
+from app.utilities.gcp_client import GCPStorageClient
+
+
+@pytest.fixture
+def pool() -> list[dict[str, str]]:
+    return [
+        {"filename": f"seed/note-images/{i:02d}-image.png", "url": f"https://x/{i}"}
+        for i in range(seed_module.SEED_NOTE_IMAGE_COUNT)
+    ]
+
+
+class TestPickNoteAttachments:
+    def test_returns_nothing_when_the_pool_is_empty(self) -> None:
+        with patch.object(seed_module.random, "random", return_value=0.0):
+            assert seed_module.pick_note_attachments([]) == []
+
+    def test_returns_nothing_when_the_roll_misses(
+        self, pool: list[dict[str, str]]
+    ) -> None:
+        with patch.object(seed_module.random, "random", return_value=1.0):
+            assert seed_module.pick_note_attachments(pool) == []
+
+    def test_boundary_roll_is_exclusive(self, pool: list[dict[str, str]]) -> None:
+        """A roll exactly at the threshold must not attach; ``random()`` is [0, 1)."""
+        threshold = seed_module.PROBABILITY_LOCATION_NOTE_IMAGES
+        with patch.object(seed_module.random, "random", return_value=threshold):
+            assert seed_module.pick_note_attachments(pool) == []
+
+    def test_attaches_when_the_roll_hits(self, pool: list[dict[str, str]]) -> None:
+        with patch.object(seed_module.random, "random", return_value=0.0):
+            assert seed_module.pick_note_attachments(pool)
+
+    def test_never_exceeds_the_frontend_cap(self, pool: list[dict[str, str]]) -> None:
+        random.seed(20260812)
+        for _ in range(500):
+            chosen = seed_module.pick_note_attachments(pool)
+            assert len(chosen) <= seed_module.MAX_NOTE_IMAGES
+
+    def test_never_repeats_an_image_within_one_note(
+        self, pool: list[dict[str, str]]
+    ) -> None:
+        random.seed(20260812)
+        for _ in range(500):
+            chosen = seed_module.pick_note_attachments(pool)
+            filenames = [item["filename"] for item in chosen]
+            assert len(set(filenames)) == len(filenames)
+
+    def test_handles_a_pool_smaller_than_the_cap(self) -> None:
+        small = [{"filename": "a.png", "url": "https://x/a"}]
+        with patch.object(seed_module.random, "random", return_value=0.0):
+            assert seed_module.pick_note_attachments(small) == small
+
+    def test_returns_copies_so_notes_cannot_alias_one_dict(
+        self, pool: list[dict[str, str]]
+    ) -> None:
+        with patch.object(seed_module.random, "random", return_value=0.0):
+            chosen = seed_module.pick_note_attachments(pool)
+        chosen[0]["url"] = "mutated"
+        assert all(item["url"] != "mutated" for item in pool)
+
+    def test_every_attachment_carries_filename_and_url(
+        self, pool: list[dict[str, str]]
+    ) -> None:
+        random.seed(7)
+        for _ in range(100):
+            for item in seed_module.pick_note_attachments(pool):
+                assert set(item) == {"filename", "url"}
+                assert item["filename"] and item["url"]
+
+    def test_roughly_matches_the_configured_probability(
+        self, pool: list[dict[str, str]]
+    ) -> None:
+        random.seed(20260812)
+        trials = 4000
+        hits = sum(1 for _ in range(trials) if seed_module.pick_note_attachments(pool))
+        expected = seed_module.PROBABILITY_LOCATION_NOTE_IMAGES
+        assert abs(hits / trials - expected) < 0.05
+
+
+class TestUploadSeedNoteImages:
+    def _client(self) -> tuple[MagicMock, list[dict[str, Any]]]:
+        calls: list[dict[str, Any]] = []
+
+        def upload_file(
+            contents: bytes,
+            filename: str,
+            content_type: str,
+            expiration_hours: int = 1,
+            key: str | None = None,
+        ) -> Any:
+            calls.append(
+                {
+                    "contents": contents,
+                    "filename": filename,
+                    "content_type": content_type,
+                    "expiration_hours": expiration_hours,
+                    "key": key,
+                }
+            )
+            return MagicMock(filename=key, url=f"https://signed/{key}")
+
+        client = MagicMock()
+        client.upload_file.side_effect = upload_file
+        return client, calls
+
+    def test_uploads_one_object_per_configured_image(self) -> None:
+        client, calls = self._client()
+        with patch.object(seed_module, "GCPStorageClient", return_value=client):
+            attachments = seed_module.upload_seed_note_images()
+
+        assert len(calls) == seed_module.SEED_NOTE_IMAGE_COUNT
+        assert len(attachments) == seed_module.SEED_NOTE_IMAGE_COUNT
+
+    def test_uses_stable_prefixed_keys_so_reseeding_overwrites(self) -> None:
+        client, calls = self._client()
+        with patch.object(seed_module, "GCPStorageClient", return_value=client):
+            seed_module.upload_seed_note_images()
+
+        keys = [call["key"] for call in calls]
+        assert all(
+            key.startswith(f"{seed_module.SEED_NOTE_IMAGE_PREFIX}/") for key in keys
+        )
+        assert len(set(keys)) == len(keys), "keys must be unique within a run"
+
+        client2, calls2 = self._client()
+        with patch.object(seed_module, "GCPStorageClient", return_value=client2):
+            seed_module.upload_seed_note_images()
+        assert [call["key"] for call in calls2] == keys, (
+            "keys must be stable across runs"
+        )
+
+    def test_uploads_identical_bytes_across_runs(self) -> None:
+        client, calls = self._client()
+        with patch.object(seed_module, "GCPStorageClient", return_value=client):
+            seed_module.upload_seed_note_images()
+        client2, calls2 = self._client()
+        with patch.object(seed_module, "GCPStorageClient", return_value=client2):
+            seed_module.upload_seed_note_images()
+
+        assert [c["contents"] for c in calls] == [c["contents"] for c in calls2]
+
+    def test_uploads_real_png_bytes(self) -> None:
+        client, calls = self._client()
+        with patch.object(seed_module, "GCPStorageClient", return_value=client):
+            seed_module.upload_seed_note_images()
+
+        for call in calls:
+            assert call["contents"].startswith(b"\x89PNG\r\n\x1a\n")
+            assert call["content_type"] == "image/png"
+
+    def test_requests_a_long_lived_url(self) -> None:
+        client, calls = self._client()
+        with patch.object(seed_module, "GCPStorageClient", return_value=client):
+            seed_module.upload_seed_note_images()
+
+        for call in calls:
+            assert call["expiration_hours"] == seed_module.SEED_NOTE_IMAGE_URL_HOURS
+            # GCS V4 signing refuses anything beyond seven days.
+            assert call["expiration_hours"] <= 24 * 7
+
+    def test_returns_the_stored_key_not_the_local_filename(self) -> None:
+        client, _ = self._client()
+        with patch.object(seed_module, "GCPStorageClient", return_value=client):
+            attachments = seed_module.upload_seed_note_images()
+
+        for attachment in attachments:
+            assert attachment["filename"].startswith(
+                f"{seed_module.SEED_NOTE_IMAGE_PREFIX}/"
+            )
+            assert set(attachment) == {"filename", "url"}
+
+
+class TestUploadFileKeyOverride:
+    """``upload_file`` must keep collision-proof keys for real user uploads."""
+
+    def _client_with_stub_bucket(self) -> tuple[GCPStorageClient, MagicMock]:
+        client = GCPStorageClient.__new__(GCPStorageClient)
+        client.logger = logging.getLogger(__name__)
+        bucket = MagicMock()
+        bucket.blob.return_value.generate_signed_url.return_value = "https://signed"
+        client.bucket = bucket
+        return client, bucket
+
+    def test_defaults_to_a_uuid_prefixed_key(self) -> None:
+        client, bucket = self._client_with_stub_bucket()
+        result = client.upload_file(b"x", "photo.jpg", "image/jpeg")
+
+        used_key = bucket.blob.call_args[0][0]
+        assert used_key.endswith("-photo.jpg")
+        assert used_key != "photo.jpg"
+        assert result.filename == used_key
+
+    def test_two_uploads_of_one_filename_do_not_collide(self) -> None:
+        client, _bucket = self._client_with_stub_bucket()
+        first = client.upload_file(b"x", "photo.jpg", "image/jpeg")
+        second = client.upload_file(b"y", "photo.jpg", "image/jpeg")
+        assert first.filename != second.filename
+
+    def test_explicit_key_is_used_verbatim(self) -> None:
+        client, bucket = self._client_with_stub_bucket()
+        result = client.upload_file(
+            b"x", "photo.jpg", "image/jpeg", key="seed/note-images/00-front-door.png"
+        )
+
+        assert bucket.blob.call_args[0][0] == "seed/note-images/00-front-door.png"
+        assert result.filename == "seed/note-images/00-front-door.png"
+
+    def test_explicit_key_is_repeatable(self) -> None:
+        client, _ = self._client_with_stub_bucket()
+        first = client.upload_file(b"x", "a.png", "image/png", key="seed/fixed.png")
+        second = client.upload_file(b"y", "a.png", "image/png", key="seed/fixed.png")
+        assert first.filename == second.filename == "seed/fixed.png"

--- a/backend/python/tests/test_seed_note_attachments.py
+++ b/backend/python/tests/test_seed_note_attachments.py
@@ -93,6 +93,21 @@ class TestPickNoteAttachments:
 
 
 class TestUploadSeedNoteImages:
+    @pytest.fixture(autouse=True)
+    def configured_gcs(self) -> Any:
+        """Pretend GCS is configured.
+
+        Without this the tests would pass or skip depending on whether the
+        machine running them happens to have GCP credentials in its env — which
+        is exactly the difference between a laptop and CI.
+        """
+        with patch.multiple(
+            seed_module.settings,
+            gcp_bucket_name="test-bucket",
+            gcp_service_account_private_key="-----BEGIN PRIVATE KEY-----test",
+        ):
+            yield
+
     def _client(self) -> tuple[MagicMock, list[dict[str, Any]]]:
         calls: list[dict[str, Any]] = []
 
@@ -183,6 +198,46 @@ class TestUploadSeedNoteImages:
                 f"{seed_module.SEED_NOTE_IMAGE_PREFIX}/"
             )
             assert set(attachment) == {"filename", "url"}
+
+
+class TestUploadSeedNoteImagesWithoutGCS:
+    """The seed has to survive an environment with no bucket.
+
+    CI's boot smoke job runs the seed with no GCP settings at all, so uploading
+    must degrade to "notes without images" rather than taking the whole seed
+    down with it.
+    """
+
+    @pytest.mark.parametrize(
+        ("bucket", "private_key"),
+        [
+            ("", ""),
+            ("", "-----BEGIN PRIVATE KEY-----test"),
+            ("test-bucket", ""),
+        ],
+    )
+    def test_returns_nothing_when_settings_are_missing(
+        self, bucket: str, private_key: str
+    ) -> None:
+        with (
+            patch.multiple(
+                seed_module.settings,
+                gcp_bucket_name=bucket,
+                gcp_service_account_private_key=private_key,
+            ),
+            patch.object(seed_module, "GCPStorageClient") as client_class,
+        ):
+            assert seed_module.upload_seed_note_images() == []
+
+        # Never even constructed — building the client is what parses the key
+        # and raises on a malformed PEM.
+        client_class.assert_not_called()
+
+    def test_an_empty_pool_seeds_notes_without_attachments(self) -> None:
+        """The skip has to reach the notes, not just the upload helper."""
+        random.seed(1)
+        for _ in range(50):
+            assert seed_module.pick_note_attachments([]) == []
 
 
 class TestUploadFileKeyOverride:


### PR DESCRIPTION
## Implementation Description

Seeded notes have always been text-only, so the note card's thumbnail layout from #236 has never been rendered against real data. This attaches images to a share of the seeded location notes.

They have to be **real objects in the bucket**. Note reads re-sign from the stored `filename`, and signing is an offline operation, so a fabricated key produces a perfectly valid signed URL that 404s the moment a thumbnail renders. Faking the rows would look like it worked until you opened the page.

**How the images are made.** Drawn in code by a small pure-stdlib PNG encoder (`app/utilities/seed_images.py`) rather than committed as fixtures or fetched at seed time — no binaries in the repo, no photo licensing question, and no network dependency beyond the bucket itself. Six flat-coloured tiles with a silhouette block, deliberately 160×120 so the 64px square thumbnail actually exercises its `object-fit` crop.

**How they're stored.** Uploaded once to fixed keys under `seed/note-images/`, so re-seeding overwrites the same six objects instead of orphaning a fresh copy on every run. That needs `upload_file` to accept a caller-chosen `key`; user uploads keep the `<uuid>-<filename>` default so two people uploading `photo.jpg` still can't collide.

**Where they land.** Location notes only — that chain is what the driver's route page renders, so it's the only place a thumbnail is ever seen. Route and driver chains stay text-only, and a test enforces that. Roughly 35% of location notes get 1–3 images, capped at `MAX_NOTE_IMAGES = 3` to match the frontend's `NOTE_IMAGE_MAX` and `NoteCreate`'s own limit.

**Seeding survives having no bucket.** CI's boot job runs the seed with no GCP settings at all, so building the storage client would die on a malformed PEM and take the whole seed down. With the bucket or private key missing, the upload is skipped and notes seed text-only; a failure with credentials actually present still raises.

## Note on history

This was originally opened against `kerushani/all-stops-note-section`, because `Note.attachments` was typed `list[Attachment]` over a plain `sa.JSON` column and Pydantic coerced assignments into `Attachment` objects that `json.dumps` refused:

```
sqlalchemy.exc.StatementError: (builtins.TypeError) Object of type Attachment is not JSON serializable
```

That meant **no note with an attachment could be written at all** — not by this seed, and not by `POST /note-chains/{id}/notes`. #236's `AttachmentListJSON` type decorator fixed that live bug; now that it has merged, this PR targets `main` and carries only the seeding work.

## Steps to Test

1. Check out this branch and re-seed.
2. Log in as a driver and open their route page, then expand stops until you find a note with images (~35% of location notes have them).
3. Thumbnails should render above the message text, three at most.

## Verification

CI is green on all four jobs (lint, test, boot, openapi-sync). Locally:

- `ruff check` — all checks passed
- `ruff format --check` — 144 files already formatted
- `mypy app tests` — success, no issues in 135 source files
- `pytest tests/test_seed_images.py tests/test_seed_note_attachments.py tests/test_seed_database.py` — **75 passed**
- Reproduced CI's environment (seed run with the GCP vars blanked, from `tests/data/test_locations.csv`): completes with `GCS is not configured — seeding notes without images`.
- End-to-end against the real bucket: uploaded all six objects, attached three to a live note, and confirmed the thumbnails render in the browser.

## What Should Reviewers Focus On?

* **Seeding writes to the shared production bucket.** Keys are fixed and idempotent, so the blast radius is six objects that get overwritten rather than accumulating — but it is still the real bucket, and worth a conscious yes.
* Whether 35% / 1–3 images is the right density, or whether you'd rather guarantee the *first* stop of every route has one so it's always visible without hunting.

## Checklist
- [x] PR name and commits are descriptive, imperative, and atomic
- [x] Tests added
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
