### PR TITLE
Run CI on Node 24.13.0 to match the Dockerfile

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -43,7 +43,7 @@ jobs:
         if: steps.changes.outputs.frontend == 'true'
         uses: actions/setup-node@v4
         with:
-          node-version: "20.11.1"
+          node-version: "24.13.0"
           cache: "pnpm"
           cache-dependency-path: frontend/pnpm-lock.yaml
 

--- a/.github/workflows/openapi-sync.yml
+++ b/.github/workflows/openapi-sync.yml
@@ -95,7 +95,7 @@ jobs:
         if: steps.changes.outputs.contract == 'true'
         uses: actions/setup-node@v4
         with:
-          node-version: "20.11.1"
+          node-version: "24.13.0"
           cache: "pnpm"
           cache-dependency-path: frontend/pnpm-lock.yaml
 
@@ -206,7 +206,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20.11.1"
+          node-version: "24.13.0"
           cache: "pnpm"
           cache-dependency-path: frontend/pnpm-lock.yaml
 

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -17,8 +17,14 @@ export default defineConfig({
     host: true, // Important for Docker
   },
   test: {
-    // Node 20+ supplies File/FormData/Blob, so these request-shape tests need
-    // no DOM. Add jsdom here if we ever test components.
+    // Node supplies File/FormData/Blob, so these request-shape tests need no
+    // DOM. Add jsdom here if we ever test components.
+    //
+    // Keep frontend/Dockerfile and the CI workflows on the SAME Node (24.13.0
+    // today). When they drift, a dep whose engines.node outruns CI's passes
+    // every local check and fails only in CI. Verify a bump on CI's Node:
+    //   docker run --rm -v "$PWD:/app" -w /app node:24.13.0 \
+    //     sh -c 'corepack enable && pnpm install --frozen-lockfile && pnpm test'
     environment: 'node',
     include: ['src/**/*.test.{ts,tsx}'],
   }


### PR DESCRIPTION
CI was pinned to Node 20.11.1 while `frontend/Dockerfile` runs node:24.13.0 — prod, local dev and every contributor's machine are on 24, and only the gate was on a February 2024 build. That bit us today: jsdom 28 pulls `html-encoding-sniffer@6`, which `require()`s an ESM-only package, and `require(esm)` only landed in Node 20.19. Every local check passed and CI went red.

`node-version` becomes `24.13.0` in the three places it appears (`lint.yml`, and both jobs in `openapi-sync.yml`). Those are the only Node pins in the repo. The stale "Node 20+" note in `vite.config.ts` is rewritten.

Worth knowing: this PR's own CI does **not** exercise the `openapi-sync` bump — that job's path filter watches files this PR doesn't touch, so it reports green without running Node. The generator determinism was checked locally instead; the daily audit job covers it on main.