### PR TITLE
F4KRP-194: Settings page - Route reminder and contact info tabs

### DIFF
--- a/frontend/src/api/system-settings.ts
+++ b/frontend/src/api/system-settings.ts
@@ -1,8 +1,11 @@
-import { useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import {
   getOrgContactOptions,
+  getOrgContactQueryKey,
   getSystemSettingsOptions,
+  getSystemSettingsQueryKey,
+  patchSystemSettingsMutation,
 } from './generated/@tanstack/react-query.gen';
 import type { SystemSettingsRead } from './generated/types.gen';
 
@@ -26,4 +29,15 @@ export function useSystemSettings() {
  */
 export function useOrgContact() {
   return useQuery(getOrgContactOptions());
+}
+
+export function useUpdateSystemSettings() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    ...patchSystemSettingsMutation(),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: getSystemSettingsQueryKey() });
+      queryClient.invalidateQueries({ queryKey: getOrgContactQueryKey() });
+    },
+  });
 }

--- a/frontend/src/common/components/Switch.tsx
+++ b/frontend/src/common/components/Switch.tsx
@@ -1,0 +1,43 @@
+import { Switch as SwitchPrimitive } from 'radix-ui';
+import * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+/**
+ * Pill toggle for an on/off setting.
+ *
+ * Distinct from {@link Checkbox}-style inputs: this commits its change as soon
+ * as it is flipped, so it belongs on settings that read as state rather than on
+ * form fields awaiting a submit.
+ */
+function Switch({
+  className,
+  ...props
+}: React.ComponentProps<typeof SwitchPrimitive.Root>) {
+  return (
+    <SwitchPrimitive.Root
+      data-slot="switch"
+      className={cn(
+        'peer inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full',
+        'outline outline-1 outline-offset-[-1px] transition-colors',
+        'data-[state=checked]:bg-blue-300 data-[state=checked]:outline-blue-300',
+        'data-[state=unchecked]:bg-grey-300 data-[state=unchecked]:outline-grey-300',
+        'focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-300',
+        'disabled:cursor-not-allowed disabled:opacity-60',
+        className
+      )}
+      {...props}
+    >
+      <SwitchPrimitive.Thumb
+        data-slot="switch-thumb"
+        className={cn(
+          'bg-grey-100 pointer-events-none block size-5 rounded-full shadow-sm',
+          'transition-transform data-[state=checked]:translate-x-[22px]',
+          'data-[state=unchecked]:translate-x-0.5'
+        )}
+      />
+    </SwitchPrimitive.Root>
+  );
+}
+
+export { Switch };

