### PR TITLE
Show the route group on driver-facing views

### DIFF
--- a/backend/python/app/models/route.py
+++ b/backend/python/app/models/route.py
@@ -133,13 +133,16 @@ class RouteDetailRead(RouteRead):
     Stops are assembled with snapshot-over-live precedence. See
     RouteStopDetailRead.
 
-    drive_date is sourced from the route's RouteGroup (mirrors
+    drive_date and group_name are sourced from the route's RouteGroup (mirrors
     RouteWithDateRead). delivery_type is uniform across a route's locations, so
     it's read from the first stop's Location and is None when the route has no
     stops.
     """
 
     drive_date: date
+    # Route names are only unique within their group ("Route 1" restarts in
+    # every group), so the driver view shows the group alongside the name.
+    group_name: str
     delivery_type: str | None = None
     stops: list[RouteStopDetailRead] = Field(default_factory=list)
 

--- a/backend/python/app/services/implementations/route_service.py
+++ b/backend/python/app/services/implementations/route_service.py
@@ -333,15 +333,15 @@ class RouteService:
 
             children_per_box = await resolve_children_per_box(session)
             rows = await self._fetch_ordered_stops(session, route_id)
-            # drive_date lives on the route's group (same source as the list
-            # endpoint's RouteWithDateRead).
-            drive_date = (
+            # drive_date and the group's name live on the route's group (same
+            # source as the list endpoint's RouteWithDateRead).
+            drive_date, group_name = (
                 await session.execute(
-                    select(col(RouteGroup.drive_date)).where(
+                    select(col(RouteGroup.drive_date), col(RouteGroup.name)).where(
                         RouteGroup.route_group_id == route.route_group_id
                     )
                 )
-            ).scalar_one()
+            ).one()
         except Exception:
             # Roll back so the caller's session is usable, then let the error
             # through: UnhandledExceptionMiddleware logs it and answers 500.
@@ -381,6 +381,7 @@ class RouteService:
         return RouteDetailRead(
             **route_read.model_dump(),
             drive_date=drive_date,
+            group_name=group_name,
             delivery_type=delivery_type,
             stops=stops,
         )

--- a/backend/python/tests/test_routes.py
+++ b/backend/python/tests/test_routes.py
@@ -3419,7 +3419,7 @@ class TestRouteRoutes:
 
     @pytest.mark.asyncio
     async def test_get_route_by_id(
-        self, async_client: AsyncClient, test_route: Any
+        self, async_client: AsyncClient, test_route: Any, test_route_group: Any
     ) -> None:
         """GET /routes/{id} returns the route with an (empty) stops list."""
         response = await async_client.get(f"/routes/{test_route.route_id}")
@@ -3427,10 +3427,31 @@ class TestRouteRoutes:
         body = response.json()
         assert body["route_id"] == str(test_route.route_id)
         assert body["stops"] == []
-        # drive_date is sourced from the route's group; with no stops there's no
-        # location to read a delivery_type from.
+        # drive_date and group_name are sourced from the route's group; with no
+        # stops there's no location to read a delivery_type from.
         assert body["drive_date"] is not None
+        assert body["group_name"] == test_route_group.name
         assert body["delivery_type"] is None
+
+    @pytest.mark.asyncio
+    async def test_driver_views_agree_on_the_group_name(
+        self, async_client: AsyncClient, test_route: Any, test_route_group: Any
+    ) -> None:
+        """The driver's home card reads the list endpoint and the route detail
+        page reads the single endpoint. Both label the route with its group, so
+        they have to report the same one."""
+        listed = await async_client.get("/routes")
+        detail = await async_client.get(f"/routes/{test_route.route_id}")
+
+        assert listed.status_code == 200
+        assert detail.status_code == 200
+        row = next(
+            item
+            for item in listed.json()["items"]
+            if item["route_id"] == str(test_route.route_id)
+        )
+        assert row["group_name"] == detail.json()["group_name"]
+        assert row["group_name"] == test_route_group.name
 
     @pytest.mark.asyncio
     async def test_get_route_by_id_embeds_ordered_stops(

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -2866,7 +2866,7 @@
         "type": "string"
       },
       "RouteDetailRead": {
-        "description": "GET /routes/{route_id} response: the bare route plus its ordered stops.\n\nStops are assembled with snapshot-over-live precedence. See\nRouteStopDetailRead.\n\ndrive_date is sourced from the route's RouteGroup (mirrors\nRouteWithDateRead). delivery_type is uniform across a route's locations, so\nit's read from the first stop's Location and is None when the route has no\nstops.",
+        "description": "GET /routes/{route_id} response: the bare route plus its ordered stops.\n\nStops are assembled with snapshot-over-live precedence. See\nRouteStopDetailRead.\n\ndrive_date and group_name are sourced from the route's RouteGroup (mirrors\nRouteWithDateRead). delivery_type is uniform across a route's locations, so\nit's read from the first stop's Location and is None when the route has no\nstops.",
         "properties": {
           "cloned_from_route_id": {
             "anyOf": [
@@ -2923,6 +2923,10 @@
             "default": false,
             "title": "Ends At Warehouse",
             "type": "boolean"
+          },
+          "group_name": {
+            "title": "Group Name",
+            "type": "string"
           },
           "length": {
             "minimum": 0,
@@ -3000,7 +3004,8 @@
           "length",
           "route_group_id",
           "route_id",
-          "drive_date"
+          "drive_date",
+          "group_name"
         ],
         "title": "RouteDetailRead",
         "type": "object"

--- a/frontend/src/api/generated/types.gen.ts
+++ b/frontend/src/api/generated/types.gen.ts
@@ -1657,7 +1657,7 @@ export type ProgressEnum =
  * Stops are assembled with snapshot-over-live precedence. See
  * RouteStopDetailRead.
  *
- * drive_date is sourced from the route's RouteGroup (mirrors
+ * drive_date and group_name are sourced from the route's RouteGroup (mirrors
  * RouteWithDateRead). delivery_type is uniform across a route's locations, so
  * it's read from the first stop's Location and is None when the route has no
  * stops.
@@ -1687,6 +1687,10 @@ export type RouteDetailRead = {
    * Ends At Warehouse
    */
   ends_at_warehouse?: boolean;
+  /**
+   * Group Name
+   */
+  group_name: string;
   /**
    * Length
    */

--- a/frontend/src/pages/driver/home/DriverHomePage.tsx
+++ b/frontend/src/pages/driver/home/DriverHomePage.tsx
@@ -64,15 +64,6 @@ export const DriverHomePage = () => {
     return driveDate < today;
   });
 
-  // Format date for display
-  const formatDate = (dateString: string) => {
-    const date = new Date(dateString);
-    return date.toLocaleDateString('en-US', {
-      month: 'short',
-      day: 'numeric',
-    });
-  };
-
   // Format time for display
   const formatTime = (timeString: string | null) => {
     if (!timeString) return '';
@@ -169,7 +160,7 @@ export const DriverHomePage = () => {
                   key={route.route_id}
                   routeId={route.route_id}
                   title={route.name}
-                  date={`${formatDate(route.drive_date)} · ${formatTime(route.start_time)} · ${route.num_stops} stops`}
+                  date={`${route.group_name} · ${formatTime(route.start_time)} · ${route.num_stops} stops`}
                   isPast={false}
                 />
               ))}
@@ -197,7 +188,7 @@ export const DriverHomePage = () => {
                   key={route.route_id}
                   routeId={route.route_id}
                   title={route.name}
-                  date={`${formatDate(route.drive_date)} · ${formatTime(route.start_time)} · ${route.num_stops} stops`}
+                  date={`${route.group_name} · ${formatTime(route.start_time)} · ${route.num_stops} stops`}
                   isPast={true}
                 />
               ))}

--- a/frontend/src/pages/driver/route/components/RouteDetailView.tsx
+++ b/frontend/src/pages/driver/route/components/RouteDetailView.tsx
@@ -75,7 +75,10 @@ export function RouteDetailView({ routeId, className }: RouteDetailViewProps) {
 
   const stops = route.stops ?? [];
   const boxTotal = stops.reduce((sum, stop) => sum + stop.boxes, 0);
+  // The group leads: route names restart at "Route 1" in every group, so the
+  // name alone doesn't identify which route this is.
   const subtitle = [
+    route.group_name,
     formatDriveDate(route.drive_date),
     formatStartTime(route.start_time),
   ].filter(Boolean);


### PR DESCRIPTION
Generated route names restart at `Route 1` in every route group, so on the driver's views — where the name is the only label — it doesn't say which route it is. The group already has a meaningful name, so this shows it on the two driver-facing views that lacked it: the home card subtitle, and the route detail page (and therefore the printed PDF). Nothing is renamed or written.

Putting it into the stored name was worse: it duplicates the date at exactly the sites it was meant to help, it clips inside `UnassignedRoutePreviewCard`, and it writes the decision to the database with no backfill.

One tradeoff worth a look: the home card's formatted `Sep 25` is now replaced by `group_name`, which carries the date only by convention. Rename a group to something dateless and the home card loses its date. Keeping both prints it twice.