### PR TITLE
Send a globalEndTime so live route generation passes API validation

### DIFF
--- a/backend/python/app/services/implementations/google_maps_routing_service.py
+++ b/backend/python/app/services/implementations/google_maps_routing_service.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import threading
+from datetime import timedelta
 from typing import TYPE_CHECKING
 from zoneinfo import ZoneInfo
 
@@ -41,6 +42,24 @@ MANDATORY_DELIVERY_PENALTY = 1_000_000
 GLOBAL_DURATION_COST_PER_HOUR = 6
 VEHICLE_COST_PER_HOUR = 1
 
+# How long after globalStartTime the plan is allowed to run. The API requires
+# a globalEndTime (see _build_payload), so this has to be a real number; a full
+# day is far beyond any delivery run and is the closest thing to "no deadline"
+# the API will accept.
+GLOBAL_HORIZON_HOURS = 24
+
+
+def _localize(moment: datetime) -> datetime:
+    """Return `moment` as a timezone-aware datetime in warehouse-local time.
+
+    A naive input is read as local warehouse time rather than UTC. Every
+    caller works in the operating timezone, so assuming UTC would silently
+    shift the plan by the offset (five hours, in the wrong direction).
+    """
+    if moment.tzinfo is None:
+        return moment.replace(tzinfo=ZoneInfo(app_settings.scheduler_timezone))
+    return moment
+
 
 def _to_rfc3339(moment: datetime) -> str:
     """Format a moment as an RFC 3339 timestamp the optimizeTours API accepts.
@@ -48,14 +67,8 @@ def _to_rfc3339(moment: datetime) -> str:
     Two things the API is strict about, and `strftime("%z")` gets wrong:
     the offset needs a colon (``-05:00``, not ``-0500``), and the timestamp
     must be unambiguous — a naive one is rejected.
-
-    A naive input is read as local warehouse time rather than UTC. Every
-    caller works in the operating timezone, so assuming UTC would silently
-    shift the plan by the offset (five hours, in the wrong direction).
     """
-    if moment.tzinfo is None:
-        moment = moment.replace(tzinfo=ZoneInfo(app_settings.scheduler_timezone))
-    return moment.isoformat()
+    return _localize(moment).isoformat()
 
 
 class GoogleMapsFleetRoutingAlgorithm(RoutingAlgorithmProtocol):
@@ -182,12 +195,22 @@ class GoogleMapsFleetRoutingAlgorithm(RoutingAlgorithmProtocol):
         # the wrong date would have the API plan against the wrong day's
         # traffic. See RouteGenerationSettings.route_start_time.
         #
