### PR TITLE
Make GET /system-settings fail loudly on a missing row

### DIFF
--- a/backend/python/app/models/location.py
+++ b/backend/python/app/models/location.py
@@ -64,16 +64,11 @@ class LocationBase(SQLModel):
     @field_validator("phone_primary", "phone_secondary")
     @classmethod
     def validate_phones(cls, v: str | None) -> str | None:
-        """Normalize to RFC 3966, as Driver and Admin do.
+        """Normalize to RFC 3966, as Driver and Admin do — POST/PATCH
+        /locations would otherwise store whatever the client sent.
 
-        The import path normalizes before it ever builds a Location, but
-        POST /locations and PATCH /locations/{id} do not — without this they
-        store whatever the client sent, and the Addresses table then shows one
-        household's number formatted and the next one raw.
-
-        Note this is *not* the import's validation gate: an invalid number
-        there is reported as an INVALID_PHONE_NUMBER alert on the review screen
-        (see LocationImportEntry, which deliberately does not inherit this).
+        Not the import's validation gate: LocationImportEntry deliberately
+        doesn't inherit this, so it can report an INVALID_PHONE_NUMBER alert.
         """
         if v is None:
             return None

--- a/backend/python/app/models/system_settings.py
+++ b/backend/python/app/models/system_settings.py
@@ -135,12 +135,8 @@ class SystemSettingsRead(SystemSettingsBase):
 
 
 class OrgContactRead(SQLModel):
-    """The slice of system settings readable without a token (see
-    ``GET /system-settings/contact``).
-
-    Enumerates its fields rather than filtering ``SystemSettingsRead``, so a
-    new settings column can't widen the public surface by accident.
-    """
+    """Smaller response object for callers that shouldn't see all settings
+    (driver screens, error pages)."""
 
     contact_name: str | None
     contact_phone: str | None

--- a/backend/python/app/routers/system_settings_routes.py
+++ b/backend/python/app/routers/system_settings_routes.py
@@ -29,12 +29,8 @@ async def get_system_settings(
     ),
     _auth: bool = Depends(require_admin),
 ) -> SystemSettingsRead:
-    """Return the singleton system settings row.
-
-    Never null — ``ensure_settings`` creates it at startup, and PATCH already
-    raises on a missing row, so a soft read here would mean a blank form that
-    every save rejects.
-    """
+    """Return the singleton settings row. Never null — PATCH already raises on
+    a missing row, so a soft read here would mean an unsaveable blank form."""
     settings = await system_settings_service.require_settings(session)
     return SystemSettingsRead.model_validate(settings)
 
@@ -46,14 +42,8 @@ async def get_org_contact(
         get_system_settings_service
     ),
 ) -> OrgContactRead:
-    """Return the org's point of contact — name and phone — to any caller.
-
-    The only unauthenticated route here, because neither consumer can present
-    an admin token: the driver route screen's "Call Food4Kids" button, and the
-    catch-all error page, which renders for logged-out visitors. These are the
-    org's published contact details, not member data; everything else on the
-    settings row stays behind ``require_admin``.
-    """
+    """The org's name and phone. Unauthenticated — the error page renders for
+    logged-out visitors, and these are published details, not member data."""
     settings = await system_settings_service.require_settings(session)
     return OrgContactRead.model_validate(settings)
 

--- a/backend/python/app/routers/system_settings_routes.py
+++ b/backend/python/app/routers/system_settings_routes.py
@@ -31,10 +31,9 @@ async def get_system_settings(
 ) -> SystemSettingsRead:
     """Return the singleton system settings row.
 
