### PR TITLE
[fix] add shared client-side telemetry + fix raw passwords being logged

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -58,6 +58,10 @@ export default [
       ],
       'simple-import-sort/imports': 'error',
       'simple-import-sort/exports': 'error',
+      // Console output can leave the device via Sentry, and an error object
+      // drags the request body with it (a login's is the password). Report
+      // through reportError() in src/lib/telemetry.ts.
+      'no-console': 'error',
       'import/first': 'error',
       'import/newline-after-import': 'error',
       'import/no-duplicates': 'error',
@@ -97,6 +101,12 @@ export default [
             'text-h1/h2/h3 and text-p1/p2/p3 are already responsive — don\'t add a tablet:/desktop: variant (it won\'t compose, since the utility has its own internal breakpoint). Use the bare utility, or a static text-m-* for a constant (non-responsive) size.',
         },
       ],
+    },
+  },
+  {
+    files: ['**/*.test.{ts,tsx}', 'emails/**/*.ts'],
+    rules: {
+      'no-console': 'off',
     },
   },
   prettier, // Must be last

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -33,9 +33,6 @@ export function useRegisterDriver() {
     onSuccess: (data) => {
       setAuthFromRegister(data);
     },
-    onError: (error) => {
-      console.error('Registration error:', error);
-    },
   });
 }
 
@@ -53,9 +50,6 @@ export function useLogin() {
     onSuccess: (data) => {
       setAuth(data);
     },
-    onError: (error) => {
-      console.error('Login error:', error);
-    },
   });
 }
 
@@ -70,7 +64,6 @@ export function useRefresh() {
         // token that aged out under an open tab restore the session identically.
         return await refreshSession();
       } catch (error) {
-        console.error('Session auto-refresh failed:', error);
         clearAuth();
         throw error;
       }
@@ -133,9 +126,6 @@ export function useLogout() {
     onSettled: () => {
       clearAuth();
       queryClient.clear();
-    },
-    onError: (error) => {
-      console.error('Logout error:', error);
     },
   });
 }

