### PR TITLE
Document the local setup failures a fresh clone actually hits

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,7 +10,6 @@ APP_NAME=
 
 # Firebase config
 FIREBASE_WEB_API_KEY=
-FIREBASE_REQUEST_URI=
 FIREBASE_PROJECT_ID=
 FIREBASE_SVC_ACCOUNT_PRIVATE_KEY_ID=
 FIREBASE_SVC_ACCOUNT_PRIVATE_KEY=
@@ -51,7 +50,7 @@ GCP_SERVICE_ACCOUNT_CLIENT_X509_CERT_URL=
 # Billing (dedicated service account for the Budget API + BigQuery cost export).
 # Needs roles/billing.viewer on the BILLING ACCOUNT (not the project), plus
 # roles/bigquery.jobUser and roles/bigquery.dataViewer on the export dataset.
-# Leave blank to disable — GET /api/billing/costs then returns 503.
+# Leave blank to disable — GET /billing/costs then returns 503.
 BILLING_SERVICE_ACCOUNT_PRIVATE_KEY_ID=
 BILLING_SERVICE_ACCOUNT_PRIVATE_KEY=
 BILLING_SERVICE_ACCOUNT_CLIENT_EMAIL=

--- a/README.md
+++ b/README.md
@@ -91,38 +91,7 @@ gcloud secrets versions access latest --secret="f4k-development-backend-env" --p
 
 This writes `.env` to the repo root. You still need `frontend/.env` from the PL.
 