--- a/frontend/src/common/components/index.ts
+++ b/frontend/src/common/components/index.ts
@@ -69,6 +69,7 @@ export {
 export { Spinner } from './Spinner';
 export type { Character, StatisticsCardColor } from './StatisticsCard';
 export { StatisticsCard } from './StatisticsCard';
+export { Switch } from './Switch';
 export { TableToolbar } from './TableToolbar';
 export { Tabs, TabsContent, TabsList, TabsTrigger } from './Tabs';
 export { Tag } from './Tag';

--- a/frontend/src/pages/admin/settings/AdminSettingsPage.tsx
+++ b/frontend/src/pages/admin/settings/AdminSettingsPage.tsx
@@ -1,23 +1,142 @@
 import SearchIcon from '@/assets/icons/search.svg?react';
-import { Account, Button } from '@/common/components';
+import {
+  Account,
+  Banner,
+  Button,
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/common/components';
 import { AnnouncementsBoard } from '@/features/announcements';
+
+import {
+  ContactInformationPanel,
+  EditingBanner,
+  RouteRemindersPanel,
+} from './components';
+import { SettingsFormProvider } from './SettingsFormProvider';
+import { useSettingsForm } from './useSettingsForm';
+
+/**
+ * Save, with a tooltip that survives being disabled.
+ *
+ * A disabled button swallows pointer events, so `title` never fires on it --
+ * the trigger has to be a wrapper element. Same pattern as the reminders
+ * panel's "Add notification" at its limit.
+ */
+const SaveButton = ({
+  onSave,
+  isSaving,
+  blockedByRequired,
+}: {
+  onSave: () => void;
+  isSaving: boolean;
+  blockedByRequired: boolean;
+}) => {
+  const button = (
+    <Button onClick={onSave} disabled={isSaving || blockedByRequired}>
+      {isSaving ? 'Saving…' : 'Save changes'}
+    </Button>
+  );
+
+  if (!blockedByRequired) return button;
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span>{button}</span>
+      </TooltipTrigger>
+      <TooltipContent className="bg-grey-500 text-grey-100">
+        Fill in every required field before saving.
+      </TooltipContent>
+    </Tooltip>
+  );
+};
+
+const SettingsPageHeader = () => {
+  const {
+    isEditing,
+    isLoading,
+    isSaving,
+    missingRequired,
+    startEditing,
+    cancelEditing,
+    save,
+  } = useSettingsForm();
+
+  const blockedByRequired = missingRequired.length > 0;
+
+  return (
+    <div className="flex items-start justify-between gap-6">
+      <div className="flex items-center gap-8">
+        <h1>Settings</h1>
+        {isEditing && <EditingBanner onDismiss={cancelEditing} />}
+      </div>
+      <div className="flex items-center gap-6">
+        <div className="flex items-center gap-4">
+          <AnnouncementsBoard />
+          <Button variant="tertiary" shape="circular">
+            <SearchIcon className="size-5 text-blue-300" />
+          </Button>
+        </div>
+        <Account />
+        {isEditing ? (
+          <SaveButton
+            onSave={save}
+            isSaving={isSaving}
+            blockedByRequired={blockedByRequired}
+          />
+        ) : (
+          <Button onClick={startEditing} disabled={isLoading}>
+            Edit settings
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+};
+
+const AdminSettingsPageContent = () => {
+  const { saveError } = useSettingsForm();
+
+  return (
+    <div className="flex flex-col gap-8">
+      <SettingsPageHeader />
+      {saveError && (
+        <Banner variant="error" className="max-w-[600px]">
+          {saveError}
+        </Banner>
+      )}
+      <Tabs defaultValue="delivery-defaults">
+        <TabsList>
+          <TabsTrigger value="delivery-defaults">Delivery Defaults</TabsTrigger>
+          <TabsTrigger value="route-reminders">Route Reminders</TabsTrigger>
+          <TabsTrigger value="contact-information">
+            Contact Information
+          </TabsTrigger>
+        </TabsList>
+        <TabsContent value="delivery-defaults">
+          {/* Filled in by the Delivery Defaults PR. */}
+        </TabsContent>
+        <TabsContent value="route-reminders">
+          <RouteRemindersPanel />
+        </TabsContent>
+        <TabsContent value="contact-information">
+          <ContactInformationPanel />
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+};
 
 export const AdminSettingsPage = () => {
   return (
-    <div className="flex flex-col gap-8">
-      <div className="flex items-start justify-between">
-        <h1>Settings</h1>
-        <div className="flex items-center gap-6">
-          <div className="flex items-center gap-4">
-            <AnnouncementsBoard />
-            <Button variant="tertiary" shape="circular">
-              <SearchIcon className="size-5 text-blue-300" />
-            </Button>
-          </div>
-          <Account />
-        </div>
-      </div>
-      <div>TODO</div>
-    </div>
+    <SettingsFormProvider>
+      <AdminSettingsPageContent />
+    </SettingsFormProvider>
   );
 };

--- a/frontend/src/pages/admin/settings/SettingsFormProvider.tsx
+++ b/frontend/src/pages/admin/settings/SettingsFormProvider.tsx
@@ -1,0 +1,135 @@
+import { type ReactNode, useCallback, useMemo, useState } from 'react';
+
+import type {
+  SystemSettingsRead,
+  SystemSettingsUpdate,
+} from '@/api/generated/types.gen';
+import {
+  useSystemSettings,
+  useUpdateSystemSettings,
+} from '@/api/system-settings';
+
+import {
+  describeSaveFailure,
+  isBlank,
+  REQUIRED_SETTING_KEYS,
+} from './settingsFields';
+import { SettingsFormContext } from './useSettingsForm';
+
+export function SettingsFormProvider({ children }: { children: ReactNode }) {
+  const { data: settings, isLoading } = useSystemSettings();
+  const updateSettings = useUpdateSystemSettings();
+
+  const [isEditing, setIsEditing] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  // Only edited fields land here, which is exactly the PATCH body: an
+  // untouched field is absent rather than sent back at its current value.
+  const [draft, setDraft] = useState<SystemSettingsUpdate>({});
+
+  const getField = useCallback(
+    <K extends keyof SystemSettingsUpdate>(key: K) => {
+      if (key in draft) return draft[key];
+      return settings?.[
+        key as keyof SystemSettingsRead
+      ] as SystemSettingsUpdate[K];
+    },
+    [draft, settings]
+  );
+
+  const setField = useCallback(
+    <K extends keyof SystemSettingsUpdate>(
+      key: K,
+      value: SystemSettingsUpdate[K]
+    ) => {
+      setDraft((current) => ({ ...current, [key]: value }));
+    },
+    []
+  );
+
+  /* Refuse to open the form until the saved row is in hand. getField prefers
+   * the draft, so an edit made during the initial fetch would win over the
+   * server's value when it lands -- e.g. adding a reminder to a still-empty
+   * list would PATCH a one-item array over the org's real reminders. */
+  const startEditing = useCallback(() => {
+    if (isLoading) return;
+    setIsEditing(true);
+  }, [isLoading]);
+
+  const cancelEditing = useCallback(() => {
+    setIsEditing(false);
+    setDraft({});
+    setSaveError(null);
+  }, []);
+
+  /* Only fields the admin emptied *in this session* block the save. A field
+   * that was already blank when the page loaded must not: a freshly
+   * provisioned row has every contact column null (ensure_settings() builds it
+   * from model defaults), and blocking on those would leave Save permanently
+   * disabled for someone who only came to flip a toggle on another tab. */
+  const missingRequired = useMemo(
+    () =>
+      REQUIRED_SETTING_KEYS.filter(
+        (key) => key in draft && isBlank(draft[key])
+      ),
+    [draft]
+  );
+
+  const save = useCallback(() => {
+    // The header disables the button, but guard here too so the rule holds for
+    // any other caller rather than relying on the UI to enforce it.
+    if (missingRequired.length > 0) return;
+    setSaveError(null);
+    updateSettings.mutate(
+      { body: draft },
+      {
+        onSuccess: () => {
+          setIsEditing(false);
+          setDraft({});
+        },
+        onError: (error) => {
+          /* Stay in edit mode with the draft intact so the admin can correct
+           * the value. Without this the mutation just settles and the page
+           * looks unchanged -- indistinguishable from a save that worked. */
+          setSaveError(describeSaveFailure(error));
+        },
+      }
+    );
+  }, [draft, missingRequired, updateSettings]);
+
+  const value = useMemo(
+    () => ({
+      settings,
+      isLoading,
+      isEditing,
+      isSaving: updateSettings.isPending,
+      isDirty: Object.keys(draft).length > 0,
+      missingRequired,
+      saveError,
+      getField,
+      setField,
+      startEditing,
+      cancelEditing,
+      save,
+    }),
+    [
+      settings,
+      isLoading,
+      isEditing,
+      updateSettings.isPending,
+      draft,
+      missingRequired,
+      saveError,
+      getField,
+      setField,
+      startEditing,
+      cancelEditing,
+      save,
+    ]
+  );
+
+  return (
+    <SettingsFormContext.Provider value={value}>
+      {children}
+    </SettingsFormContext.Provider>
+  );
+}

--- a/frontend/src/pages/admin/settings/components/ContactInformationPanel.tsx
+++ b/frontend/src/pages/admin/settings/components/ContactInformationPanel.tsx
@@ -1,0 +1,142 @@
+import { Field, FieldLabel, Input } from '@/common/components';
+import { formatPhone } from '@/common/utils';
+import { cn } from '@/lib/utils';
+
+import {
+  isBlank,
+  REQUIRED_SETTING_KEYS,
+  type StringSettingKey,
+} from '../settingsFields';
+import { useSettingsForm } from '../useSettingsForm';
+
+interface ContactField {
+  /* Narrowed to string-valued settings: `keyof SystemSettingsUpdate` would also
+   * admit numeric, boolean and array columns, and widen the value type enough
+   * that writing a string to one of them would still type-check. */
+  key: StringSettingKey;
+  label: string;
+  placeholder: string;
+  type?: string;
+  /** Display transform for a stored value that is not human-readable. */
+  format?: (value: string) => string;
+}
+
+/* Order follows the design, which is also the order these appear in the email
+ * footer: the ways to reach the org first, then its social links. */
+const CONTACT_FIELDS: ContactField[] = [
+  {
+    key: 'f4k_wr_email',
+    label: 'Email',
+    placeholder: 'Enter email address',
+    type: 'email',
+  },
+  {
+    key: 'contact_phone',
+    label: 'Phone Number',
+    placeholder: 'Enter phone number',
+    type: 'tel',
+    /* Stored RFC 3966 ("tel:+1-519-576-3443;ext=1") is not what the design
+     * shows. formatPhone renders it as "(519) 576-3443 Ext. 1" and returns
+     * anything it does not recognise untouched, so text the admin is midway
+     * through typing passes through unchanged. The backend re-normalises on
+     * save, so only the display needs this. */
+    format: formatPhone,
+  },
+  {
+    key: 'f4k_wr_website',
+    label: 'Website',
+    placeholder: 'Enter website URL',
+    type: 'url',
+  },
+  {
+    key: 'f4k_wr_address',
+    label: 'Address',
+    placeholder: 'Enter address',
+  },
+  {
+    key: 'f4k_wr_instagram',
+    label: 'Instagram',
+    placeholder: 'Paste Instagram page URL',
+    type: 'url',
+  },
+  {
+    key: 'f4k_wr_facebook',
+    label: 'Facebook',
+    placeholder: 'Paste Facebook page URL',
+    type: 'url',
+  },
+  {
+    key: 'f4k_wr_twitter',
+    label: 'Twitter',
+    placeholder: 'Paste Twitter page URL',
+    type: 'url',
+  },
+];
+
+export const ContactInformationPanel = () => {
+  const { isEditing, getField, setField } = useSettingsForm();
+
+  return (
+    <div className="flex max-w-[600px] flex-col gap-6">
+      <div className="flex flex-col gap-1">
+        <h2 className="text-h2 text-grey-500 font-bold">
+          Food4Kids Waterloo Region
+        </h2>
+        <p className="text-p2 text-grey-400">
+          Contact details entered here appear in the footer of every automated
+          email to drivers.
+        </p>
+      </div>
+
+      {CONTACT_FIELDS.map(({ key, label, placeholder, type, format }) => {
+        const inputId = `settings-${key}`;
+        // No cast: a StringSettingKey narrows the value to `string | null`.
+        const stored = getField(key) ?? '';
+        const required = (REQUIRED_SETTING_KEYS as readonly string[]).includes(
+          key
+        );
+        // Only nag once they have actually emptied it, not on arrival.
+        const error =
+          isEditing && required && isBlank(stored)
+            ? `${label} is required.`
+            : undefined;
+        return (
+          <Field key={key}>
+            <FieldLabel htmlFor={inputId} required={required}>
+              {label}
+            </FieldLabel>
+            <Input
+              id={inputId}
+              type={type}
+              /* readOnly rather than disabled: the saved value still needs to
+               * read as content (and stay selectable / announced by screen
+               * readers) outside edit mode. `disabled` would also dim it to
+               * opacity-60, which the design does not do -- grey-150 on
+               * grey-400 is the whole uneditable treatment. */
+              readOnly={!isEditing}
+              className={cn(
+                !isEditing &&
+                  // cursor-not-allowed is on `disabled:` in the shared
+                  // Input, which readOnly never triggers -- so the
+                  // "you cannot type here" cue has to be set explicitly.
+                  'bg-grey-150 text-grey-400 cursor-not-allowed'
+              )}
+              /* Figma dev note: "Empty fields display nothing in the text
+               * field." A placeholder prompts you to type, so it belongs to
+               * edit mode only -- outside it an unset field stays blank
+               * instead of looking pre-filled. */
+              placeholder={isEditing ? placeholder : undefined}
+              error={error}
+              value={format ? format(stored) : stored}
+              onChange={(event) =>
+                // An emptied optional field clears the column rather than
+                // storing "", which the model's min_length=1 would reject.
+                setField(key, event.target.value || null)
+              }
+            />
+          </Field>
+        );
+      })}
+    </div>
+  );
+};

--- a/frontend/src/pages/admin/settings/components/EditingBanner.tsx
+++ b/frontend/src/pages/admin/settings/components/EditingBanner.tsx
@@ -1,0 +1,37 @@
+import EditIcon from '@/assets/icons/edit.svg?react';
+import XIcon from '@/assets/icons/x.svg?react';
+
+interface EditingBannerProps {
+  onDismiss: () => void;
+}
+
+/**
+ * The "editing enabled" pill that sits beside the page title while the settings
+ * form is unlocked.
+ *
+ * Deliberately not the shared {@link Banner}: that one is the full-width
+ * bordered block used for success/error/warning results. This is the design's
+ * compact neutral pill — it reports a mode, not an outcome, so it carries no
+ * status colour.
+ */
+export const EditingBanner = ({ onDismiss }: EditingBannerProps) => {
+  return (
+    <div
+      role="status"
+      className="border-grey-300 bg-grey-100 flex items-center gap-4 rounded-[40px] border px-6 py-3"
+    >
+      <EditIcon aria-hidden="true" className="text-grey-500 size-5 shrink-0" />
+      <p className="text-p1 text-grey-500">
+        Editing enabled. Save changes to apply updates.
+      </p>
+      <button
+        type="button"
+        onClick={onDismiss}
+        aria-label="Stop editing"
+        className="text-grey-500 hover:text-grey-400 shrink-0 cursor-pointer transition-colors"
+      >
+        <XIcon className="size-5" />
+      </button>
+    </div>
+  );
+};

--- a/frontend/src/pages/admin/settings/components/RouteRemindersPanel.tsx
+++ b/frontend/src/pages/admin/settings/components/RouteRemindersPanel.tsx
@@ -1,0 +1,243 @@
+import type { EmailReminder } from '@/api/generated/types.gen';
+import TrashIcon from '@/assets/icons/trash.svg?react';
+import {
+  Button,
+  Dropdown,
+  DropdownContent,
+  DropdownItem,
+  DropdownTrigger,
+  DropdownValue,
+  Switch,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/common/components';
+
+import {
+  ADD_REMINDER_LIMIT_MESSAGE,
+  createReminder,
+  daysBeforeOptionsFor,
+  formatDaysBefore,
+  formatTimeLabel,
+  MAX_REMINDERS,
+  timeOptionsFor,
+} from '../reminderOptions';
+import { useSettingsForm } from '../useSettingsForm';
+
+interface ReminderRowProps {
+  reminder: EmailReminder;
+  index: number;
+  isEditing: boolean;
+  onChange: (index: number, next: EmailReminder) => void;
+  onRemove: (index: number) => void;
+}
+
+const ReminderRow = ({
+  reminder,
+  index,
+  isEditing,
+  onChange,
+  onRemove,
+}: ReminderRowProps) => {
+  const daysId = `reminder-${index}-days`;
+  const timeId = `reminder-${index}-time`;
+
+  return (
+    <div className="flex flex-col gap-2">
+      <h3 className="text-h3 text-grey-500 font-bold">
+        Notification {index + 1}
+      </h3>
+      <div className="flex items-end gap-8">
+        <div className="flex flex-col gap-1">
+          <label htmlFor={daysId} className="text-p2 text-grey-400">
+            How many days before?
+          </label>
+          <Dropdown
+            value={String(reminder.days_before)}
+            onValueChange={(value) =>
+              onChange(index, { ...reminder, days_before: Number(value) })
+            }
+            disabled={!isEditing}
+          >
+            <DropdownTrigger id={daysId} className="w-[148px]">
+              <DropdownValue />
+            </DropdownTrigger>
+            <DropdownContent>
+              {daysBeforeOptionsFor(reminder.days_before).map((days) => (
+                <DropdownItem key={days} value={String(days)}>
+                  {formatDaysBefore(days)}
+                </DropdownItem>
+              ))}
+            </DropdownContent>
+          </Dropdown>
+        </div>
+
+        <div className="flex flex-col gap-1">
+          <label htmlFor={timeId} className="text-p2 text-grey-400">
+            At what time?
+          </label>
+          <Dropdown
+            value={reminder.time}
+            onValueChange={(value) =>
+              onChange(index, { ...reminder, time: value })
+            }
+            disabled={!isEditing}
+          >
+            <DropdownTrigger id={timeId} className="w-[126px]">
+              <DropdownValue />
+            </DropdownTrigger>
+            <DropdownContent className="max-h-64 overflow-y-auto">
+              {timeOptionsFor(reminder.time).map((time) => (
+                <DropdownItem key={time} value={time}>
+                  {formatTimeLabel(time)}
+                </DropdownItem>
+              ))}
+            </DropdownContent>
+          </Dropdown>
+        </div>
+
+        {isEditing && (
+          <Button
+            variant="destructive"
+            shape="circular"
+            onClick={() => onRemove(index)}
+            aria-label={`Remove notification ${index + 1}`}
+          >
+            <TrashIcon className="size-5" />
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+};
+
+interface AnnouncementToggle {
+  key: 'announcement_emails_to_admins' | 'announcement_emails_to_drivers';
+  label: string;
+}
+
+const ANNOUNCEMENT_TOGGLES: AnnouncementToggle[] = [
+  {
+    key: 'announcement_emails_to_admins',
+    label: 'Enable email notifications for admin',
+  },
+  {
+    key: 'announcement_emails_to_drivers',
+    label: 'Enable email notifications for drivers',
+  },
+];
+
+/**
+ * Audience filters for announcement emails.
+ *
+ * These do not send anything on their own -- they narrow who receives an
+ * announcement that was already posted with email requested from the
+ * announcements board. With both off, such a post emails no one.
+ */
+const AnnouncementsSection = () => {
+  const { isEditing, getField, setField } = useSettingsForm();
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex flex-col gap-1">
+        <h2 className="text-h2 text-grey-500 font-bold">Announcements</h2>
+        <p className="text-p2 text-grey-400">
+          Admins and drivers can be notified by email when announcements are
+          posted.
+        </p>
+      </div>
+      <div className="flex max-w-[420px] flex-col gap-2">
+        {ANNOUNCEMENT_TOGGLES.map(({ key, label }) => {
+          const switchId = `settings-${key}`;
+          return (
+            <div key={key} className="flex items-center justify-between gap-8">
+              <label htmlFor={switchId} className="text-p1 text-grey-500">
+                {label}
+              </label>
+              <Switch
+                id={switchId}
+                checked={getField(key) ?? true}
+                onCheckedChange={(checked) => setField(key, checked)}
+                disabled={!isEditing}
+              />
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+export const RouteRemindersPanel = () => {
+  const { isEditing, getField, setField } = useSettingsForm();
+  const reminders = getField('email_reminders') ?? [];
+  const isAtLimit = reminders.length >= MAX_REMINDERS;
+
+  const replaceAt = (index: number, next: EmailReminder) => {
+    setField(
+      'email_reminders',
+      reminders.map((reminder, i) => (i === index ? next : reminder))
+    );
+  };
+
+  const removeAt = (index: number) => {
+    setField(
+      'email_reminders',
+      reminders.filter((_, i) => i !== index)
+    );
+  };
+
+  const addReminder = () => {
+    setField('email_reminders', [...reminders, createReminder()]);
+  };
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex flex-col gap-1">
+        <h2 className="text-h2 text-grey-500 font-bold">
+          Automated Route Reminders
+        </h2>
+        <p className="text-p2 text-grey-400">
+          Email reminders can be sent to drivers before their routes. Up to
+          three notifications can be set.
+        </p>
+      </div>
+
+      {isEditing &&
+        /* The button stays mounted at the limit so the tooltip has a trigger to
+         * hang off — a disabled button swallows pointer events, so the wrapper
+         * span is what Radix listens on. */
+        (isAtLimit ? (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span className="w-fit">
+                <Button disabled className="w-fit">
+                  Add notification
+                </Button>
+              </span>
+            </TooltipTrigger>
+            <TooltipContent className="bg-grey-500 text-grey-100">
+              {ADD_REMINDER_LIMIT_MESSAGE}
+            </TooltipContent>
+          </Tooltip>
+        ) : (
+          <Button onClick={addReminder} className="w-fit">
+            Add notification
+          </Button>
+        ))}
+
+      {reminders.map((reminder, index) => (
+        <ReminderRow
+          key={index}
+          reminder={reminder}
+          index={index}
+          isEditing={isEditing}
+          onChange={replaceAt}
+          onRemove={removeAt}
+        />
+      ))}
+
+      <AnnouncementsSection />
+    </div>
+  );
+};

--- a/frontend/src/pages/admin/settings/components/index.ts
+++ b/frontend/src/pages/admin/settings/components/index.ts
@@ -1,2 +1,3 @@
-// Export Admin Settings page components here
-export {};
+export { ContactInformationPanel } from './ContactInformationPanel';
+export { EditingBanner } from './EditingBanner';
+export { RouteRemindersPanel } from './RouteRemindersPanel';

--- a/frontend/src/pages/admin/settings/reminderOptions.ts
+++ b/frontend/src/pages/admin/settings/reminderOptions.ts
@@ -1,0 +1,87 @@
+import type { EmailReminder } from '@/api/generated/types.gen';
+
+/** "Up to three notifications can be set", per the design. */
+export const MAX_REMINDERS = 3;
+
+export const ADD_REMINDER_LIMIT_MESSAGE =
+  "You've reached the limit of three automated reminders";
+
+/**
+ * Lead days offered in the "How many days before?" dropdown.
+ *
+ * Starts at 1, not 0: a reminder is meant to arrive *ahead* of the route, so
+ * "day of" is not a lead time an admin should be able to pick. The model still
+ * permits `days_before >= 0`, and the Figma shows "Day of" on Notification 1 --
+ * this is a deliberate product decision to require a real day.
+ *
+ * The ceiling is a UI choice: a week covers the cadence the design shows with
+ * room either side, and keeps the list scannable.
+ */
+const MIN_DAYS_BEFORE = 1;
+const MAX_DAYS_BEFORE = 7;
+
+export const DAYS_BEFORE_OPTIONS = Array.from(
+  { length: MAX_DAYS_BEFORE - MIN_DAYS_BEFORE + 1 },
+  (_, i) => i + MIN_DAYS_BEFORE
+);
+
+/**
+ * The options to offer for a reminder whose stored lead is `value`.
+ *
+ * Rows saved before this rule existed -- the seed still creates a day-of
+ * reminder -- can sit outside the list, and Radix Select renders an unmatched
+ * value as blank. Including the stored value keeps the row truthful and
+ * editable; it just is not offered to anything that does not already use it.
+ */
+export function daysBeforeOptionsFor(value: number): number[] {
+  if (DAYS_BEFORE_OPTIONS.includes(value)) return DAYS_BEFORE_OPTIONS;
+  return [...DAYS_BEFORE_OPTIONS, value].sort((a, b) => a - b);
+}
+
+export function formatDaysBefore(days: number): string {
+  if (days === 0) return 'Day of';
+  return days === 1 ? '1 day before' : `${days} days before`;
+}
+
+const TIME_STEP_MINUTES = 30;
+
+function toTimeValue(hour: number, minute: number): string {
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${pad(hour)}:${pad(minute)}:00`;
+}
+
+export const TIME_OPTIONS = Array.from(
+  { length: (24 * 60) / TIME_STEP_MINUTES },
+  (_, slot) => {
+    const totalMinutes = slot * TIME_STEP_MINUTES;
+    return toTimeValue(Math.floor(totalMinutes / 60), totalMinutes % 60);
+  }
+);
+
+export function formatTimeLabel(value: string): string {
+  const [hourRaw = 0, minuteRaw = 0] = value.split(':').map(Number);
+  const period = hourRaw >= 12 ? 'PM' : 'AM';
+  const hour = hourRaw % 12 === 0 ? 12 : hourRaw % 12;
+  return `${hour}:${String(minuteRaw).padStart(2, '0')} ${period}`;
+}
+
+/**
+ * The options to offer for a reminder whose stored time is `value`.
+ *
+ * A reminder saved before this screen existed -- or seeded -- can sit off the
+ * 30-minute grid, and Radix Select renders a value with no matching item as
+ * blank. Rounding the *display* onto the grid would be worse than blank: the
+ * row would claim a time the reminder does not actually fire at, and editing
+ * any other part of that row would carry the real time through to the PATCH
+ * unchanged. Offering the stored value as its own option keeps what is shown
+ * and what is saved identical.
+ */
+export function timeOptionsFor(value: string): string[] {
+  if (TIME_OPTIONS.includes(value)) return TIME_OPTIONS;
+  return [...TIME_OPTIONS, value].sort();
+}
+
+/** A new row copies the model's own default rather than inventing a time. */
+export function createReminder(): EmailReminder {
+  return { days_before: 1, time: '09:00:00' };
+}

--- a/frontend/src/pages/admin/settings/settingsFields.ts
+++ b/frontend/src/pages/admin/settings/settingsFields.ts
@@ -1,0 +1,66 @@
+import { isAxiosError } from 'axios';
+
+import { describeApiFailure } from '@/api/errors';
+import type { SystemSettingsUpdate } from '@/api/generated/types.gen';
+
+/**
+ * The settings keys whose value is a plain string.
+ *
+ * `keyof SystemSettingsUpdate` is too wide for a text input: it also covers
+ * numbers (`boxes_per_car`), booleans (`announcement_emails_to_admins`), arrays
+ * (`delivery_types`, `email_reminders`) and the import map. Because a key typed
+ * as that whole union widens the value type to a union too, assigning a string
+ * to a numeric column would type-check. Narrowing here makes a wrong key a
+ * compile error instead, and removes the need to cast reads back to `string`.
+ */
+export type StringSettingKey = {
+  [K in keyof SystemSettingsUpdate]-?: NonNullable<
+    SystemSettingsUpdate[K]
+  > extends string
+    ? K
+    : never;
+}[keyof SystemSettingsUpdate];
+
+/**
+ * Settings that must hold a value before changes can be saved.
+ *
+ * The single source of truth for "required": it drives the red asterisk on the
+ * label *and* the save block. Keeping one list is the point — an asterisk that
+ * nothing enforces is worse than no asterisk, because it claims a guarantee the
+ * column (all of these are nullable server-side) does not make.
+ */
+export const REQUIRED_SETTING_KEYS = [
+  'f4k_wr_email',
+  'contact_phone',
+  'f4k_wr_website',
+  'f4k_wr_address',
+] as const satisfies readonly StringSettingKey[];
+
+export type RequiredSettingKey = (typeof REQUIRED_SETTING_KEYS)[number];
+
+/** Whitespace is not a value -- " " should not satisfy a required field. */
+export function isBlank(value: string | null | undefined): boolean {
+  return !value || !value.trim();
+}
+
+/**
+ * Turn a failed settings PATCH into something worth showing an admin.
+ *
+ * `describeApiFailure` deliberately returns null for a 4xx, because only the
+ * caller knows how to word "the server looked at your input and refused it".
+ * For this form that means surfacing the server's own `detail`, which is where
+ * the model validators (`EmailStr`, `validate_phone`, the delivery-type rules)
+ * put their reason.
+ */
+export function describeSaveFailure(error: unknown): string {
+  const generic = describeApiFailure(error);
+  if (generic) return generic;
+
+  const detail = isAxiosError(error)
+    ? (error.response?.data as { detail?: unknown } | undefined)?.detail
+    : undefined;
+
+  if (typeof detail === 'string') return detail;
+  // FastAPI's 422 shape is a list of per-field objects, too raw to show as-is.
+  return 'Some values were rejected. Check the highlighted fields and try again.';
+}

--- a/frontend/src/pages/admin/settings/useSettingsForm.ts
+++ b/frontend/src/pages/admin/settings/useSettingsForm.ts
@@ -1,0 +1,55 @@
+import { createContext, useContext } from 'react';
+
+import type {
+  SystemSettingsRead,
+  SystemSettingsUpdate,
+} from '@/api/generated/types.gen';
+
+import type { RequiredSettingKey } from './settingsFields';
+
+export interface SettingsFormValue {
+  /** The saved row. `undefined` only while the first fetch is in flight. */
+  settings: SystemSettingsRead | undefined;
+  isLoading: boolean;
+  isEditing: boolean;
+  isSaving: boolean;
+  /** True once any field has been edited away from its saved value. */
+  isDirty: boolean;
+  /**
+   * The edited value for a field, falling back to what is saved. Every panel
+   * reads through this so read mode and edit mode render from one source.
+   */
+  getField: <K extends keyof SystemSettingsUpdate>(
+    key: K
+  ) => SystemSettingsUpdate[K];
+  setField: <K extends keyof SystemSettingsUpdate>(
+    key: K,
+    value: SystemSettingsUpdate[K]
+  ) => void;
+  /**
+   * Required settings that are currently blank. Non-empty means the draft
+   * cannot be saved -- the header disables the save button off this, and the
+   * panels flag the individual fields.
+   */
+  missingRequired: RequiredSettingKey[];
+  /** Why the last save failed, or null. Cleared when editing is cancelled. */
+  saveError: string | null;
+  startEditing: () => void;
+  /** Leaves edit mode and throws the draft away. */
+  cancelEditing: () => void;
+  save: () => void;
+}
+
+export const SettingsFormContext = createContext<SettingsFormValue | null>(
+  null
+);
+
+export function useSettingsForm() {
+  const context = useContext(SettingsFormContext);
+  if (!context) {
+    throw new Error(
+      'useSettingsForm must be used within a SettingsFormProvider'
+    );
+  }
+  return context;
+}


### PR DESCRIPTION
## JIRA Ticket
[F4KRP-194](https://f4kblueprint.atlassian.net/browse/F4KRP-194)

Frontend changes - only implements 2/3 tabs on the settings page

## Implementation Description
<!-- Quick summary of what you built and why. Include design justifications if needed -->
* Added the route reminder and contact info tabs - delivery defaults will be added separately.
* The Contact Information subtitle is false. It says these details appear in every email footer; the footer is hardcoded in F4KEmailLayout. Editing those fields changes no email. -> will be fixed in another pr

## Steps to Test
<!-- What should the reviewer do to verify your changes? Include expected results -->
1. Can test out the ui

## Screenshots *(frontend only — delete if not applicable)*
Implemented (uneditable):
<img width="1591" height="752" alt="Screenshot 2026-08-25 at 7 09 50 PM" src="https://github.com/user-attachments/assets/e6fcbce5-745c-418b-812e-2e50a5071167" />

<img width="1617" height="911" alt="Screenshot 2026-08-25 at 7 10 11 PM" src="https://github.com/user-attachments/assets/508fe91f-9f77-4c78-b741-627a8560a0f5" />


Figma (uneditable):
<img width="1472" height="1144" alt="Settings - Route Reminders - NON-EDITABLE MODE" src="https://github.com/user-attachments/assets/f8d1a7c2-526f-4896-af0c-9d26de037ecb" />

<img width="1472" height="1144" alt="Settings - Automated Route Reminders" src="https://github.com/user-attachments/assets/cd4947b5-1251-4358-bdff-72e9565f1c67" />

Implemented (editable):
<img width="1201" height="794" alt="Screenshot 2026-08-25 at 7 12 51 PM" src="https://github.com/user-attachments/assets/a6a00193-7036-4241-a9cc-0ee2712a8468" />

<img width="1199" height="862" alt="Screenshot 2026-08-25 at 7 13 07 PM" src="https://github.com/user-attachments/assets/1a49696e-f450-4742-9674-cb4e17c70f89" />

Figma (editable):
<img width="1472" height="1144" alt="3 Notifications - EDITING MODE" src="https://github.com/user-attachments/assets/e448e0dd-85e7-4991-83f7-c7a189b7182f" />

<img width="1472" height="1144" alt="Settings - Automated Route Reminders (1)" src="https://github.com/user-attachments/assets/56a42be3-ee0b-483f-bfdc-009d695fde31" />

## What Should Reviewers Focus On?
<!-- Call out substantial changes or anything you want a second opinion on -->
* Does user interaction make sense? Clicking on the dropdown, adding notification, etc.?

## Checklist
- [x] PR name and commits are descriptive, imperative, and atomic (trivial commits squashed)
- [x] I have requested a review from Claude, understood its suggestions, and implemented fixes where needed (or documented disagreements)
- [x] I have requested a review from the PL and relevant devs with background on this PR

**Frontend only — delete if not applicable:**
- [x] Follows Tailwind/shadcn best practices per README; no hardcoded color or spacing values
- [x] Implementation matches Zeplin designs and screenshots are attached above
- [x] Screens render correctly on mobile and desktop; no console warnings or errors