--- a/frontend/src/instrument.ts
+++ b/frontend/src/instrument.ts
@@ -7,10 +7,7 @@ if (import.meta.env.VITE_SENTRY_DSN) {
     integrations: [
       Sentry.browserTracingIntegration(),
       Sentry.replayIntegration(),
-      // Automatically capture console.log, console.warn, and console.error calls as Sentry logs
-      Sentry.consoleLoggingIntegration({ levels: ['log', 'warn', 'error'] }),
     ],
-    // Enable logs
     enableLogs: true,
 
     tracesSampleRate: 0.2,

--- a/frontend/src/lib/axiosClient.test.ts
+++ b/frontend/src/lib/axiosClient.test.ts
@@ -1,5 +1,5 @@
 import type { AxiosResponse, InternalAxiosRequestConfig } from 'axios';
-import { AxiosError } from 'axios';
+import { AxiosError, isAxiosError } from 'axios';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { useAuthStore } from '@/api/authStore';
@@ -549,5 +549,152 @@ describe('refreshing an aged-out token', () => {
 
     expect(refreshes()).toHaveLength(0);
     expect(useAuthStore.getState().accessToken).toBe('token-abc');
+  });
+});
+
+describe('errors reach callers without credentials', () => {
+  /**
+   * However a request fails, the error reaching application code must not
+   * carry `config.data` (a login's is the password) or the Authorization
+   * header — while the wire still saw the body, proving the scrub runs after
+   * the replay decision rather than before it.
+   */
+  type Reply = { status: number; body?: unknown };
+
+  const RENEWED: AuthResponse = {
+    access_token: 'token-xyz',
+    email: 'dana@example.com',
+    first_name: 'Dana',
+    full_name: 'Dana Bell',
+    id: 'user-1',
+    last_name: 'Bell',
+    remember_me: false,
+    role: 'Admin',
+  };
+
+  /** `config.data` captured at adapter time — the scrub must not reach back. */
+  let bodiesOnTheWire: unknown[] = [];
+
+  function serve(reply: (config: InternalAxiosRequestConfig) => Reply) {
+    axiosClient.defaults.adapter = async (config) => {
+      bodiesOnTheWire.push(config.data);
+      const answer = reply(config);
+      const response = {
+        data: answer.body ?? { detail: 'nope' },
+        status: answer.status,
+        statusText: answer.status < 400 ? 'OK' : 'Error',
+        headers: {},
+        config,
+      } as AxiosResponse;
+      if (answer.status >= 400) {
+        throw new AxiosError(
+          `Request failed with status code ${answer.status}`,
+          AxiosError.ERR_BAD_REQUEST,
+          config,
+          null,
+          response
+        );
+      }
+      return response;
+    };
+  }
+
+  const isRefresh = (config: InternalAxiosRequestConfig) =>
+    (config.url ?? '').endsWith('/auth/refresh');
+
+  const tokenOn = (config: InternalAxiosRequestConfig) =>
+    String(config.headers.Authorization ?? '');
+
+  function signedIn() {
+    useAuthStore.setState({
+      accessToken: 'token-abc',
+      user: null,
+      isAuthenticated: true,
+      isRestoringSession: false,
+      sessionExpired: false,
+    });
+  }
+
+  function attempt() {
+    return createLocationGroup({
+      body: { name: 'Tuesday A', location_ids: [] },
+      throwOnError: true,
+    });
+  }
+
+  async function attemptAndCatch(): Promise<unknown> {
+    try {
+      await attempt();
+    } catch (error) {
+      return error;
+    }
+    throw new Error('Expected the request to fail');
+  }
+
+  function expectScrubbed(error: unknown) {
+    if (!isAxiosError(error)) throw new Error('Expected an AxiosError');
+    expect(error.config?.data).toBeUndefined();
+    expect(error.config?.headers?.Authorization).toBeUndefined();
+    // Same object by reference, but pin the other path to it anyway.
+    expect(error.response?.config.data).toBeUndefined();
+  }
+
+  beforeEach(() => {
+    bodiesOnTheWire = [];
+    useAuthStore.getState().clearAuth();
+  });
+
+  afterEach(() => {
+    useAuthStore.getState().clearAuth();
+  });
+
+  it('scrubs a plain failure that carried a body and a token', async () => {
+    signedIn();
+    serve(() => ({ status: 500 }));
+
+    const error = await attemptAndCatch();
+
+    expect(bodiesOnTheWire[0]).toBeTruthy();
+    expectScrubbed(error);
+  });
+
+  it('scrubs the 401 handed back when the refresh is refused', async () => {
+    signedIn();
+    serve(() => ({ status: 401 }));
+
+    const error = await attemptAndCatch();
+
+    expectScrubbed(error);
+  });
+
+  it('scrubs a refused replay, which still went out with its body', async () => {
+    signedIn();
+    // Refresh succeeds; the request itself is refused before and after.
+    serve((config) =>
+      isRefresh(config) ? { status: 200, body: RENEWED } : { status: 401 }
+    );
+
+    const error = await attemptAndCatch();
+
+    // Wire order: original, refresh, replay. The replay must have carried
+    // the body — scrubbing before the retry would break every replay.
+    expect(bodiesOnTheWire).toHaveLength(3);
+    expect(bodiesOnTheWire[2]).toBeTruthy();
+    expectScrubbed(error);
+  });
+
+  it('leaves a successful replay untouched', async () => {
+    signedIn();
+    serve((config) => {
+      if (isRefresh(config)) return { status: 200, body: RENEWED };
+      return tokenOn(config) === `Bearer ${RENEWED.access_token}`
+        ? { status: 200, body: { id: 'group-1' } }
+        : { status: 401 };
+    });
+
+    const { data } = await attempt();
+
+    expect(data).toEqual({ id: 'group-1' });
+    expect(bodiesOnTheWire[2]).toBeTruthy();
   });
 });

