### PR TITLE
Fix note-section design nits

### DIFF
--- a/frontend/src/api/announcements.ts
+++ b/frontend/src/api/announcements.ts
@@ -17,7 +17,6 @@ export function useAnnouncements() {
   return useQuery({
     ...getAnnouncementsOptions(),
     enabled: isAuthenticated,
-    placeholderData: [],
   });
 }
 

--- a/frontend/src/api/notes.ts
+++ b/frontend/src/api/notes.ts
@@ -19,7 +19,6 @@ export function useNotes(
   return useQuery({
     ...getNotesOptions({ path: { note_chain_id: noteChainId ?? '' } }),
     enabled: isAuthenticated && enabled && !!noteChainId,
-    placeholderData: [],
   });
 }
 

--- a/frontend/src/pages/driver/route/components/NoteCard.tsx
+++ b/frontend/src/pages/driver/route/components/NoteCard.tsx
@@ -34,7 +34,7 @@ export function NoteCard({
   const date = formatNoteDate(note.created_at);
 
   return (
-    <article className="relative flex flex-col gap-2 rounded-xl bg-white px-4 py-3">
+    <article className="relative flex flex-col gap-2 px-4 py-3">
       <div className={canManage ? 'pr-7' : undefined}>
         <p className="text-p2 text-grey-500 min-w-0">
           <span className="text-grey-400 font-semibold">{author}</span>

--- a/frontend/src/pages/driver/route/components/NoteFormModal.tsx
+++ b/frontend/src/pages/driver/route/components/NoteFormModal.tsx
@@ -112,6 +112,22 @@ function NoteForm({
     trimmed.length > 0 && trimmed.length <= NOTE_MESSAGE_MAX && !busy;
   const isOverCharThreshold = message.length >= NOTE_MESSAGE_MAX * 0.8;
 
+  // Creating shows what you have staged; editing shows what the note already
+  // carries. Editing used to show nothing at all, which read as "my images are
+  // gone" even though the update only ever touches the message.
+  const shownImages =
+    mode === 'edit'
+      ? (note?.attachments ?? []).map((attachment) => ({
+          key: attachment.filename,
+          src: attachment.url,
+          removable: false,
+        }))
+      : images.map((image) => ({
+          key: image.previewUrl,
+          src: image.previewUrl,
+          removable: true,
+        }));
+
   const handleFilesSelected = (event: React.ChangeEvent<HTMLInputElement>) => {
     const files = Array.from(event.target.files ?? []);
     event.target.value = '';
@@ -199,7 +215,7 @@ function NoteForm({
     >
       <ModalHeader className="shrink-0">
         <ModalTitle variant="form">
-          {mode === 'edit' ? 'Edit note' : 'Announcements'}
+          {mode === 'edit' ? 'Edit note' : 'Add note'}
         </ModalTitle>
       </ModalHeader>
 
@@ -233,24 +249,26 @@ function NoteForm({
               )}
             />
 
-            {mode === 'create' && images.length > 0 && (
+            {shownImages.length > 0 && (
               <div className="flex flex-wrap gap-2 px-3 pt-2 pr-4 pb-3">
-                {images.map((image) => (
-                  <div
-                    key={image.previewUrl}
-                    className="relative size-16 shrink-0"
-                  >
+                {shownImages.map((image) => (
+                  <div key={image.key} className="relative size-16 shrink-0">
                     <div className="border-grey-300 size-full overflow-hidden rounded-lg border">
                       <img
-                        src={image.previewUrl}
+                        src={image.src}
                         alt=""
                         className="size-full object-cover"
                       />
                     </div>
-                    <RemoveImageButton
-                      disabled={busy}
-                      onClick={() => removeImage(image.previewUrl)}
-                    />
+                    {/* Only staged images can be taken back out. An edit can
+                        change the message and nothing else, so the note's
+                        existing images are shown but not removable. */}
+                    {image.removable && (
+                      <RemoveImageButton
+                        disabled={busy}
+                        onClick={() => removeImage(image.key)}
+                      />
+                    )}
                   </div>
                 ))}
               </div>
@@ -266,6 +284,12 @@ function NoteForm({
             {mode === 'create' && (
               <p>
                 {images.length}/{NOTE_IMAGE_MAX} images
+              </p>
+            )}
+            {mode === 'edit' && shownImages.length > 0 && (
+              <p>
+                {shownImages.length}{' '}
+                {shownImages.length === 1 ? 'image' : 'images'}
               </p>
             )}
           </div>

--- a/frontend/src/pages/driver/route/components/StopContactSection.tsx
+++ b/frontend/src/pages/driver/route/components/StopContactSection.tsx
@@ -1,7 +1,6 @@
 import type { RouteStopDetailRead } from '@/api/generated/types.gen';
 import PhoneIcon from '@/assets/icons/phone.svg?react';
 import { Button } from '@/common/components';
-import { cn } from '@/lib/utils';
 
 import { formatPhoneDisplay, telHref } from './noteUtils';
 
@@ -15,19 +14,9 @@ interface ContactCardProps {
   phone: string;
 }
 
-// Full width on mobile, but capped from tablet up. The design fixes these at
-// ~310px on both the 834 and 1440 frames rather than letting a phone number
-// stretch the whole content column with dead space before the call button.
-const CONTACT_CARD_WIDTH = 'tablet:max-w-[310px]';
-
 function ContactCard({ name, label, phone }: ContactCardProps) {
   return (
-    <div
-      className={cn(
-        'border-grey-300 flex items-center gap-3 rounded-xl border bg-white p-3',
-        CONTACT_CARD_WIDTH
-      )}
-    >
+    <div className="border-grey-300 flex items-center gap-3 rounded-xl border bg-white p-3">
       <div className="flex min-w-0 flex-1 flex-col">
         <p className="text-p1 text-grey-500 font-semibold break-words">
           {name} <span className="text-grey-400 font-normal">({label})</span>

--- a/frontend/src/pages/driver/route/components/StopContactSection.tsx
+++ b/frontend/src/pages/driver/route/components/StopContactSection.tsx
@@ -1,6 +1,7 @@
 import type { RouteStopDetailRead } from '@/api/generated/types.gen';
 import PhoneIcon from '@/assets/icons/phone.svg?react';
 import { Button } from '@/common/components';
+import { cn } from '@/lib/utils';
 
 import { formatPhoneDisplay, telHref } from './noteUtils';
 
@@ -14,9 +15,19 @@ interface ContactCardProps {
   phone: string;
 }
 
+// Full width on mobile, but capped from tablet up. The design fixes these at
+// ~310px on both the 834 and 1440 frames rather than letting a phone number
+// stretch the whole content column with dead space before the call button.
+const CONTACT_CARD_WIDTH = 'tablet:max-w-[310px]';
+
 function ContactCard({ name, label, phone }: ContactCardProps) {
   return (
-    <div className="border-grey-300 flex items-center gap-3 rounded-xl border bg-white p-3">
+    <div
+      className={cn(
+        'border-grey-300 flex items-center gap-3 rounded-xl border bg-white p-3',
+        CONTACT_CARD_WIDTH
+      )}
+    >
       <div className="flex min-w-0 flex-1 flex-col">
         <p className="text-p1 text-grey-500 font-semibold break-words">
           {name} <span className="text-grey-400 font-normal">({label})</span>

--- a/frontend/src/pages/driver/route/components/StopNotesSection.tsx
+++ b/frontend/src/pages/driver/route/components/StopNotesSection.tsx
@@ -10,6 +10,7 @@ import {
   useUpdateNote,
 } from '@/api/notes';
 import { Button, Spinner } from '@/common/components';
+import { cn } from '@/lib/utils';
 
 import { NoteCard } from './NoteCard';
 import { NoteDeleteConfirmModal } from './NoteDeleteConfirmModal';
@@ -145,9 +146,16 @@ export function StopNotesSection({
 
       {/* One card holds the whole thread plus the compose button, with the
           notes hairline-separated inside it. The notes are one conversation
-          about this stop, not a stack of unrelated cards. */}
+          about this stop, not a stack of unrelated cards. With no notes there
+          is no thread to hold, and the card collapses to a white ring around
+          the button. */}
       {!isLoading && (
-        <div className="flex flex-col rounded-xl bg-white p-2">
+        <div
+          className={cn(
+            'flex flex-col',
+            notes.length > 0 && 'rounded-xl bg-white p-2'
+          )}
+        >
           {notes.map((note, index) => (
             <div
               key={note.note_id}

--- a/frontend/src/pages/driver/route/components/StopNotesSection.tsx
+++ b/frontend/src/pages/driver/route/components/StopNotesSection.tsx
@@ -143,24 +143,31 @@ export function StopNotesSection({
         <p className="text-p2 text-grey-400">No notes yet.</p>
       )}
 
-      {!isLoading && notes.length > 0 && (
-        <div className="flex flex-col gap-2">
-          {notes.map((note) => (
-            <NoteCard
+      {/* One card holds the whole thread plus the compose button, with the
+          notes hairline-separated inside it. The notes are one conversation
+          about this stop, not a stack of unrelated cards. */}
+      {!isLoading && (
+        <div className="flex flex-col rounded-xl bg-white p-2">
+          {notes.map((note, index) => (
+            <div
               key={note.note_id}
-              note={note}
-              currentUserId={currentUserId}
-              canManage={canManageNote(note, currentUserId, role)}
-              onEdit={openEdit}
-              onDelete={openDelete}
-            />
+              className={index > 0 ? 'border-grey-200 border-t' : undefined}
+            >
+              <NoteCard
+                note={note}
+                currentUserId={currentUserId}
+                canManage={canManageNote(note, currentUserId, role)}
+                onEdit={openEdit}
+                onDelete={openDelete}
+              />
+            </div>
           ))}
+
+          <Button type="button" className="w-full" onClick={openCreate}>
+            Add note
+          </Button>
         </div>
       )}
-
-      <Button type="button" className="w-full" onClick={openCreate}>
-        Add note
-      </Button>
 
       <NoteFormModal
         open={formOpen}

--- a/frontend/src/pages/driver/route/components/noteUtils.ts
+++ b/frontend/src/pages/driver/route/components/noteUtils.ts
@@ -15,10 +15,15 @@ export function formatNoteDate(isoDate: string | null | undefined): string {
 
 export function noteAuthorLabel(note: NoteRead, currentUserId: string): string {
   if (note.is_system) return 'System';
+
+  const name = note.author_name?.trim();
+  // Your own notes still show your name, with "(You)" only as a marker — the
+  // design labels them "Andy Mayback (You)". A bare "You" reads as a different
+  // kind of author from every other row in the thread.
   if (note.user_id && note.user_id === currentUserId) {
-    return 'You';
+    return name ? `${name} (You)` : 'You';
   }
-  return note.author_name?.trim() || 'Unknown';
+  return name || 'Unknown';
 }
 
 export function canManageNote(


### PR DESCRIPTION
Follow-up to #236, fixing the nits found during the design-overlay review. All of it is verified live in the browser at 1440.

### Design
- **Notes are one card, not a stack.** The 834 and 1440 frames both show a single white card per stop holding the whole thread, notes separated by a hairline, with the blue **Add note** button *inside* the card. Previously each note was its own card and the button sat below them. `NoteCard` no longer draws its own chrome; `StopNotesSection` supplies the card.
- **Contact cards fill the content column at every width.** They line up with the notes card above them instead of stopping short. (I first capped them at ~310px to match the frame's measured width; Colin's call is full-width, same as mobile.)

### Behaviour
- **`Name (You)` instead of a bare `You`.** The design labels your own notes "Andy Mayback (You)"; a bare "You" read as a different kind of author from every other row.
- **The edit modal shows the note's existing images.** It previously showed nothing, which read as "my images are gone" even though an edit only ever touches the message. They are shown read-only (no remove button) because `NoteUpdate` carries only `message` — the update endpoint can't change attachments. There is no edit-note frame in Figma to follow; the ✕ badges exist only on the Add-note frames.
- **`placeholderData: []` removed from `useNotes` and `useAnnouncements`.** It pinned `isLoading` to `false` forever, so the spinner was dead code and "No notes yet." flashed before the real data arrived. `AnnouncementsPanel` had the same latent bug.
- **The create-note modal was titled "Announcements".** It now says "Add note", which is what the `Add Note` frames are titled.

### Verified
`tsc --noEmit` and `eslint src` clean. Checked in the browser against the design overlay at 1440: one card with hairline dividers and the button inside, contact card full-width and flush with the notes card, `Jeff Vasquez (You) • Aug 15` on a note I authored, and an uploaded image reappearing in the edit modal with a "1 image" count.