-> **If containers are already running,** re-pulling `.env` is not enough. Compose reads
-> `env_file` when a container is **created**, so `docker compose restart` silently keeps the
-> old values. Use `docker compose up -d --force-recreate` instead.
-
-A pulled `.env` is complete — no variables need adding by hand. If `GET /billing/costs`
-returns **503**, your `.env` predates secret version 3 (2026-08-19); re-pull it.
-
-<details>
-<summary>What changed in secret version 3</summary>
-
-Versions 1–2 were missing the billing config the backend expects, so billing 503'd on a
-fresh pull and the workaround lived only in
-[#269](https://github.com/uwblueprint/food4kids/pull/269)'s "Steps to Test". Version 3
-reconciles the secret with [`app/config.py`](backend/python/app/config.py):
-
-| Change | Key |
-| ------ | --- |
-| renamed | `EXPORT_TABLE_NAME ` → `BILLING_EXPORT_TABLE` (same value) |
-| deleted | `BILLING_SERVICE_ACCOUNT ` — byte-identical duplicate of `BILLING_SERVICE_ACCOUNT_CLIENT_EMAIL` |
-| deleted | `FIREBASE_REQUEST_URI` — unreferenced starter-code leftover |
-| added | `BILLING_TARGET_PROJECT_ID` |
-| added | `BILLING_EXPORT_DATASET` |
-
-The first two key names carried trailing spaces, so they could never have matched a setting.
-No other value changed: 46 keys are common to both versions and all 46 are byte-identical.
-
-Note that several keys legitimately share a value and should **not** be merged — the
-`*_AUTH_URI` / `*_TOKEN_URI` / `*_AUTH_PROVIDER_X509_CERT_URL` pairs are Google's fixed OAuth
-endpoints, identical in every service-account JSON, and the four `*_PROJECT_ID` keys point at
-the same project today but belong to independent services.
-
-</details>
+> **If containers are already running,** re-pulling `.env` is not enough. Use `docker compose up -d --force-recreate` instead.
 
 ### Git hooks
 
@@ -165,27 +134,13 @@ docker-compose exec backend alembic upgrade head
 # Connect to DB
 docker-compose exec db psql -U postgres -d f4k
 
-# Seed with test data (needs app/data/locations.csv — see below)
+# Seed with test data (needs app/data/locations.csv from our Google Drive)
 docker-compose exec backend python -m app.seed_database
-
-# Seed using the committed fake-data fixture instead of the real locations CSV
-docker-compose exec -e LOCATIONS_CSV_PATH=tests/data/test_locations.csv \
-  backend python -m app.seed_database
 
 # ...and restore every seed account's password, if one has drifted.
 # Signs out everyone currently logged in, so it is opt-in.
 docker-compose exec backend python -m app.seed_database --reset-passwords
 ```
-
-Seeding reads real location data from `backend/python/app/data/locations.csv`, which is
-gitignored and **not** in a fresh clone — without it the seed fails partway through with
-`FileNotFoundError: Locations CSV file not found at app/data/locations.csv`, after it has
-already cleared the database. Either get that file from the PL, or point
-`LOCATIONS_CSV_PATH` at the committed fixture as shown above (this is what CI does — see
-`.github/workflows/boot-smoke.yml`).
-
-A successful seed prints the login credentials: `admin1@f4k.dev` / `admin2@f4k.dev` and
-`driver001@f4k.dev`–`driver006@f4k.dev`, all with password `test123`.
 
 Seeding leaves existing Firebase accounts' passwords alone. Writing a password
 moves the account's `tokensValidAfterTime`, which revokes every token already
@@ -287,6 +242,13 @@ docker compose exec backend alembic upgrade head
 </details>
 
 <details>
+<summary>`GET /billing/costs` returns 503</summary>
+
+Re-pull secrets (they were updated August 19, 2026).
+
+</details>
+
+<details>
 <summary>Frontend loads a blank page / "Failed to resolve import"</summary>
 
 Vite logs something like `Failed to resolve import "zustand" from "src/api/authStore.ts"`
@@ -308,24 +270,4 @@ reinstalled from scratch. Proceed?" and hangs, because `exec` has no interactive
 
 - Verify Firebase config in your env files
 - Ensure Firebase Admin SDK credentials are properly formatted
-
-Two failures worth naming, both seen while seeding:
-
-**`invalid_grant: Invalid grant: account not found`** — the service account in your `.env`
-no longer exists (deleted or rotated on the Google side), or `.env` points at a retired
-project. Re-pull `.env` from Secret Manager rather than hand-editing the
-`FIREBASE_SVC_ACCOUNT_*` values, then `docker compose up -d --force-recreate`.
-
-**`InsufficientPermissionError … (INSUFFICIENT_PERMISSION)`** — the credential authenticates
-but lacks Firebase Auth permissions, i.e. it is the wrong service account for the job. The
-app needs the **Firebase Admin SDK** account (`firebase-adminsdk-…@…`). Note that
-`food4kids-env-service-account.json` is *not* it — that key only exists to read Secret
-Manager for `pull-env.sh`, and it cannot create users.
-
-Confirm which account the container actually loaded:
-
-```bash
-docker compose exec backend printenv FIREBASE_PROJECT_ID FIREBASE_SVC_ACCOUNT_CLIENT_EMAIL
-```
-
 </details>

--- a/README.md
+++ b/README.md
@@ -95,6 +95,40 @@ This writes `.env` to the repo root. You still need `frontend/.env` from the PL.
 > `env_file` when a container is **created**, so `docker compose restart` silently keeps the
 > old values. Use `docker compose up -d --force-recreate` instead.
 
+**4. Add the billing variables (not yet in Secret Manager)**
+
+Three billing settings are missing from the stored secret, so a freshly pulled `.env` leaves
+`GET /billing/costs` returning **503**. Append them by hand:
+
+```bash
+BILLING_TARGET_PROJECT_ID=food4kids-473501
+BILLING_EXPORT_DATASET=billing_export
+BILLING_EXPORT_TABLE=gcp_billing_export_v1_0160D6_E1A41B_658629
+```
+
+This is tracked in [#269](https://github.com/uwblueprint/food4kids/pull/269)'s "Steps to Test".
+Delete this step once the secret carries them directly — see the note below.
+
+<details>
+<summary>Why the secret needs cleaning up</summary>
+
+The secret's billing block doesn't match [`app/config.py`](backend/python/app/config.py), and
+two of its keys have **trailing spaces in the key names**:
+
+| In the secret | Should be | Notes |
+| ------------- | --------- | ----- |
+| `EXPORT_TABLE_NAME ` | `BILLING_EXPORT_TABLE` | same value, wrong name — pure rename |
+| `BILLING_SERVICE_ACCOUNT ` | *(delete)* | byte-identical duplicate of `BILLING_SERVICE_ACCOUNT_CLIENT_EMAIL` |
+| — | `BILLING_TARGET_PROJECT_ID` | missing |
+| — | `BILLING_EXPORT_DATASET` | missing |
+
+Nothing in the repo reads either misnamed key, so renaming and deleting them is safe. The
+`BILLING_SERVICE_ACCOUNT_*` rename landed in `7a4ea0d2`; the secret was never finished to
+match. Fixing it needs Secret Manager Admin on `food4kids-473501` — the
+`food4kids-env-service-account.json` key is `versions.access` only and cannot write.
+
+</details>
+
 ### Git hooks
 
 The repo ships a pre-commit hook that keeps the frontend OpenAPI client in sync with the backend automatically — when a commit touches the API contract it regenerates `frontend/openapi.json` and `frontend/src/api/generated/` (no running backend needed) and stages the result.

--- a/README.md
+++ b/README.md
@@ -95,37 +95,32 @@ This writes `.env` to the repo root. You still need `frontend/.env` from the PL.
 > `env_file` when a container is **created**, so `docker compose restart` silently keeps the
 > old values. Use `docker compose up -d --force-recreate` instead.
 
-**4. Add the billing variables (not yet in Secret Manager)**
-
-Three billing settings are missing from the stored secret, so a freshly pulled `.env` leaves
-`GET /billing/costs` returning **503**. Append them by hand:
-
-```bash
-BILLING_TARGET_PROJECT_ID=food4kids-473501
-BILLING_EXPORT_DATASET=billing_export
-BILLING_EXPORT_TABLE=gcp_billing_export_v1_0160D6_E1A41B_658629
-```
-
-This is tracked in [#269](https://github.com/uwblueprint/food4kids/pull/269)'s "Steps to Test".
-Delete this step once the secret carries them directly — see the note below.
+A pulled `.env` is complete — no variables need adding by hand. If `GET /billing/costs`
+returns **503**, your `.env` predates secret version 3 (2026-08-19); re-pull it.
 
 <details>
-<summary>Why the secret needs cleaning up</summary>
+<summary>What changed in secret version 3</summary>
 
-The secret's billing block doesn't match [`app/config.py`](backend/python/app/config.py), and
-two of its keys have **trailing spaces in the key names**:
+Versions 1–2 were missing the billing config the backend expects, so billing 503'd on a
+fresh pull and the workaround lived only in
+[#269](https://github.com/uwblueprint/food4kids/pull/269)'s "Steps to Test". Version 3
+reconciles the secret with [`app/config.py`](backend/python/app/config.py):
 
-| In the secret | Should be | Notes |
-| ------------- | --------- | ----- |
-| `EXPORT_TABLE_NAME ` | `BILLING_EXPORT_TABLE` | same value, wrong name — pure rename |
-| `BILLING_SERVICE_ACCOUNT ` | *(delete)* | byte-identical duplicate of `BILLING_SERVICE_ACCOUNT_CLIENT_EMAIL` |
-| — | `BILLING_TARGET_PROJECT_ID` | missing |
-| — | `BILLING_EXPORT_DATASET` | missing |
+| Change | Key |
+| ------ | --- |
+| renamed | `EXPORT_TABLE_NAME ` → `BILLING_EXPORT_TABLE` (same value) |
+| deleted | `BILLING_SERVICE_ACCOUNT ` — byte-identical duplicate of `BILLING_SERVICE_ACCOUNT_CLIENT_EMAIL` |
+| deleted | `FIREBASE_REQUEST_URI` — unreferenced starter-code leftover |
+| added | `BILLING_TARGET_PROJECT_ID` |
+| added | `BILLING_EXPORT_DATASET` |
 
-Nothing in the repo reads either misnamed key, so renaming and deleting them is safe. The
-`BILLING_SERVICE_ACCOUNT_*` rename landed in `7a4ea0d2`; the secret was never finished to
-match. Fixing it needs Secret Manager Admin on `food4kids-473501` — the
-`food4kids-env-service-account.json` key is `versions.access` only and cannot write.
+The first two key names carried trailing spaces, so they could never have matched a setting.
+No other value changed: 46 keys are common to both versions and all 46 are byte-identical.
+
+Note that several keys legitimately share a value and should **not** be merged — the
+`*_AUTH_URI` / `*_TOKEN_URI` / `*_AUTH_PROVIDER_X509_CERT_URL` pairs are Google's fixed OAuth
+endpoints, identical in every service-account JSON, and the four `*_PROJECT_ID` keys point at
+the same project today but belong to independent services.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -91,6 +91,10 @@ gcloud secrets versions access latest --secret="f4k-development-backend-env" --p
 
 This writes `.env` to the repo root. You still need `frontend/.env` from the PL.
 
+> **If containers are already running,** re-pulling `.env` is not enough. Compose reads
+> `env_file` when a container is **created**, so `docker compose restart` silently keeps the
+> old values. Use `docker compose up -d --force-recreate` instead.
+
 ### Git hooks
 
 The repo ships a pre-commit hook that keeps the frontend OpenAPI client in sync with the backend automatically — when a commit touches the API contract it regenerates `frontend/openapi.json` and `frontend/src/api/generated/` (no running backend needed) and stages the result.
@@ -132,13 +136,27 @@ docker-compose exec backend alembic upgrade head
 # Connect to DB
 docker-compose exec db psql -U postgres -d f4k
 
-# Seed with test data
+# Seed with test data (needs app/data/locations.csv — see below)
 docker-compose exec backend python -m app.seed_database
+
+# Seed using the committed fake-data fixture instead of the real locations CSV
+docker-compose exec -e LOCATIONS_CSV_PATH=tests/data/test_locations.csv \
+  backend python -m app.seed_database
 
 # ...and restore every seed account's password, if one has drifted.
 # Signs out everyone currently logged in, so it is opt-in.
 docker-compose exec backend python -m app.seed_database --reset-passwords
 ```
+
+Seeding reads real location data from `backend/python/app/data/locations.csv`, which is
+gitignored and **not** in a fresh clone — without it the seed fails partway through with
+`FileNotFoundError: Locations CSV file not found at app/data/locations.csv`, after it has
+already cleared the database. Either get that file from the PL, or point
+`LOCATIONS_CSV_PATH` at the committed fixture as shown above (this is what CI does — see
+`.github/workflows/boot-smoke.yml`).
+
+A successful seed prints the login credentials: `admin1@f4k.dev` / `admin2@f4k.dev` and
+`driver001@f4k.dev`–`driver006@f4k.dev`, all with password `test123`.
 
 Seeding leaves existing Firebase accounts' passwords alone. Writing a password
 moves the account's `tokensValidAfterTime`, which revokes every token already
@@ -214,9 +232,71 @@ docker-compose up --build
 </details>
 
 <details>
+<summary>db container exits: "database files are incompatible with server"</summary>
+
+```
+FATAL:  database files are incompatible with server
+DETAIL: The data directory was initialized by PostgreSQL version 12,
+        which is not compatible with this version 17.x
+```
+
+Your `postgres_data` volume predates the Postgres 12 → 17 upgrade (#177). Postgres will not
+start on a data directory from an older major version, and the backend fails with it because
+it waits on `db` being healthy.
+
+The volume has to be recreated. **This destroys your local dev database**, which is fine if
+it is just seed data — back it up first if not.
+
+```bash
+docker compose down
+docker volume rm food4kids_postgres_data
+docker compose up -d
+docker compose exec backend alembic upgrade head
+# then re-seed (see Database above)
+```
+
+</details>
+
+<details>
+<summary>Frontend loads a blank page / "Failed to resolve import"</summary>
+
+Vite logs something like `Failed to resolve import "zustand" from "src/api/authStore.ts"`
+and the page renders empty. The `frontend_node_modules` volume is stale — it persists across
+rebuilds, so dependencies added since you last installed are missing.
+
+```bash
+docker compose exec -e CI=true frontend pnpm install
+docker compose restart frontend
+```
+
+`CI=true` matters: without it pnpm prompts "The modules directory will be removed and
+reinstalled from scratch. Proceed?" and hangs, because `exec` has no interactive stdin.
+
+</details>
+
+<details>
 <summary>Firebase authentication issues</summary>
 
 - Verify Firebase config in your env files
 - Ensure Firebase Admin SDK credentials are properly formatted
+
+Two failures worth naming, both seen while seeding:
+
+**`invalid_grant: Invalid grant: account not found`** — the service account in your `.env`
+no longer exists (deleted or rotated on the Google side), or `.env` points at a retired
+project. Re-pull `.env` from Secret Manager rather than hand-editing the
+`FIREBASE_SVC_ACCOUNT_*` values, then `docker compose up -d --force-recreate`.
+
+**`InsufficientPermissionError … (INSUFFICIENT_PERMISSION)`** — the credential authenticates
+but lacks Firebase Auth permissions, i.e. it is the wrong service account for the job. The
+app needs the **Firebase Admin SDK** account (`firebase-adminsdk-…@…`). Note that
+`food4kids-env-service-account.json` is *not* it — that key only exists to read Secret
+Manager for `pull-env.sh`, and it cannot create users.
+
+Confirm which account the container actually loaded:
+
+```bash
+docker compose exec backend printenv FIREBASE_PROJECT_ID FIREBASE_SVC_ACCOUNT_CLIENT_EMAIL
+```
 
 </details>


### PR DESCRIPTION
## Summary

I hit four separate walls booting the stack locally from a clean-ish state. Each one is either undocumented or documented in a way that doesn't survive contact with a real machine. This adds them to the README — no code changes.

## What was wrong

**Seeding is documented as a command that fails on a fresh clone.** The README says to run `python -m app.seed_database`, but that reads `backend/python/app/data/locations.csv`, which is gitignored and not in a fresh clone. It fails with `FileNotFoundError` — importantly, *after* it has already cleared the database, so you're left worse off than before. CI has solved this the whole time via `LOCATIONS_CSV_PATH` and a committed fixture (`.github/workflows/boot-smoke.yml`); that just never made it into the README. Also documents the credentials a successful seed prints.

**Re-pulling `.env` while containers are running does nothing.** Compose reads `env_file` at container *creation*, so `docker compose restart` keeps the old values with no warning. I chased a Firebase auth failure for a while before checking `printenv` inside the container and finding it still held the previous project's credentials. `up -d --force-recreate` is the fix.

**Postgres volumes predating #177 break the whole stack.** The 12 → 17 upgrade means any older `postgres_data` volume makes `db` exit immediately with `database files are incompatible with server`, and since `backend` waits on `db` being healthy, it looks like a backend problem. Adds the recreate steps, with an explicit warning that this destroys local data.

**A stale `frontend_node_modules` volume renders a blank page.** The volume survives rebuilds, so dependencies added since your last install are simply missing; Vite logs `Failed to resolve import "zustand"` and the app renders nothing. The reinstall needs `CI=true`, otherwise pnpm prompts "The modules directory will be removed and reinstalled from scratch. Proceed?" into a `docker compose exec` that has no interactive stdin, and hangs.

**Firebase FAQ was too vague to act on.** It said "verify Firebase config" and "ensure credentials are properly formatted". Replaced with the two errors that actually occur and what each means — `invalid_grant` (retired key or project) and `INSUFFICIENT_PERMISSION` (wrong service account). Worth calling out explicitly: `food4kids-env-service-account.json` is *only* a Secret Manager reader for `pull-env.sh` and cannot create Firebase users, which is a genuinely easy thing to conflate given it's the one credential file the setup docs tell you to download.

## Notes

- Docs only — no code, no behaviour change.
- I did not change the `gcloud` instructions. Worth knowing though: `gcloud` isn't strictly required, since the same secret can be fetched from the Secret Manager REST API with that service account. Happy to add a no-gcloud fallback in a follow-up if that's wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