-    Never null: ``ensure_settings`` creates the row at startup, so a missing one
-    is a broken deployment. This used to answer 200-with-null while its own
-    PATCH — which goes through ``require_settings`` — raised on the same state,
-    so the Settings page would render a blank form that could not be saved.
+    Never null — ``ensure_settings`` creates it at startup, and PATCH already
+    raises on a missing row, so a soft read here would mean a blank form that
+    every save rejects.
     """
     settings = await system_settings_service.require_settings(session)
     return SystemSettingsRead.model_validate(settings)

--- a/backend/python/app/routers/system_settings_routes.py
+++ b/backend/python/app/routers/system_settings_routes.py
@@ -21,17 +21,23 @@ from app.services.jobs import refresh_daily_reminder_email_schedule
 router = APIRouter(prefix="/system-settings", tags=["system-settings"])
 
 
-@router.get("/", response_model=SystemSettingsRead | None)
+@router.get("/", response_model=SystemSettingsRead)
 async def get_system_settings(
     session: AsyncSession = Depends(get_session),
     system_settings_service: SystemSettingsService = Depends(
         get_system_settings_service
     ),
     _auth: bool = Depends(require_admin),
-) -> SystemSettingsRead | None:
-    """Return the singleton system settings row, or null if none has been created."""
-    settings = await system_settings_service.get_settings(session)
-    return SystemSettingsRead.model_validate(settings) if settings else None
+) -> SystemSettingsRead:
+    """Return the singleton system settings row.
+
+    Never null: ``ensure_settings`` creates the row at startup, so a missing one
+    is a broken deployment. This used to answer 200-with-null while its own
+    PATCH — which goes through ``require_settings`` — raised on the same state,
+    so the Settings page would render a blank form that could not be saved.
+    """
+    settings = await system_settings_service.require_settings(session)
+    return SystemSettingsRead.model_validate(settings)
 
 
 @router.get("/contact", response_model=OrgContactRead)

--- a/backend/python/app/utilities/utils.py
+++ b/backend/python/app/utilities/utils.py
@@ -15,12 +15,8 @@ MAX_STORED_PHONE_LENGTH = 32
 def validate_phone(v: str) -> str:
     """Normalize a phone number to RFC 3966 (``tel:+1-519-576-3443;ext=1``).
 
-    RFC 3966 rather than E.164 because E.164 has no extension field: it parses
-    ``(519) 576-3443 Ext. 1`` happily and then drops the ``Ext. 1`` on the way
-    out. F4K's own contact number has an extension, and school delivery
-    locations routinely do, so silently truncating to the switchboard sends a
-    driver to the wrong line with nothing raised. The stored value doubles as
-    the ``tel:`` URI a call button needs.
+    RFC 3966 rather than E.164 because E.164 silently drops extensions, and
+    F4K's number has one. Doubles as the ``tel:`` URI a call button needs.
     """
     try:
         parsed_phone = phonenumbers.parse(v, "CA")

--- a/backend/python/tests/test_auth_integration.py
+++ b/backend/python/tests/test_auth_integration.py
@@ -141,8 +141,7 @@ ROUTE_POLICIES: dict[tuple[str, str], Policy] = {
     ("DELETE", "/locations/{location_id}"): Policy.ADMIN_ONLY,
     # --- system settings ---
     ("GET", "/system-settings/"): Policy.ADMIN_ONLY,
-    # Public by design: the error page renders for logged-out visitors. Scoped
-    # to contact_name/contact_phone by OrgContactRead.
+    # Public by design; scoped to name/phone by OrgContactRead.
     ("GET", "/system-settings/contact"): Policy.PUBLIC,
     # --- reports ---
     ("GET", "/reports/deliveries/count"): Policy.ADMIN_ONLY,

--- a/backend/python/tests/test_org_contact_route.py
+++ b/backend/python/tests/test_org_contact_route.py
@@ -1,8 +1,7 @@
-"""The auth split on ``/system-settings``: ``/contact`` is public, the rest is not.
+"""``/system-settings/contact`` is public, the rest of the router isn't.
 
-``conftest.py``'s client fixtures stub ``require_admin`` to a no-op, which would
-make a gated route indistinguishable from a public one — so these tests build
-their own app with only the session overridden, and send no token.
+conftest's client fixtures stub out require_admin, so these build their own app
+and send no token.
 """
 
 from collections.abc import AsyncGenerator
@@ -50,12 +49,8 @@ async def settings_row(test_session: AsyncSession) -> Any:
 async def _set_contact(
     session: AsyncSession, settings: SystemSettings, **fields: Any
 ) -> None:
-    """Write contact fields the way a PATCH would.
-
-    A ``table=True`` SQLModel skips validation on assignment, so the value goes
-    through ``SystemSettingsUpdate`` to get the RFC 3966 normalization
-    production applies.
-    """
+    """Write contact fields the way a PATCH would — a table=True SQLModel skips
+    validation on assignment, so the RFC 3966 normalization needs forcing."""
     validated = SystemSettingsUpdate(**fields)
     for key in fields:
         setattr(settings, key, getattr(validated, key))