-        # No globalEndTime: the routes have no hard deadline, and inventing one
-        # would make the model infeasible whenever a day's deliveries overrun it.
+        # globalEndTime is NOT optional, however much it reads like it. Omitting
+        # it does not mean "no deadline" — the API defaults the field to the
+        # epoch and then rejects the request outright:
+        #   INVALID_REQUEST: `global_start_time` after `global_end_time`
+        # So every live call fails validation without it, on any start date.
+        # GLOBAL_HORIZON_HOURS is deliberately far wider than a delivery run
+        # (nothing else here bounds the plan — vehicles carry no time windows),
+        # which keeps the "no hard deadline" intent while satisfying the API.
+        # A tight bound would silently make busy days infeasible instead.
+        global_start = _localize(settings.route_start_time)
+        global_end = global_start + timedelta(hours=GLOBAL_HORIZON_HOURS)
         return {
             "model": {
                 "globalDurationCostPerHour": GLOBAL_DURATION_COST_PER_HOUR,
-                "globalStartTime": _to_rfc3339(settings.route_start_time),
+                "globalStartTime": _to_rfc3339(global_start),
+                "globalEndTime": _to_rfc3339(global_end),
                 "vehicles": vehicles,
                 "shipments": forced_pickups + deliveries,
             }

--- a/backend/python/app/services/implementations/google_maps_routing_service.py
+++ b/backend/python/app/services/implementations/google_maps_routing_service.py
@@ -42,19 +42,16 @@ MANDATORY_DELIVERY_PENALTY = 1_000_000
 GLOBAL_DURATION_COST_PER_HOUR = 6
 VEHICLE_COST_PER_HOUR = 1
 
-# How long after globalStartTime the plan is allowed to run. The API requires
-# a globalEndTime (see _build_payload), so this has to be a real number; a full
-# day is far beyond any delivery run and is the closest thing to "no deadline"
-# the API will accept.
+# The plan's time horizon. The API rejects a request with no globalEndTime
+# (see _build_payload), and a day is far past any delivery run.
 GLOBAL_HORIZON_HOURS = 24
 
 
 def _localize(moment: datetime) -> datetime:
     """Return `moment` as a timezone-aware datetime in warehouse-local time.
 
-    A naive input is read as local warehouse time rather than UTC. Every
-    caller works in the operating timezone, so assuming UTC would silently
-    shift the plan by the offset (five hours, in the wrong direction).
+    A naive input is warehouse-local, not UTC — every caller works in the
+    operating timezone, so assuming UTC would shift the plan by the offset.
     """
     if moment.tzinfo is None:
         return moment.replace(tzinfo=ZoneInfo(app_settings.scheduler_timezone))
@@ -195,15 +192,10 @@ class GoogleMapsFleetRoutingAlgorithm(RoutingAlgorithmProtocol):
         # the wrong date would have the API plan against the wrong day's
         # traffic. See RouteGenerationSettings.route_start_time.
         #
-        # globalEndTime is NOT optional, however much it reads like it. Omitting
-        # it does not mean "no deadline" — the API defaults the field to the
-        # epoch and then rejects the request outright:
-        #   INVALID_REQUEST: `global_start_time` after `global_end_time`
-        # So every live call fails validation without it, on any start date.
-        # GLOBAL_HORIZON_HOURS is deliberately far wider than a delivery run
-        # (nothing else here bounds the plan — vehicles carry no time windows),
-        # which keeps the "no hard deadline" intent while satisfying the API.
-        # A tight bound would silently make busy days infeasible instead.
+        # globalEndTime is required, however optional it reads: omitting it
+        # defaults the field to the epoch, and every call then fails with
+        # "`global_start_time` after `global_end_time`". The horizon is wide
+        # because nothing else bounds the plan — vehicles carry no time windows.
         global_start = _localize(settings.route_start_time)
         global_end = global_start + timedelta(hours=GLOBAL_HORIZON_HOURS)
         return {

--- a/backend/python/app/services/implementations/google_maps_routing_service.py
+++ b/backend/python/app/services/implementations/google_maps_routing_service.py
@@ -42,8 +42,8 @@ MANDATORY_DELIVERY_PENALTY = 1_000_000
 GLOBAL_DURATION_COST_PER_HOUR = 6
 VEHICLE_COST_PER_HOUR = 1
 
-# The plan's time horizon. The API rejects a request with no globalEndTime
-# (see _build_payload), and a day is far past any delivery run.
+# The plan's time horizon. A globalEndTime is mandatory, so this is wide
+# enough that it never binds — nothing else here constrains the plan either.
 GLOBAL_HORIZON_HOURS = 24
 
 
@@ -192,10 +192,6 @@ class GoogleMapsFleetRoutingAlgorithm(RoutingAlgorithmProtocol):
         # the wrong date would have the API plan against the wrong day's
         # traffic. See RouteGenerationSettings.route_start_time.
         #
-        # globalEndTime is required, however optional it reads: omitting it
-        # defaults the field to the epoch, and every call then fails with
-        # "`global_start_time` after `global_end_time`". The horizon is wide
-        # because nothing else bounds the plan — vehicles carry no time windows.
         global_start = _localize(settings.route_start_time)
         global_end = global_start + timedelta(hours=GLOBAL_HORIZON_HOURS)
         return {

--- a/backend/python/scripts/fleet_routing_manual.py
+++ b/backend/python/scripts/fleet_routing_manual.py
@@ -8,7 +8,7 @@ NOTE: This hits the live Google API and will incur charges.
 """
 
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, time, timedelta
 from uuid import UUID, uuid4
 
 import pytest
@@ -53,9 +53,15 @@ async def test_fleet_routing_live() -> None:
     if not app_settings.route_opt_client_email:
         pytest.skip("ROUTE_OPT_* env vars not configured")
 
+    # Relative to today so the script doesn't rot: the API plans against the
+    # timestamp's day, and a hardcoded date drifts into the past.
+    tomorrow_at_nine = datetime.combine(
+        datetime.now().date() + timedelta(days=1), time(9, 0)
+    )
+
     settings = RouteGenerationSettings(
         num_routes=2,
-        route_start_time=datetime(2025, 6, 1, 9, 0),
+        route_start_time=tomorrow_at_nine,
         return_to_warehouse=True,
     )
 

--- a/backend/python/scripts/fleet_routing_manual.py
+++ b/backend/python/scripts/fleet_routing_manual.py
@@ -53,8 +53,7 @@ async def test_fleet_routing_live() -> None:
     if not app_settings.route_opt_client_email:
         pytest.skip("ROUTE_OPT_* env vars not configured")
 
-    # Relative to today so the script doesn't rot: the API plans against the
-    # timestamp's day, and a hardcoded date drifts into the past.
+    # Relative so the script doesn't rot — the API plans against the day given.
     tomorrow_at_nine = datetime.combine(
         datetime.now().date() + timedelta(days=1), time(9, 0)
     )

--- a/backend/python/tests/test_google_maps_routing_service.py
+++ b/backend/python/tests/test_google_maps_routing_service.py
@@ -157,11 +157,8 @@ class TestBuildPayload:
     ) -> None:
         """globalEndTime must be present and later than globalStartTime.
 
-        The API does not treat an omitted globalEndTime as "no deadline" — it
-        defaults the field to the epoch and rejects the request with
-        "`global_start_time` after `global_end_time`". Every live call failed
-        that way while these unit tests stayed green, so this asserts the
-        invariant the API actually enforces.
+        Omitting it defaults the field to the epoch, and the API rejects every
+        request with "`global_start_time` after `global_end_time`".
         """
         model = algorithm._build_payload(
             [make_location()], 43.0, -79.0, sample_settings
@@ -188,7 +185,6 @@ class TestBuildPayload:
             "model"
         ]
 
-        # Both ends sit inside DST here, so they share the -04:00 offset.
         assert model["globalStartTime"] == "2026-07-09T08:30:00-04:00"
         assert model["globalEndTime"] == "2026-07-10T08:30:00-04:00"
 

--- a/backend/python/tests/test_google_maps_routing_service.py
+++ b/backend/python/tests/test_google_maps_routing_service.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import time
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Any
 from uuid import UUID, uuid4
 
@@ -12,6 +12,7 @@ import pytest
 from app.schemas.route_generation import RouteGenerationSettings
 from app.services.implementations.google_maps_routing_service import (
     GLOBAL_DURATION_COST_PER_HOUR,
+    GLOBAL_HORIZON_HOURS,
     MANDATORY_DELIVERY_PENALTY,
     VEHICLE_COST_PER_HOUR,
     GoogleMapsFleetRoutingAlgorithm,
@@ -145,9 +146,69 @@ class TestBuildPayload:
 
         # January 1st is outside DST, so America/New_York is UTC-5 here.
         assert model["globalStartTime"] == "2025-01-01T09:00:00-05:00"
-        assert "globalEndTime" not in model
         for vehicle in model["vehicles"]:
             assert "startTime" not in vehicle
+
+    def test_global_end_time_is_always_sent_and_after_the_start(
+        self,
+        algorithm: GoogleMapsFleetRoutingAlgorithm,
+        make_location: Any,
+        sample_settings: RouteGenerationSettings,
+    ) -> None:
+        """globalEndTime must be present and later than globalStartTime.
+
+        The API does not treat an omitted globalEndTime as "no deadline" — it
+        defaults the field to the epoch and rejects the request with
+        "`global_start_time` after `global_end_time`". Every live call failed
+        that way while these unit tests stayed green, so this asserts the
+        invariant the API actually enforces.
+        """
+        model = algorithm._build_payload(
+            [make_location()], 43.0, -79.0, sample_settings
+        )["model"]
+
+        assert "globalEndTime" in model
+        start = datetime.fromisoformat(model["globalStartTime"])
+        end = datetime.fromisoformat(model["globalEndTime"])
+        assert end > start
+        assert end - start == timedelta(hours=GLOBAL_HORIZON_HOURS)
+
+    def test_global_end_time_spans_a_full_day_of_slack(
+        self,
+        algorithm: GoogleMapsFleetRoutingAlgorithm,
+        make_location: Any,
+    ) -> None:
+        """The horizon is wide enough that a long day can never overrun it."""
+        settings = RouteGenerationSettings(
+            num_routes=1,
+            route_start_time=datetime(2026, 7, 9, 8, 30),
+        )
+
+        model = algorithm._build_payload([make_location()], 43.0, -79.0, settings)[
+            "model"
+        ]
+
+        # Both ends sit inside DST here, so they share the -04:00 offset.
+        assert model["globalStartTime"] == "2026-07-09T08:30:00-04:00"
+        assert model["globalEndTime"] == "2026-07-10T08:30:00-04:00"
+
+    def test_global_end_time_follows_an_explicit_offset(
+        self,
+        algorithm: GoogleMapsFleetRoutingAlgorithm,
+        make_location: Any,
+    ) -> None:
+        """A tz-aware start keeps its own offset on both ends of the window."""
+        settings = RouteGenerationSettings(
+            num_routes=1,
+            route_start_time=datetime(2025, 1, 1, 14, 0, tzinfo=timezone.utc),
+        )
+
+        model = algorithm._build_payload([make_location()], 43.0, -79.0, settings)[
+            "model"
+        ]
+
+        assert model["globalStartTime"] == "2025-01-01T14:00:00+00:00"
+        assert model["globalEndTime"] == "2025-01-02T14:00:00+00:00"
 
     def test_global_start_time_keeps_the_drive_date(
         self,


### PR DESCRIPTION
## Problem

Every real call to the Route Optimization API failed validation:

```
400 INVALID_REQUEST: Validation caught 1 error(s). Here is the first one:
`global_start_time` after `global_end_time`
(offending value(s): [2026-09-01T13:00:00+00:00, 1971-01-01T00:00:00+00:00])
```

`_build_payload` deliberately omitted `globalEndTime`, with a comment explaining that the routes have no hard deadline. The API does not read an omitted `globalEndTime` as "no deadline" — it defaults the field to the epoch and rejects the request as start-after-end. Date-independent: it reproduced with both past and future start times.

## Fix

Send `globalEndTime = globalStartTime + 24h`. Nothing else in the payload bounds the plan — vehicles carry no `startTimeWindows`/`endTimeWindows` — so the horizon is the only limit, and a full day is far beyond any delivery run. That preserves the original "no hard deadline" intent while satisfying validation; a tight bound would instead make busy days silently infeasible.

The old comment is replaced with one that states the real API behaviour, so nobody removes the field again.

Also extracted `_localize` so the start and end are derived from the same timezone-normalized moment, rather than re-normalizing a formatted string.

## Verification

Live API, via the manual integration script — this is the point, since the unit tests passed the whole time this was broken:

```
docker exec f4k_backend sh -c 'cd /app && python -m pytest scripts/fleet_routing_manual.py -q -s'

Route 1 (4 stops): Fairview Park Mall, Homer Watson Park, Waterloo Town Square, Uptown Waterloo
Route 2 (3 stops): Kitchener City Hall, Victoria Park, Elmira Golf Club
1 passed
```

`scripts/fleet_routing_manual.py` hardcoded a 2025-06-01 start date; it now anchors on tomorrow at 09:00 so it doesn't rot again.

## Tests

Three new cases in `TestBuildPayload`: `globalEndTime` present and strictly after `globalStartTime`, the full-day span with a naive DST start, and the span with an explicit UTC offset. `tests/test_google_maps_routing_service.py`: 22 passed.

`ruff check`, `ruff format --check`, `mypy app scripts`: clean.

## Relation to #264

Independent of #264 — that PR changes `_ensure_credentials`, this one changes `_build_payload`. Verified they rebase onto each other cleanly, and the live run above used `main`'s existing `ROUTE_OPT_*` credential path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)