--- a/frontend/src/lib/axiosClient.ts
+++ b/frontend/src/lib/axiosClient.ts
@@ -123,4 +123,14 @@ axiosClient.interceptors.response.use(undefined, async (error: unknown) => {
   return axiosClient(config);
 });
 
+// Drop the request body and auth token from failed requests, so no error can
+// take them off this device. After the 401 handler: a replay re-sends config.
+axiosClient.interceptors.response.use(undefined, (error: unknown) => {
+  if (isAxiosError(error) && error.config) {
+    delete error.config.data;
+    error.config.headers?.delete('Authorization');
+  }
+  return Promise.reject(error);
+});
+
 export default axiosClient;

--- a/frontend/src/lib/queryClient.ts
+++ b/frontend/src/lib/queryClient.ts
@@ -1,6 +1,14 @@
-import { QueryClient } from '@tanstack/react-query';
+import { MutationCache, QueryCache, QueryClient } from '@tanstack/react-query';
+
+import { reportError } from '@/lib/telemetry';
 
 const queryClient = new QueryClient({
+  queryCache: new QueryCache({
+    onError: (error) => reportError(error, 'query'),
+  }),
+  mutationCache: new MutationCache({
+    onError: (error) => reportError(error, 'mutation'),
+  }),
   defaultOptions: {
     queries: {
       staleTime: 1000 * 60 * 5, // 5 minutes — data stays fresh before refetching

--- a/frontend/src/lib/telemetry.test.ts
+++ b/frontend/src/lib/telemetry.test.ts
@@ -1,0 +1,133 @@
+import * as Sentry from '@sentry/react';
+import { AxiosError, AxiosHeaders, type AxiosResponse } from 'axios';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { reportError } from '@/lib/telemetry';
+
+vi.mock('@sentry/react', () => ({
+  isInitialized: vi.fn(() => true),
+  captureException: vi.fn(),
+  logger: { warn: vi.fn(), error: vi.fn() },
+}));
+
+/**
+ * Facts are picked fields only, with no query strings. Every failure is
+ * logged; only breakage and silence also become issues — never a 4xx the UI
+ * already words for the user.
+ */
+
+function httpError(status: number, url = '/location-groups'): AxiosError {
+  const config = { url, method: 'post', headers: new AxiosHeaders() };
+  const response = {
+    data: { detail: 'nope' },
+    status,
+    statusText: 'Error',
+    headers: {},
+    config,
+  } as AxiosResponse;
+  return new AxiosError(
+    `Request failed with status code ${status}`,
+    AxiosError.ERR_BAD_REQUEST,
+    config as never,
+    null,
+    response
+  );
+}
+
+function networkError(): AxiosError {
+  const config = { url: '/routes', method: 'get', headers: new AxiosHeaders() };
+  return new AxiosError(
+    'Network Error',
+    AxiosError.ERR_NETWORK,
+    config as never
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('reportError', () => {
+  it('captures a 500', () => {
+    reportError(httpError(500), 'query');
+    expect(Sentry.captureException).toHaveBeenCalledTimes(1);
+  });
+
+  it('captures network silence', () => {
+    reportError(networkError(), 'query');
+    expect(Sentry.captureException).toHaveBeenCalledTimes(1);
+  });
+
+  it('captures non-HTTP bugs', () => {
+    reportError(new TypeError('x is not a function'), 'query');
+    expect(Sentry.captureException).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([400, 401, 403, 404, 409, 422])(
+    'logs a %i as a warning without raising an issue',
+    (status) => {
+      reportError(httpError(status), 'mutation');
+      expect(Sentry.captureException).not.toHaveBeenCalled();
+      expect(Sentry.logger.warn).toHaveBeenCalledWith(
+        'Request failed',
+        expect.objectContaining({ status, context: 'mutation' })
+      );
+    }
+  );
+
+  it('logs unexpected failures at error level, with the facts attached', () => {
+    reportError(httpError(503), 'query');
+    expect(Sentry.logger.error).toHaveBeenCalledWith('Request failed', {
+      context: 'query',
+      status: 503,
+      code: AxiosError.ERR_BAD_REQUEST,
+      method: 'POST',
+      path: '/location-groups',
+    });
+  });
+
+  it('strips query strings from the path', () => {
+    reportError(httpError(500, '/drivers?email=dana@example.com'), 'query');
+    const [, attributes] = vi.mocked(Sentry.logger.error).mock.calls[0];
+    expect(attributes).toMatchObject({ path: '/drivers' });
+  });
+
+  it('reports the transport code when there was no response', () => {
+    reportError(networkError(), 'query');
+    const [, attributes] = vi.mocked(Sentry.logger.error).mock.calls[0];
+    expect(attributes).toMatchObject({ code: 'ERR_NETWORK' });
+    expect(attributes).not.toHaveProperty('status');
+  });
+
+  it('records connectivity when the request got no answer', () => {
+    vi.stubGlobal('navigator', { onLine: false });
+    reportError(networkError(), 'query');
+    const [, attributes] = vi.mocked(Sentry.logger.error).mock.calls[0];
+    expect(attributes).toMatchObject({ online: false });
+  });
+
+  it('leaves connectivity off a failure the server answered', () => {
+    vi.stubGlobal('navigator', { onLine: true });
+    reportError(httpError(404), 'query');
+    const [, attributes] = vi.mocked(Sentry.logger.warn).mock.calls[0];
+    expect(attributes).not.toHaveProperty('online');
+  });
+
+  it('carries only the context for a non-HTTP error', () => {
+    reportError(new Error('boom'), 'mutation');
+    expect(Sentry.logger.error).toHaveBeenCalledWith('Request failed', {
+      context: 'mutation',
+    });
+  });
+
+  it('stays quiet when Sentry is not initialized', () => {
+    vi.mocked(Sentry.isInitialized).mockReturnValue(false);
+    reportError(httpError(500), 'query');
+    expect(Sentry.captureException).not.toHaveBeenCalled();
+    expect(Sentry.logger.error).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/lib/telemetry.test.ts
+++ b/frontend/src/lib/telemetry.test.ts
@@ -1,5 +1,10 @@
 import * as Sentry from '@sentry/react';
-import { AxiosError, AxiosHeaders, type AxiosResponse } from 'axios';
+import {
+  AxiosError,
+  AxiosHeaders,
+  type AxiosResponse,
+  CanceledError,
+} from 'axios';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { reportError } from '@/lib/telemetry';
@@ -115,6 +120,13 @@ describe('reportError', () => {
     reportError(httpError(404), 'query');
     const [, attributes] = vi.mocked(Sentry.logger.warn).mock.calls[0];
     expect(attributes).not.toHaveProperty('online');
+  });
+
+  it('ignores a cancelled request', () => {
+    reportError(new CanceledError('canceled'), 'query');
+    expect(Sentry.logger.error).not.toHaveBeenCalled();
+    expect(Sentry.logger.warn).not.toHaveBeenCalled();
+    expect(Sentry.captureException).not.toHaveBeenCalled();
   });
 
   it('carries only the context for a non-HTTP error', () => {

--- a/frontend/src/lib/telemetry.ts
+++ b/frontend/src/lib/telemetry.ts
@@ -1,0 +1,72 @@
+import * as Sentry from '@sentry/react';
+import { isAxiosError } from 'axios';
+
+/**
+ * The one sanctioned way to report a failure. Never hand an error object to a
+ * logger: an AxiosError drags the whole request along with it. Wired globally
+ * in queryClient.ts, so hooks rarely call this directly.
+ *
+ * Every failure is logged to Sentry, so the log stream shows what users are
+ * hitting. Only unexpected ones — 5xx, network silence, non-HTTP bugs — also
+ * become issues; a 4xx is the server refusing user input, which the form
+ * already words for them.
+ */
+
+/** The complete set of fields allowed to leave the device. */
+interface FailureFacts {
+  /** Where the failure surfaced, e.g. 'query', 'mutation'. */
+  context: string;
+  status?: number;
+  /** Axios transport code when there is no HTTP status, e.g. ERR_NETWORK. */
+  code?: string;
+  method?: string;
+  /** Request path with query and fragment removed — parameters can carry PII. */
+  path?: string;
+  /** Only set when the request got no answer: a dead zone or a dead server. */
+  online?: boolean;
+}
+
+export function reportError(error: unknown, context: string): void {
+  const url = isAxiosError(error) ? (error.config?.url ?? '') : '';
+  const status = isAxiosError(error) ? error.response?.status : undefined;
+  const facts: FailureFacts = isAxiosError(error)
+    ? {
+        context,
+        status,
+        code: error.code,
+        method: error.config?.method?.toUpperCase(),
+        path: url.split(/[?#]/)[0] || undefined,
+        // Drivers work on cellular. Without this, a tunnel and an outage
+        // produce identical records.
+        online:
+          status === undefined && typeof navigator !== 'undefined'
+            ? navigator.onLine
+            : undefined,
+      }
+    : { context };
+
+  if (import.meta.env.DEV) {
+    // eslint-disable-next-line no-console
+    console.warn('Request failed:', facts);
+  }
+
+  if (!Sentry.isInitialized()) {
+    return;
+  }
+
+  // Attributes must be primitives; drop the fields this failure didn't have.
+  const attributes = Object.fromEntries(
+    Object.entries(facts).filter(([, value]) => value !== undefined)
+  );
+
+  // No status means no answer at all (or a non-HTTP bug) — ours to notice,
+  // like a 5xx. Capturing the error is safe: axiosClient strips the body and
+  // token from every rejection first.
+  const unexpected = facts.status === undefined || facts.status >= 500;
+  if (unexpected) {
+    Sentry.logger.error('Request failed', attributes);
+    Sentry.captureException(error, { extra: { ...facts } });
+  } else {
+    Sentry.logger.warn('Request failed', attributes);
+  }
+}

--- a/frontend/src/lib/telemetry.ts
+++ b/frontend/src/lib/telemetry.ts
@@ -1,5 +1,5 @@
 import * as Sentry from '@sentry/react';
-import { isAxiosError } from 'axios';
+import { isAxiosError, isCancel } from 'axios';
 
 /**
  * The one sanctioned way to report a failure. Never hand an error object to a
@@ -27,6 +27,10 @@ interface FailureFacts {
 }
 
 export function reportError(error: unknown, context: string): void {
+  if (isCancel(error)) {
+    return;
+  }
+
   const url = isAxiosError(error) ? (error.config?.url ?? '') : '';
   const status = isAxiosError(error) ? error.response?.status : undefined;
   const facts: FailureFacts = isAxiosError(error)
@@ -65,7 +69,7 @@ export function reportError(error: unknown, context: string): void {
   const unexpected = facts.status === undefined || facts.status >= 500;
   if (unexpected) {
     Sentry.logger.error('Request failed', attributes);
-    Sentry.captureException(error, { extra: { ...facts } });
+    Sentry.captureException(error, { extra: attributes });
   } else {
     Sentry.logger.warn('Request failed', attributes);
   }


### PR DESCRIPTION

## JIRA Ticket
N/A

## Implementation Description
- removes request body and auth headers from AxiosError
- new file telemetry.ts
    -  adds reportError - enables console log on dev environment, forwards everything else to sentry
- adds global error logging for every query and mutation failure in `queryClient.ts`

## What Should Reviewers Focus On?
<!-- Call out substantial changes or anything you want a second opinion on -->
- Ensure the facts in `telemetry.ts` contains useful data for client-side telemetry


## Checklist
- [x] PR name and commits are descriptive, imperative, and atomic (trivial commits squashed)
- [x] I have requested a review from Claude, understood its suggestions, and implemented fixes where needed (or documented disagreements)
- [x] I have requested a review from the PL and relevant devs with background on this PR

**Frontend only — delete if not applicable:**
- [x] Follows Tailwind/shadcn best practices per README; no hardcoded color or spacing values
- [x] Implementation matches Zeplin designs and screenshots are attached above
- [x] Screens render correctly on mobile and desktop; no console warnings or errors