### PR TITLE
Send the Forbidden page's Log in button to /login

### DIFF
--- a/frontend/src/common/components/ErrorScreen.tsx
+++ b/frontend/src/common/components/ErrorScreen.tsx
@@ -63,8 +63,7 @@ export function ForbiddenPage() {
         This page is only available to authorized users. Please log in to
         continue.
       </p>
-      {/* TODO: replace '/' with login route */}
-      <Button variant="primary" onClick={() => navigate('/')}>
+      <Button variant="primary" onClick={() => navigate('/login')}>
         Log in
       </Button>
     </ErrorScreen>


### PR DESCRIPTION
## Summary

`ForbiddenPage` in `frontend/src/common/components/ErrorScreen.tsx` navigated to `/` with a `TODO: replace '/' with login route` comment. The login route already exists — `App.tsx` registers `<Route path="/login" element={<LoginPage />} />`.

Today the button lands in the right place only by chance: `/` redirects to `/admin/home`, which bounces a logged-out user to `/login`. That breaks the moment the root redirect changes. This points the button straight at `/login` and drops the TODO.

## Other `navigate('/')` call sites

Both remaining instances genuinely mean "go home" and are left alone:

- `LoginPage.tsx:58` — after a successful login.
- `CreatePassword.tsx:94` — the "Continue" button after account creation; `useRegisterDriver` calls `setAuthFromRegister`, so the driver is already authenticated at that point.

## Verification

From `frontend/`, all green:

- `pnpm exec tsc -b --noEmit`
- `pnpm exec eslint src --max-warnings=0`
- `pnpm exec prettier --check "src/**/*.{ts,tsx,json,css,md}"`
- `pnpm exec vitest run` — 55 tests passed (2 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)