@@ -95,8 +90,7 @@ async def test_contact_readable_without_a_token(
 async def test_contact_exposes_only_name_and_phone(
     anonymous_client: AsyncClient, test_session: AsyncSession, settings_row: Any
 ) -> None:
-    """The guard that matters: warehouse coords and column maps live on the
-    same row, and none of it may reach an unauthenticated caller."""
+    """Warehouse coords and column maps are on the same row and must not leak."""
     settings_row.warehouse_location = "50 Sportsworld Crossing Rd, Kitchener"
     settings_row.warehouse_latitude = 43.4123
     settings_row.warehouse_longitude = -80.4567
@@ -153,11 +147,7 @@ async def test_contact_returns_phone_without_name(
 async def test_contact_missing_settings_row_is_a_server_error(
     anonymous_client: AsyncClient,
 ) -> None:
-    """No ``settings_row`` fixture, so the startup invariant is broken.
-
-    ``require_settings`` raises rather than inventing an empty contact, so this
-    500s instead of claiming with a 200 that there is no phone number.
-    """
+    """No settings row: 500s rather than claiming there's no phone number."""
     response = await anonymous_client.get("/system-settings/contact")
 
     assert response.status_code == 500
@@ -173,8 +163,8 @@ async def test_contact_missing_settings_row_is_a_server_error(
 async def test_full_settings_still_requires_a_token(
     anonymous_client: AsyncClient,
 ) -> None:
-    """Same router, same tokenless client, refused — without this the tests
-    above would also pass if the router had simply lost its auth."""
+    """Refused — without this, the tests above would pass on a router that had
+    simply lost its auth."""
     response = await anonymous_client.get("/system-settings/")
 
     assert response.status_code == 401

--- a/backend/python/tests/test_routes.py
+++ b/backend/python/tests/test_routes.py
@@ -5831,22 +5831,17 @@ class TestSystemSettingsRoutes:
         body = response.json()
         assert body is not None
         assert body["system_settings_id"]
-        # Model defaults, from the row ensure_settings creates at startup.
-        assert body["boxes_per_car"] == 10
+        assert body["boxes_per_car"] == 10  # model defaults
         assert body["delivery_types"] == ["Family", "School"]
 
     @pytest.mark.asyncio
     async def test_get_system_settings_without_a_row_is_a_server_error(
         self, test_session: AsyncSession
     ) -> None:
-        """A missing row is a broken startup invariant, not a 200-with-null.
+        """A missing row is a broken invariant, not a 200-with-null.
 
-        The read and the write have to agree: ``update_settings`` already
-        raises via ``require_settings``, so answering null here would hand the
-        Settings page a blank form that every save rejects.
-
-        Built inline because ``async_client`` creates the row (mirroring
-        startup), which is exactly the state under test.
+        Built inline because ``async_client`` creates the row, which is the
+        state under test.
         """
         app = create_app()
 

--- a/backend/python/tests/test_routes.py
+++ b/backend/python/tests/test_routes.py
@@ -10,17 +10,24 @@ Tests cover:
 """
 
 import json
+from collections.abc import AsyncGenerator
 from datetime import date, datetime, time, timedelta, timezone
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import UUID, uuid4
 
 import pytest
-from httpx import AsyncClient
+from httpx import ASGITransport, AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.dependencies.auth import DriverAccess, require_self_driver_or_admin
+from app import create_app
+from app.dependencies.auth import (
+    DriverAccess,
+    require_admin,
+    require_self_driver_or_admin,
+)
 from app.dependencies.services import get_google_maps_client
+from app.models import get_session
 from app.models.enum import ProgressEnum, RouteStatusEnum
 from app.models.location import Location
 from app.models.location_group import LocationGroup
@@ -5817,9 +5824,43 @@ class TestSystemSettingsRoutes:
 
     @pytest.mark.asyncio
     async def test_get_system_settings(self, async_client: AsyncClient) -> None:
-        """GET /system-settings returns 200 (null-safe when unset)."""
+        """GET /system-settings returns the singleton row, never null."""
         response = await async_client.get("/system-settings/")
         assert response.status_code == 200
+
+        body = response.json()
+        assert body is not None
+        assert body["system_settings_id"]
+        # Model defaults, from the row ensure_settings creates at startup.
+        assert body["boxes_per_car"] == 10
+        assert body["delivery_types"] == ["Family", "School"]
+
+    @pytest.mark.asyncio
+    async def test_get_system_settings_without_a_row_is_a_server_error(
+        self, test_session: AsyncSession
+    ) -> None:
+        """A missing row is a broken startup invariant, not a 200-with-null.
+
+        The read and the write have to agree: ``update_settings`` already
+        raises via ``require_settings``, so answering null here would hand the
+        Settings page a blank form that every save rejects.
+
+        Built inline because ``async_client`` creates the row (mirroring
+        startup), which is exactly the state under test.
+        """
+        app = create_app()
+
+        async def _session() -> AsyncGenerator[AsyncSession, None]:
+            yield test_session
+
+        app.dependency_overrides[get_session] = _session
+        app.dependency_overrides[require_admin] = lambda: True
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            response = await ac.get("/system-settings/")
+
+        assert response.status_code == 500
 
     @pytest.mark.asyncio
     async def test_patch_system_settings(self, async_client: AsyncClient) -> None:

--- a/backend/python/tests/test_routes.py
+++ b/backend/python/tests/test_routes.py
@@ -5838,11 +5838,7 @@ class TestSystemSettingsRoutes:
     async def test_get_system_settings_without_a_row_is_a_server_error(
         self, test_session: AsyncSession
     ) -> None:
-        """A missing row is a broken invariant, not a 200-with-null.
-
-        Built inline because ``async_client`` creates the row, which is the
-        state under test.
-        """
+        """Built inline because async_client creates the row under test."""
         app = create_app()
 
         async def _session() -> AsyncGenerator[AsyncSession, None]:

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -7748,7 +7748,7 @@
     },
     "/system-settings/": {
       "get": {
-        "description": "Return the singleton system settings row.\n\nNever null: ``ensure_settings`` creates the row at startup, so a missing one\nis a broken deployment. This used to answer 200-with-null while its own\nPATCH — which goes through ``require_settings`` — raised on the same state,\nso the Settings page would render a blank form that could not be saved.",
+        "description": "Return the singleton system settings row.\n\nNever null — ``ensure_settings`` creates it at startup, and PATCH already\nraises on a missing row, so a soft read here would mean a blank form that\nevery save rejects.",
         "operationId": "get_system_settings",
         "responses": {
           "200": {

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -7748,22 +7748,14 @@
     },
     "/system-settings/": {
       "get": {
-        "description": "Return the singleton system settings row, or null if none has been created.",
+        "description": "Return the singleton system settings row.\n\nNever null: ``ensure_settings`` creates the row at startup, so a missing one\nis a broken deployment. This used to answer 200-with-null while its own\nPATCH — which goes through ``require_settings`` — raised on the same state,\nso the Settings page would render a blank form that could not be saved.",
         "operationId": "get_system_settings",
         "responses": {
           "200": {
             "content": {
               "application/json": {
                 "schema": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/components/schemas/SystemSettingsRead"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ],
-                  "title": "Response Get System Settings"
+                  "$ref": "#/components/schemas/SystemSettingsRead"
                 }
               }
             },

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -2579,7 +2579,7 @@
         "type": "object"
       },
       "OrgContactRead": {
-        "description": "The slice of system settings readable without a token (see\n``GET /system-settings/contact``).\n\nEnumerates its fields rather than filtering ``SystemSettingsRead``, so a\nnew settings column can't widen the public surface by accident.",
+        "description": "Smaller response object for callers that shouldn't see all settings\n(driver screens, error pages).",
         "properties": {
           "contact_name": {
             "anyOf": [
@@ -7748,7 +7748,7 @@
     },
     "/system-settings/": {
       "get": {
-        "description": "Return the singleton system settings row.\n\nNever null — ``ensure_settings`` creates it at startup, and PATCH already\nraises on a missing row, so a soft read here would mean a blank form that\nevery save rejects.",
+        "description": "Return the singleton settings row. Never null — PATCH already raises on\na missing row, so a soft read here would mean an unsaveable blank form.",
         "operationId": "get_system_settings",
         "responses": {
           "200": {
@@ -7820,7 +7820,7 @@
     },
     "/system-settings/contact": {
       "get": {
-        "description": "Return the org's point of contact — name and phone — to any caller.\n\nThe only unauthenticated route here, because neither consumer can present\nan admin token: the driver route screen's \"Call Food4Kids\" button, and the\ncatch-all error page, which renders for logged-out visitors. These are the\norg's published contact details, not member data; everything else on the\nsettings row stays behind ``require_admin``.",
+        "description": "The org's name and phone. Unauthenticated — the error page renders for\nlogged-out visitors, and these are published details, not member data.",
         "operationId": "get_org_contact",
         "responses": {
           "200": {

--- a/frontend/src/api/generated/@tanstack/react-query.gen.ts
+++ b/frontend/src/api/generated/@tanstack/react-query.gen.ts
@@ -2580,7 +2580,12 @@ export const getSystemSettingsQueryKey = (
 /**
  * Get System Settings
  *
- * Return the singleton system settings row, or null if none has been created.
+ * Return the singleton system settings row.
+ *
+ * Never null: ``ensure_settings`` creates the row at startup, so a missing one
+ * is a broken deployment. This used to answer 200-with-null while its own
+ * PATCH — which goes through ``require_settings`` — raised on the same state,
+ * so the Settings page would render a blank form that could not be saved.
  */
 export const getSystemSettingsOptions = (
   options?: Options<GetSystemSettingsData>

--- a/frontend/src/api/generated/@tanstack/react-query.gen.ts
+++ b/frontend/src/api/generated/@tanstack/react-query.gen.ts
@@ -2582,10 +2582,9 @@ export const getSystemSettingsQueryKey = (
  *
  * Return the singleton system settings row.
  *
- * Never null: ``ensure_settings`` creates the row at startup, so a missing one
- * is a broken deployment. This used to answer 200-with-null while its own
- * PATCH — which goes through ``require_settings`` — raised on the same state,
- * so the Settings page would render a blank form that could not be saved.
+ * Never null — ``ensure_settings`` creates it at startup, and PATCH already
+ * raises on a missing row, so a soft read here would mean a blank form that
+ * every save rejects.
  */
 export const getSystemSettingsOptions = (
   options?: Options<GetSystemSettingsData>

--- a/frontend/src/api/generated/@tanstack/react-query.gen.ts
+++ b/frontend/src/api/generated/@tanstack/react-query.gen.ts
@@ -2580,11 +2580,8 @@ export const getSystemSettingsQueryKey = (
 /**
  * Get System Settings
  *
- * Return the singleton system settings row.
- *
- * Never null — ``ensure_settings`` creates it at startup, and PATCH already
- * raises on a missing row, so a soft read here would mean a blank form that
- * every save rejects.
+ * Return the singleton settings row. Never null — PATCH already raises on
+ * a missing row, so a soft read here would mean an unsaveable blank form.
  */
 export const getSystemSettingsOptions = (
   options?: Options<GetSystemSettingsData>
@@ -2642,13 +2639,8 @@ export const getOrgContactQueryKey = (options?: Options<GetOrgContactData>) =>
 /**
  * Get Org Contact
  *
- * Return the org's point of contact — name and phone — to any caller.
- *
- * The only unauthenticated route here, because neither consumer can present
- * an admin token: the driver route screen's "Call Food4Kids" button, and the
- * catch-all error page, which renders for logged-out visitors. These are the
- * org's published contact details, not member data; everything else on the
- * settings row stays behind ``require_admin``.
+ * The org's name and phone. Unauthenticated — the error page renders for
+ * logged-out visitors, and these are published details, not member data.
  */
 export const getOrgContactOptions = (options?: Options<GetOrgContactData>) =>
   queryOptions<

--- a/frontend/src/api/generated/sdk.gen.ts
+++ b/frontend/src/api/generated/sdk.gen.ts
@@ -1564,11 +1564,8 @@ export const getSuggestedDriver = <ThrowOnError extends boolean = false>(
 /**
  * Get System Settings
  *
- * Return the singleton system settings row.
- *
- * Never null — ``ensure_settings`` creates it at startup, and PATCH already
- * raises on a missing row, so a soft read here would mean a blank form that
- * every save rejects.
+ * Return the singleton settings row. Never null — PATCH already raises on
+ * a missing row, so a soft read here would mean an unsaveable blank form.
  */
 export const getSystemSettings = <ThrowOnError extends boolean = false>(
   options?: Options<GetSystemSettingsData, ThrowOnError>
@@ -1610,13 +1607,8 @@ export const patchSystemSettings = <ThrowOnError extends boolean = false>(
 /**
  * Get Org Contact
  *
- * Return the org's point of contact — name and phone — to any caller.
- *
- * The only unauthenticated route here, because neither consumer can present
- * an admin token: the driver route screen's "Call Food4Kids" button, and the
- * catch-all error page, which renders for logged-out visitors. These are the
- * org's published contact details, not member data; everything else on the
- * settings row stays behind ``require_admin``.
+ * The org's name and phone. Unauthenticated — the error page renders for
+ * logged-out visitors, and these are published details, not member data.
  */
 export const getOrgContact = <ThrowOnError extends boolean = false>(
   options?: Options<GetOrgContactData, ThrowOnError>

--- a/frontend/src/api/generated/sdk.gen.ts
+++ b/frontend/src/api/generated/sdk.gen.ts
@@ -1566,10 +1566,9 @@ export const getSuggestedDriver = <ThrowOnError extends boolean = false>(
  *
  * Return the singleton system settings row.
  *
- * Never null: ``ensure_settings`` creates the row at startup, so a missing one
- * is a broken deployment. This used to answer 200-with-null while its own
- * PATCH — which goes through ``require_settings`` — raised on the same state,
- * so the Settings page would render a blank form that could not be saved.
+ * Never null — ``ensure_settings`` creates it at startup, and PATCH already
+ * raises on a missing row, so a soft read here would mean a blank form that
+ * every save rejects.
  */
 export const getSystemSettings = <ThrowOnError extends boolean = false>(
   options?: Options<GetSystemSettingsData, ThrowOnError>

--- a/frontend/src/api/generated/sdk.gen.ts
+++ b/frontend/src/api/generated/sdk.gen.ts
@@ -1564,7 +1564,12 @@ export const getSuggestedDriver = <ThrowOnError extends boolean = false>(
 /**
  * Get System Settings
  *
- * Return the singleton system settings row, or null if none has been created.
+ * Return the singleton system settings row.
+ *
+ * Never null: ``ensure_settings`` creates the row at startup, so a missing one
+ * is a broken deployment. This used to answer 200-with-null while its own
+ * PATCH — which goes through ``require_settings`` — raised on the same state,
+ * so the Settings page would render a blank form that could not be saved.
  */
 export const getSystemSettings = <ThrowOnError extends boolean = false>(
   options?: Options<GetSystemSettingsData, ThrowOnError>

--- a/frontend/src/api/generated/types.gen.ts
+++ b/frontend/src/api/generated/types.gen.ts
@@ -1471,11 +1471,8 @@ export type NoteUpdate = {
 /**
  * OrgContactRead
  *
- * The slice of system settings readable without a token (see
- * ``GET /system-settings/contact``).
- *
- * Enumerates its fields rather than filtering ``SystemSettingsRead``, so a
- * new settings column can't widen the public surface by accident.
+ * Smaller response object for callers that shouldn't see all settings
+ * (driver screens, error pages).
  */
 export type OrgContactRead = {
   /**

--- a/frontend/src/api/generated/types.gen.ts
+++ b/frontend/src/api/generated/types.gen.ts
@@ -4700,11 +4700,9 @@ export type GetSystemSettingsData = {
 
 export type GetSystemSettingsResponses = {
   /**
-   * Response Get System Settings
-   *
    * Successful Response
    */
-  200: SystemSettingsRead | null;
+  200: SystemSettingsRead;
 };
 
 export type GetSystemSettingsResponse =

--- a/frontend/src/api/system-settings.ts
+++ b/frontend/src/api/system-settings.ts
@@ -18,11 +18,11 @@ export function useSystemSettings() {
 }
 
 /**
- * The org's point of contact. Separate from {@link useSystemSettings} because
- * its endpoint is unauthenticated — that one would 401 for both callers.
+ * The org's name and phone, from the public endpoint — {@link useSystemSettings}
+ * would 401 for driver screens and the error page.
  *
- * `contact_phone` is RFC 3966, i.e. already a valid `href`. Pass it through
- * untouched for links, and through `formatPhone` for anything a reader sees.
+ * `contact_phone` is RFC 3966: already a valid `href`, use `formatPhone` to
+ * display it.
  */
 export function useOrgContact() {
   return useQuery(getOrgContactOptions());

--- a/frontend/src/api/system-settings.ts
+++ b/frontend/src/api/system-settings.ts
@@ -6,8 +6,7 @@ import {
 } from './generated/@tanstack/react-query.gen';
 import type { SystemSettingsRead } from './generated/types.gen';
 
-// `undefined` only — while the query is in flight. The API no longer answers
-// null: a missing settings row is a broken deployment and fails the request.
+// `undefined` only — the in-flight state. The API no longer answers null.
 export function getConfiguredDeliveryTypes(
   settings: SystemSettingsRead | undefined
 ) {

--- a/frontend/src/api/system-settings.ts
+++ b/frontend/src/api/system-settings.ts
@@ -6,8 +6,10 @@ import {
 } from './generated/@tanstack/react-query.gen';
 import type { SystemSettingsRead } from './generated/types.gen';
 
+// `undefined` only — while the query is in flight. The API no longer answers
+// null: a missing settings row is a broken deployment and fails the request.
 export function getConfiguredDeliveryTypes(
-  settings: SystemSettingsRead | null | undefined
+  settings: SystemSettingsRead | undefined
 ) {
   return settings?.delivery_types ?? [];
 }

--- a/frontend/src/common/components/ErrorScreen.contact.test.ts
+++ b/frontend/src/common/components/ErrorScreen.contact.test.ts
@@ -2,11 +2,8 @@ import { describe, expect, it } from 'vitest';
 
 import { contactSentence } from './ErrorScreen.contact';
 
-/**
- * Every name/phone × set/unset/undefined combination is reachable, and each
- * must stay grammatical. The failure guarded against is the literal
- * "contact  at  for help." a naive template would produce.
- */
+// Every name/phone combination is reachable and each must stay grammatical —
+// the failure guarded against is a literal "contact  at  for help."
 describe('contactSentence', () => {
   it('names the contact and their number when both are configured', () => {
     expect(contactSentence('Emily Loro', 'tel:+1-519-576-3443')).toBe(
@@ -65,8 +62,7 @@ describe('contactSentence', () => {
   });
 
   it('never leaks a raw tel: URI into the sentence', () => {
-    // A non-NANP number is storable and has no design, but must not surface
-    // as a raw "tel:" URI. Pins that the copy goes through formatPhone.
+    // Storable, no design for it, but must not surface as a raw "tel:" URI.
     expect(contactSentence(null, 'tel:+44-20-7946-0958')).toBe(
       'If the issue persists, call +44 20 7946 0958 for help.'
     );

--- a/frontend/src/common/components/ErrorScreen.contact.ts
+++ b/frontend/src/common/components/ErrorScreen.contact.ts
@@ -1,25 +1,18 @@
 import { formatPhone } from '@/common/utils/phoneUtils';
 
 /**
- * Build the "if this keeps happening, call someone" half of the catch-all
- * error message.
+ * The "if it keeps happening, call someone" line, or `null` if there's no one
+ * to name. Both fields are independently nullable, so all four combinations
+ * have to stay grammatical.
  *
- * Both fields are independently nullable and the page renders before the query
- * resolves, so all four combinations are reachable and each needs to stay
- * grammatical — hence a function rather than an inline template that would
- * produce "contact  at  for help."
- *
- * Split out of `ErrorScreen.tsx` (cf. `Button.variants.ts`) because mixing
- * component and non-component exports breaks Fast Refresh.
- *
- * @returns the sentence, or `null` when there is no contact to name.
+ * Its own file because mixing component and non-component exports breaks Fast
+ * Refresh (cf. `Button.variants.ts`).
  */
 export function contactSentence(
   name: string | null | undefined,
   phone: string | null | undefined
 ): string | null {
   const who = name?.trim() || null;
-  // The stored value is RFC 3966; readers get the design's (519) 576-3443 form.
   const number = phone ? formatPhone(phone) : null;
 
   if (who && number)

--- a/frontend/src/common/utils/phoneUtils.ts
+++ b/frontend/src/common/utils/phoneUtils.ts
@@ -1,24 +1,10 @@
 /**
- * Render a stored phone number the way the designs show it.
+ * Render a stored RFC 3966 number the way the designs show it: `(519) 576-3443`.
  *
- * The API stores RFC 3966 — `tel:+1-519-576-3443` or, with an extension,
- * `tel:+1-519-576-3443;ext=1`. Figma shows `(519) 576-3443`, so every screen
- * that displays a number formats it here rather than printing the raw column.
- *
- * North American numbers get the designed form. A number with an explicit
- * non-NANP country code is still storable — `validate_phone` parses with region
- * "CA", but `phonenumbers` ignores that default whenever the input already
- * carries a country code, so `+44 20 7946 0958` validates and stores as
- * `tel:+44-20-7946-0958`. There is no design for that case; it at least must
- * not leak a raw `tel:` URI into the UI, so it renders as the plain
- * international number.
- *
- * A value matching neither shape is returned untouched rather than throwing,
- * because one screen legitimately shows unnormalized values: the import
- * Validate step keeps a row's raw spreadsheet text when the number fails
- * validation, so the admin can see what they typed and fix it. Those cells are
- * already flagged red with an "Invalid Phone Number" alert — reformatting or
- * hiding them would be worse.
+ * Non-NANP numbers are storable but have no design, so they render as a plain
+ * international number. Anything unrecognized is returned untouched — the
+ * import Validate step shows raw spreadsheet text for numbers that failed
+ * validation, already flagged red.
  */
 const NANP = /^tel:\+1-(\d{3})-(\d{3})-(\d{4})(?:;ext=(\d+))?$/;
 const INTERNATIONAL = /^tel:(\+\d[\d-]*)(?:;ext=(\d+))?$/;

--- a/frontend/src/pages/driver/route/components/RouteDetailView.tsx
+++ b/frontend/src/pages/driver/route/components/RouteDetailView.tsx
@@ -48,8 +48,7 @@ function formatStartTime(value: string | null | undefined): string | null {
 
 export function RouteDetailView({ routeId, className }: RouteDetailViewProps) {
   const { data: route, isLoading, isError } = useRoute(routeId);
-  // Deliberately outside the loading/error gate below — a slow contact lookup
-  // shouldn't keep a driver from their stops.
+  // Outside the loading gate below — a slow lookup shouldn't block the stops.
   const { data: orgContact } = useOrgContact();
   const contactPhone = orgContact?.contact_phone;
   const [mapsLoading, setMapsLoading] = useState(false);
@@ -180,8 +179,7 @@ export function RouteDetailView({ routeId, className }: RouteDetailViewProps) {
           className="desktop:h-[408px] tablet:h-[270px] h-[182px]"
         />
         <div className="grid grid-cols-2 gap-3">
-          {/* RFC 3966, so the stored value is already the href. With none
-              configured, a disabled button beats a link to nowhere. */}
+          {/* Stored RFC 3966, so it's already the href. */}
           {contactPhone ? (
             <Button asChild variant="secondary" className="tablet:w-full">
               <a href={contactPhone}>Call Food4Kids</a>


### PR DESCRIPTION
Follow-up to #272, which surfaced this: `GET /system-settings/` treated a missing settings row as a soft case (`get_settings` → `None` → `SystemSettingsRead | None`), while `/contact` treated the identical condition as a hard failure.

The interesting divergence turned out not to be between those two endpoints, but **between `GET /` and its own `PATCH`**. `update_settings` already goes through `require_settings` and raises. So on a missing row today, the read succeeds with null and every write 500s — the Settings page renders a blank form that cannot be saved. Soft read, hard write, same resource.

Two more things pointed the same way:

- `GET /` was the last route-level `get_settings()` caller. `update_settings`, `rename_delivery_type`, `location_service` and `/contact` all use `require_settings`, whose docstring already claims *"every other code path can treat its existence as a given — fail loudly rather than silently substituting fallback config."*
- The null branch had no test coverage. `conftest`'s `_ensure_system_settings` creates the row for every `async_client` test, and `test_get_system_settings` only asserted `200`, despite a docstring reading "null-safe when unset".

So this deletes the exemption rather than documenting it: `GET /` uses `require_settings`, and `| None` comes off the response model. `get_settings()` is now reachable only through its two accessors (`ensure_settings`, `require_settings`), which is where the None handling belongs.

## Testing

- `test_get_system_settings` now asserts the actual payload (id present, model defaults) instead of just a status code.
- New `test_get_system_settings_without_a_row_is_a_server_error` drives the previously-uncovered case against an app built without the row-creating fixture.
- Full backend suite: 832 passed. Frontend: 64 passed, `tsc`/eslint/prettier clean, `ruff check` + `ruff format --check` + `mypy` clean.

## Frontend

The generated `200` response type stops being nullable, so `getConfiguredDeliveryTypes` takes `SystemSettingsRead | undefined` — `undefined` still covers the in-flight query, which is the only remaining absent state. No call site changes; all four already pass the hook's `data` straight through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
