### PR TITLE
F4KRP-214: Add unassigned routes card

### DIFF
--- a/frontend/src/pages/admin/home/AdminHomePage.tsx
+++ b/frontend/src/pages/admin/home/AdminHomePage.tsx
@@ -4,6 +4,8 @@ import { formatDisplayDate } from '@/common/utils';
 import { AnnouncementsBoard } from '@/features/announcements';
 import { StatisticsWidget } from '@/features/statistics';
 
+import { UnassignedRoutesCard } from './components';
+
 const today = formatDisplayDate(new Date());
 
 /** Every bento tile: 28px corners and the soft admin-page shadow. */
@@ -44,6 +46,8 @@ export const AdminHomePage = () => {
           <CardContent>TODO: Unassigned Routes</CardContent>
         </Card>
         <Card className={TILE}>
+        <UnassignedRoutesCard />
+        <Card>
           <CardContent>TODO: Recent Notes</CardContent>
         </Card>
       </div>

--- a/frontend/src/pages/admin/home/AdminHomePage.tsx
+++ b/frontend/src/pages/admin/home/AdminHomePage.tsx
@@ -42,12 +42,8 @@ export const AdminHomePage = () => {
           </Card>
           <StatisticsWidget />
         </div>
-        <Card className={TILE}>
-          <CardContent>TODO: Unassigned Routes</CardContent>
-        </Card>
-        <Card className={TILE}>
         <UnassignedRoutesCard />
-        <Card>
+        <Card className={TILE}>
           <CardContent>TODO: Recent Notes</CardContent>
         </Card>
       </div>

--- a/frontend/src/pages/admin/home/components/UnassignedRoutePreviewCard.tsx
+++ b/frontend/src/pages/admin/home/components/UnassignedRoutePreviewCard.tsx
@@ -87,11 +87,11 @@ export function UnassignedRoutePreviewCard({
     <>
       <div
         className={cn(
-          'border-grey-300 flex min-w-0 flex-[1_0_0] flex-col items-start self-stretch overflow-hidden rounded-xl border bg-white',
+          'border-grey-300 isolate z-0 flex min-w-0 flex-[1_0_0] flex-col items-start self-stretch overflow-hidden rounded-xl border bg-white',
           className
         )}
       >
-        <div className="bg-grey-150 relative h-40 w-full shrink-0">
+        <div className="bg-grey-150 relative isolate z-0 h-40 w-full shrink-0 overflow-hidden [&_.leaflet-bottom]:z-0 [&_.leaflet-container]:z-0 [&_.leaflet-pane]:z-0 [&_.leaflet-top]:z-0">
           {isLoading && (
             <div className="absolute inset-0 z-10 flex items-center justify-center">
               <Spinner size="sm" />
@@ -112,7 +112,7 @@ export function UnassignedRoutePreviewCard({
               Map unavailable
             </div>
           )}
-          <div className="absolute top-2.5 right-2.5 z-[500] flex items-center gap-1.5 rounded-full bg-white px-2.5 py-1 shadow-sm">
+          <div className="absolute top-2.5 right-2.5 z-10 flex items-center gap-1.5 rounded-full bg-white px-2.5 py-1 shadow-sm">
             <ClockIcon className="text-grey-400 size-3.5 shrink-0" />
             <span className="text-m-p3 text-grey-400 whitespace-nowrap">
               {startsIn}

--- a/frontend/src/pages/admin/home/components/UnassignedRoutePreviewCard.tsx
+++ b/frontend/src/pages/admin/home/components/UnassignedRoutePreviewCard.tsx
@@ -1,0 +1,158 @@
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+
+import type { RouteWithDateRead } from '@/api/generated/types.gen';
+import ClockIcon from '@/assets/icons/clock.svg?react';
+import { Button, Spinner } from '@/common/components';
+import { RouteMap } from '@/common/components/RouteMap';
+import { useRoute } from '@/common/hooks/useRoute';
+import { parseDateOnly } from '@/common/utils';
+import { cn } from '@/lib/utils';
+
+import { ReassignDriverModal } from '../../routes/components/ReassignDriverModal';
+
+interface UnassignedRoutePreviewCardProps {
+  route: RouteWithDateRead;
+  className?: string;
+}
+
+function formatPreviewDate(driveDate: string): string {
+  return parseDateOnly(driveDate).toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+function formatStartTime(value: string | null | undefined): string | null {
+  if (!value) return null;
+  const [h, m] = value.split(':');
+  const hour = Number(h);
+  const minute = Number(m);
+  if (Number.isNaN(hour) || Number.isNaN(minute)) return null;
+  const period = hour < 12 ? 'AM' : 'PM';
+  const hour12 = hour % 12 === 0 ? 12 : hour % 12;
+  return `${hour12}:${String(minute).padStart(2, '0')} ${period}`;
+}
+
+function getRouteStartDate(
+  driveDate: string,
+  startTime: string | null | undefined
+): Date {
+  const date = parseDateOnly(driveDate);
+  if (!startTime) return date;
+  const [h, m, s] = startTime.split(':').map(Number);
+  if (Number.isNaN(h) || Number.isNaN(m)) return date;
+  date.setHours(h, m, Number.isNaN(s) ? 0 : s, 0);
+  return date;
+}
+
+function formatStartsIn(
+  driveDate: string,
+  startTime: string | null | undefined
+): string {
+  const start = getRouteStartDate(driveDate, startTime);
+  const diffMs = start.getTime() - Date.now();
+  if (diffMs <= 0) {
+    return startTime ? 'Started' : `Starts ${formatPreviewDate(driveDate)}`;
+  }
+  const totalMinutes = Math.floor(diffMs / 60_000);
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  if (hours === 0) return `Starts in ${minutes}m`;
+  if (minutes === 0) return `Starts in ${hours}h`;
+  return `Starts in ${hours}h ${minutes}m`;
+}
+
+function PreviewMetadata({ route }: { route: RouteWithDateRead }) {
+  const parts = [
+    formatPreviewDate(route.drive_date),
+    formatStartTime(route.start_time),
+    `${route.num_stops} stop${route.num_stops === 1 ? '' : 's'}`,
+  ].filter(Boolean);
+
+  return (
+    <p className="text-m-p3 text-grey-400 font-normal">
+      {parts.join(' • ')}
+    </p>
+  );
+}
+
+export function UnassignedRoutePreviewCard({
+  route,
+  className,
+}: UnassignedRoutePreviewCardProps) {
+  const { data: detail, isLoading, isError } = useRoute(route.route_id);
+  const [assignOpen, setAssignOpen] = useState(false);
+  const startsIn = formatStartsIn(route.drive_date, route.start_time);
+
+  return (
+    <>
+      <div
+        className={cn(
+          'border-grey-300 flex min-w-0 flex-col overflow-hidden rounded-xl border bg-white',
+          className
+        )}
+      >
+        <div className="relative h-40 w-full shrink-0 bg-grey-150">
+          {isLoading && (
+            <div className="absolute inset-0 z-10 flex items-center justify-center">
+              <Spinner size="sm" />
+            </div>
+          )}
+          {!isLoading && !isError && (
+            <div className="pointer-events-none h-full w-full">
+              <RouteMap
+                key={route.route_id}
+                encodedPolyline={detail?.encoded_polyline}
+                stops={detail?.stops}
+                className="h-full rounded-none border-0"
+              />
+            </div>
+          )}
+          {!isLoading && isError && (
+            <div className="text-m-p3 text-grey-400 flex h-full items-center justify-center px-4 text-center">
+              Map unavailable
+            </div>
+          )}
+          <div className="absolute top-2.5 right-2.5 z-[500] flex items-center gap-1.5 rounded-full bg-white px-2.5 py-1 shadow-sm">
+            <ClockIcon className="text-grey-400 size-3.5 shrink-0" />
+            <span className="text-m-p3 text-grey-400 whitespace-nowrap">
+              {startsIn}
+            </span>
+          </div>
+        </div>
+
+        <div className="flex flex-col gap-3 p-4">
+          <div className="flex flex-col gap-0.5">
+            <p className="text-m-p1 text-grey-500 font-bold">{route.name}</p>
+            <PreviewMetadata route={route} />
+          </div>
+          <div className="flex gap-2">
+            <Button
+              variant="secondary"
+              shape="compact"
+              asChild
+              className="min-w-0 flex-1"
+            >
+              <Link to="/admin/routes?tab=routes">View route</Link>
+            </Button>
+            <Button
+              variant="primary"
+              shape="compact"
+              className="min-w-0 flex-1"
+              onClick={() => setAssignOpen(true)}
+            >
+              Assign
+            </Button>
+          </div>
+        </div>
+      </div>
+
+      <ReassignDriverModal
+        open={assignOpen}
+        onOpenChange={setAssignOpen}
+        route={route}
+      />
+    </>
+  );
+}

--- a/frontend/src/pages/admin/home/components/UnassignedRoutePreviewCard.tsx
+++ b/frontend/src/pages/admin/home/components/UnassignedRoutePreviewCard.tsx
@@ -56,55 +56,57 @@ export function UnassignedRoutePreviewCard({
     <>
       <div
         className={cn(
-          'border-grey-300 isolate z-0 flex min-w-0 flex-[1_0_0] flex-col items-start self-stretch overflow-hidden rounded-xl border bg-white',
+          'isolate z-0 flex min-w-0 flex-[1_0_0] flex-col items-start self-stretch',
           className
         )}
       >
-        <div className="bg-grey-150 relative isolate z-0 h-40 w-full shrink-0 overflow-hidden [&_.leaflet-bottom]:z-0 [&_.leaflet-container]:z-0 [&_.leaflet-pane]:z-0 [&_.leaflet-top]:z-0">
-          {isLoading && (
-            <div className="absolute inset-0 z-10 flex items-center justify-center">
-              <Spinner size="sm" />
-            </div>
-          )}
-          {!isLoading && !isError && (
-            <div className="pointer-events-none h-full w-full">
-              <RouteMap
-                key={route.route_id}
-                encodedPolyline={detail?.encoded_polyline}
-                stops={detail?.stops}
-                className="h-full rounded-none border-0"
-              />
-            </div>
-          )}
-          {!isLoading && isError && (
-            <div className="text-m-p3 text-grey-400 flex h-full items-center justify-center px-4 text-center">
-              Map unavailable
-            </div>
-          )}
-        </div>
-
-        <div className="flex flex-col items-start gap-4 self-stretch p-6">
-          <div className="flex flex-col gap-0.5">
-            <p className="text-m-p1 text-grey-500 font-bold">{route.name}</p>
-            <PreviewMetadata route={route} />
+        <div className="border-grey-300 flex w-full flex-col overflow-hidden rounded-xl border bg-white">
+          <div className="bg-grey-150 relative isolate z-0 h-40 w-full shrink-0 overflow-hidden [&_.leaflet-bottom]:z-0 [&_.leaflet-container]:z-0 [&_.leaflet-pane]:z-0 [&_.leaflet-top]:z-0">
+            {isLoading && (
+              <div className="absolute inset-0 z-10 flex items-center justify-center">
+                <Spinner size="sm" />
+              </div>
+            )}
+            {!isLoading && !isError && (
+              <div className="pointer-events-none h-full w-full">
+                <RouteMap
+                  key={route.route_id}
+                  encodedPolyline={detail?.encoded_polyline}
+                  stops={detail?.stops}
+                  className="h-full rounded-none border-0"
+                />
+              </div>
+            )}
+            {!isLoading && isError && (
+              <div className="text-m-p3 text-grey-400 flex h-full items-center justify-center px-4 text-center">
+                Map unavailable
+              </div>
+            )}
           </div>
-          <div className="flex items-center gap-4 self-stretch">
-            <Button
-              variant="secondary"
-              shape="compact"
-              asChild
-              className="min-w-0 flex-1"
-            >
-              <Link to="/admin/routes?tab=routes">View route</Link>
-            </Button>
-            <Button
-              variant="primary"
-              shape="compact"
-              className="min-w-0 flex-1"
-              onClick={() => setAssignOpen(true)}
-            >
-              Assign
-            </Button>
+
+          <div className="flex flex-col items-start gap-4 self-stretch p-4">
+            <div className="flex flex-col gap-0.5">
+              <p className="text-m-p1 text-grey-500 font-bold">{route.name}</p>
+              <PreviewMetadata route={route} />
+            </div>
+            <div className="flex items-center gap-4 self-stretch">
+              <Button
+                variant="secondary"
+                shape="compact"
+                asChild
+                className="min-w-0 flex-1"
+              >
+                <Link to="/admin/routes?tab=routes">View route</Link>
+              </Button>
+              <Button
+                variant="primary"
+                shape="compact"
+                className="min-w-0 flex-1"
+                onClick={() => setAssignOpen(true)}
+              >
+                Assign
+              </Button>
+            </div>
           </div>
         </div>
       </div>

--- a/frontend/src/pages/admin/home/components/UnassignedRoutePreviewCard.tsx
+++ b/frontend/src/pages/admin/home/components/UnassignedRoutePreviewCard.tsx
@@ -71,9 +71,7 @@ function PreviewMetadata({ route }: { route: RouteWithDateRead }) {
   ].filter(Boolean);
 
   return (
-    <p className="text-m-p3 text-grey-400 font-normal">
-      {parts.join(' • ')}
-    </p>
+    <p className="text-m-p3 text-grey-400 font-normal">{parts.join(' • ')}</p>
   );
 }
 
@@ -89,11 +87,11 @@ export function UnassignedRoutePreviewCard({
     <>
       <div
         className={cn(
-          'border-grey-300 flex min-w-0 flex-col overflow-hidden rounded-xl border bg-white',
+          'border-grey-300 flex min-w-0 flex-[1_0_0] flex-col items-start self-stretch overflow-hidden rounded-xl border bg-white',
           className
         )}
       >
-        <div className="relative h-40 w-full shrink-0 bg-grey-150">
+        <div className="bg-grey-150 relative h-40 w-full shrink-0">
           {isLoading && (
             <div className="absolute inset-0 z-10 flex items-center justify-center">
               <Spinner size="sm" />
@@ -122,12 +120,12 @@ export function UnassignedRoutePreviewCard({
           </div>
         </div>
 
-        <div className="flex flex-col gap-3 p-4">
+        <div className="flex flex-col items-start gap-4 self-stretch p-6">
           <div className="flex flex-col gap-0.5">
             <p className="text-m-p1 text-grey-500 font-bold">{route.name}</p>
             <PreviewMetadata route={route} />
           </div>
-          <div className="flex gap-2">
+          <div className="flex items-center gap-4 self-stretch">
             <Button
               variant="secondary"
               shape="compact"

--- a/frontend/src/pages/admin/home/components/UnassignedRoutePreviewCard.tsx
+++ b/frontend/src/pages/admin/home/components/UnassignedRoutePreviewCard.tsx
@@ -2,7 +2,6 @@ import { useState } from 'react';
 import { Link } from 'react-router-dom';
 
 import type { RouteWithDateRead } from '@/api/generated/types.gen';
-import ClockIcon from '@/assets/icons/clock.svg?react';
 import { Button, Spinner } from '@/common/components';
 import { RouteMap } from '@/common/components/RouteMap';
 import { useRoute } from '@/common/hooks/useRoute';
@@ -34,35 +33,6 @@ function formatStartTime(value: string | null | undefined): string | null {
   return `${hour12}:${String(minute).padStart(2, '0')} ${period}`;
 }
 
-function getRouteStartDate(
-  driveDate: string,
-  startTime: string | null | undefined
-): Date {
-  const date = parseDateOnly(driveDate);
-  if (!startTime) return date;
-  const [h, m, s] = startTime.split(':').map(Number);
-  if (Number.isNaN(h) || Number.isNaN(m)) return date;
-  date.setHours(h, m, Number.isNaN(s) ? 0 : s, 0);
-  return date;
-}
-
-function formatStartsIn(
-  driveDate: string,
-  startTime: string | null | undefined
-): string {
-  const start = getRouteStartDate(driveDate, startTime);
-  const diffMs = start.getTime() - Date.now();
-  if (diffMs <= 0) {
-    return startTime ? 'Started' : `Starts ${formatPreviewDate(driveDate)}`;
-  }
-  const totalMinutes = Math.floor(diffMs / 60_000);
-  const hours = Math.floor(totalMinutes / 60);
-  const minutes = totalMinutes % 60;
-  if (hours === 0) return `Starts in ${minutes}m`;
-  if (minutes === 0) return `Starts in ${hours}h`;
-  return `Starts in ${hours}h ${minutes}m`;
-}
-
 function PreviewMetadata({ route }: { route: RouteWithDateRead }) {
   const parts = [
     formatPreviewDate(route.drive_date),
@@ -81,7 +51,6 @@ export function UnassignedRoutePreviewCard({
 }: UnassignedRoutePreviewCardProps) {
   const { data: detail, isLoading, isError } = useRoute(route.route_id);
   const [assignOpen, setAssignOpen] = useState(false);
-  const startsIn = formatStartsIn(route.drive_date, route.start_time);
 
   return (
     <>
@@ -112,12 +81,6 @@ export function UnassignedRoutePreviewCard({
               Map unavailable
             </div>
           )}
-          <div className="absolute top-2.5 right-2.5 z-10 flex items-center gap-1.5 rounded-full bg-white px-2.5 py-1 shadow-sm">
-            <ClockIcon className="text-grey-400 size-3.5 shrink-0" />
-            <span className="text-m-p3 text-grey-400 whitespace-nowrap">
-              {startsIn}
-            </span>
-          </div>
         </div>
 
         <div className="flex flex-col items-start gap-4 self-stretch p-6">

--- a/frontend/src/pages/admin/home/components/UnassignedRoutesCard.tsx
+++ b/frontend/src/pages/admin/home/components/UnassignedRoutesCard.tsx
@@ -101,10 +101,7 @@ export function UnassignedRoutesCard() {
           <div className="flex min-w-0 items-center gap-2">
             <CardTitle className="text-h3">Unassigned</CardTitle>
             {total > 0 && (
-              <Tag
-                variant="error"
-                className="text-p3 text-red flex h-auto shrink-0 items-center justify-center self-stretch rounded-full border-0 bg-[#F4D5D5] px-3 py-0 font-normal"
-              >
+              <Tag variant="error" className="shrink-0">
                 {total} route{total === 1 ? '' : 's'}
               </Tag>
             )}

--- a/frontend/src/pages/admin/home/components/UnassignedRoutesCard.tsx
+++ b/frontend/src/pages/admin/home/components/UnassignedRoutesCard.tsx
@@ -103,7 +103,7 @@ export function UnassignedRoutesCard() {
             {total > 0 && (
               <Tag
                 variant="error"
-                className="text-p3 h-auto shrink-0 rounded-full border-0 bg-[#F4D5D5] px-2.5 py-0.5 font-normal text-red"
+                className="text-p3 text-red flex h-auto shrink-0 items-center justify-center self-stretch rounded-full border-0 bg-[#F4D5D5] px-3 py-0 font-normal"
               >
                 {total} route{total === 1 ? '' : 's'}
               </Tag>
@@ -137,7 +137,7 @@ export function UnassignedRoutesCard() {
           <div className="flex min-h-0 gap-4">
             <UnassignedRoutePreviewCard
               route={selectedRoute}
-              className="w-[280px] shrink-0"
+              className="min-w-0"
             />
             <ul className="flex min-h-0 min-w-0 flex-1 flex-col gap-1 overflow-y-auto">
               {routes.map((route) => {

--- a/frontend/src/pages/admin/home/components/UnassignedRoutesCard.tsx
+++ b/frontend/src/pages/admin/home/components/UnassignedRoutesCard.tsx
@@ -1,0 +1,160 @@
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+
+import type { RouteWithDateRead } from '@/api/generated/types.gen';
+import { useRoutes } from '@/api/routes';
+import {
+  Button,
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  Spinner,
+  Tag,
+} from '@/common/components';
+import { parseDateOnly, toNaiveDateString } from '@/common/utils';
+import { cn } from '@/lib/utils';
+
+import { UnassignedRoutePreviewCard } from './UnassignedRoutePreviewCard';
+
+const WIDGET_PAGE_SIZE = 5;
+
+function formatRouteDate(driveDate: string): string {
+  return parseDateOnly(driveDate).toLocaleDateString('en-US', {
+    month: 'long',
+    day: 'numeric',
+    year: 'numeric',
+  });
+}
+
+function routeKey(route: RouteWithDateRead): string {
+  return `${route.route_id}-${route.drive_date}`;
+}
+
+function UnassignedRouteRow({
+  route,
+  isSelected,
+  onSelect,
+}: {
+  route: RouteWithDateRead;
+  isSelected: boolean;
+  onSelect: () => void;
+}) {
+  const stopsLabel = `${route.num_stops} stop${route.num_stops === 1 ? '' : 's'}`;
+
+  return (
+    <li>
+      <button
+        type="button"
+        onClick={onSelect}
+        className={cn(
+          'flex w-full cursor-pointer items-center justify-between self-stretch rounded-sm px-5 py-2 text-left',
+          isSelected && 'bg-blue-50'
+        )}
+      >
+        <div className="flex min-w-0 flex-col">
+          <p className="text-m-p2 text-grey-500 font-normal">{route.name}</p>
+          {route.group_name ? (
+            <p className="text-m-p3 text-grey-500 font-normal">
+              {route.group_name}
+            </p>
+          ) : null}
+        </div>
+        <div className="flex shrink-0 flex-col text-right">
+          <p className="text-m-p2 text-grey-500 font-normal">
+            {formatRouteDate(route.drive_date)}
+          </p>
+          <p className="text-m-p3 text-grey-500 font-normal">{stopsLabel}</p>
+        </div>
+      </button>
+    </li>
+  );
+}
+
+export function UnassignedRoutesCard() {
+  const today = toNaiveDateString(new Date());
+  const { data, isLoading, isError } = useRoutes({
+    unassigned_only: true,
+    start_date: today,
+    order: 'asc',
+    page: 1,
+    page_size: WIDGET_PAGE_SIZE,
+  });
+  const [selectedKey, setSelectedKey] = useState<string | null>(null);
+
+  const routes: RouteWithDateRead[] = data?.items ?? [];
+  const total = data?.total ?? 0;
+
+  const effectiveSelectedKey =
+    selectedKey && routes.some((route) => routeKey(route) === selectedKey)
+      ? selectedKey
+      : routes[0]
+        ? routeKey(routes[0])
+        : null;
+  const selectedRoute =
+    routes.find((route) => routeKey(route) === effectiveSelectedKey) ?? null;
+
+  return (
+    <Card className="col-span-2 min-h-0">
+      <CardHeader className="mb-2">
+        <div className="flex items-center justify-between gap-2">
+          <div className="flex min-w-0 items-center gap-2">
+            <CardTitle className="text-h3">Unassigned</CardTitle>
+            {total > 0 && (
+              <Tag
+                variant="error"
+                className="text-p3 h-auto shrink-0 rounded-full border-0 bg-[#F4D5D5] px-2.5 py-0.5 font-normal text-red"
+              >
+                {total} route{total === 1 ? '' : 's'}
+              </Tag>
+            )}
+          </div>
+          <Button variant="textLink" asChild className="shrink-0">
+            <Link to="/admin/routes?tab=routes">View all</Link>
+          </Button>
+        </div>
+      </CardHeader>
+      <CardContent className="flex min-h-0 flex-col gap-3">
+        {isLoading && (
+          <div className="flex flex-1 items-center justify-center py-8">
+            <Spinner size="sm" />
+          </div>
+        )}
+
+        {!isLoading && isError && (
+          <p className="text-p2 text-grey-400 py-6 text-center">
+            Couldn&apos;t load unassigned routes. Try refreshing.
+          </p>
+        )}
+
+        {!isLoading && !isError && routes.length === 0 && (
+          <p className="text-p2 text-grey-400 py-6 text-center">
+            All upcoming routes have drivers assigned.
+          </p>
+        )}
+
+        {!isLoading && !isError && routes.length > 0 && selectedRoute && (
+          <div className="flex min-h-0 gap-4">
+            <UnassignedRoutePreviewCard
+              route={selectedRoute}
+              className="w-[280px] shrink-0"
+            />
+            <ul className="flex min-h-0 min-w-0 flex-1 flex-col gap-1 overflow-y-auto">
+              {routes.map((route) => {
+                const key = routeKey(route);
+                return (
+                  <UnassignedRouteRow
+                    key={key}
+                    route={route}
+                    isSelected={effectiveSelectedKey === key}
+                    onSelect={() => setSelectedKey(key)}
+                  />
+                );
+              })}
+            </ul>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/pages/admin/home/components/UnassignedRoutesCard.tsx
+++ b/frontend/src/pages/admin/home/components/UnassignedRoutesCard.tsx
@@ -95,7 +95,7 @@ export function UnassignedRoutesCard() {
     routes.find((route) => routeKey(route) === effectiveSelectedKey) ?? null;
 
   return (
-    <Card className="col-span-2 min-h-0">
+    <Card className="shadow-admin-bento min-h-0 rounded-4xl">
       <CardHeader className="mb-2">
         <div className="flex items-center justify-between gap-2">
           <div className="flex min-w-0 items-center gap-2">

--- a/frontend/src/pages/admin/home/components/index.ts
+++ b/frontend/src/pages/admin/home/components/index.ts
@@ -1,2 +1,2 @@
-// Export Admin Home page components here
-export {};
+export { UnassignedRoutePreviewCard } from './UnassignedRoutePreviewCard';
+export { UnassignedRoutesCard } from './UnassignedRoutesCard';


### PR DESCRIPTION
## JIRA Ticket
[F4KRP-214](https://f4kblueprint.atlassian.net/browse/F4KRP-214)

## Implementation Description
* Adds Unassigned routes widget to the admin dashboard 
* Note: for the "Start in" clock, if start_time is null, the drive_date is used in place.

## Steps to Test
<!-- What should the reviewer do to verify your changes? Include expected results -->
1. The widget on the dashboard ; should be able to switch between routes

## Screenshots 
<!-- Attach implemented screens alongside Zeplin designs for comparison -->
Implemented:
<img width="699" height="347" alt="Screenshot 2026-08-12 at 11 33 06 PM" src="https://github.com/user-attachments/assets/849703af-a7ee-439f-8a7b-cb7b48cfc6d4" />

Figma
<img width="937" height="414" alt="Frame 499 (1)" src="https://github.com/user-attachments/assets/202c8f13-824e-49f9-92e5-3a9c36ee518e" />

## What Should Reviewers Focus On?
<!-- Call out substantial changes or anything you want a second opinion on -->
* Figma design for this wasn't 100% finalized, but looks pretty close to done. If there's any changes that should be made to it, let me know!

## Checklist
- [x] PR name and commits are descriptive, imperative, and atomic (trivial commits squashed)
- [x] I have requested a review from Claude, understood its suggestions, and implemented fixes where needed (or documented disagreements)
- [x] I have requested a review from the PL and relevant devs with background on this PR

**Frontend only — delete if not applicable:**
- [x] Follows Tailwind/shadcn best practices per README; no hardcoded color or spacing values
- [ ] Implementation matches Zeplin designs and screenshots are attached above
- [x] Screens render correctly on mobile and desktop; no console warnings or errors