### PR TITLE
Sort route names naturally

### DIFF
--- a/backend/python/app/services/implementations/location_service.py
+++ b/backend/python/app/services/implementations/location_service.py
@@ -63,6 +63,7 @@ from app.services.implementations.location_import_validation import (
 )
 from app.utilities.google_maps_client import GeocodeResult, GoogleMapsClient
 from app.utilities.pagination import paginate_query
+from app.utilities.route_ordering import route_name_order_by
 
 if TYPE_CHECKING:
     from app.services.implementations.system_settings_service import (
@@ -378,7 +379,9 @@ class LocationService:
         """Return a mapping of location_id → route name for the soonest
         upcoming unfrozen route group each location appears in.
 
-        One query rather than per-location N+1.
+        A location on two routes the same day reports the lower-numbered one,
+        so the column doesn't flip between loads. One query rather than
+        per-location N+1.
         """
         ids = list(location_ids)
         if not ids:
@@ -395,7 +398,10 @@ class LocationService:
             .where(col(RouteStop.location_id).in_(ids))
             .where(RouteGroup.drive_date >= today)
             .where(col(RouteSnapshot.route_id).is_(None))
-            .order_by(col(RouteGroup.drive_date).asc())
+            .order_by(
+                col(RouteGroup.drive_date).asc(),
+                *route_name_order_by(col(Route.name)),
+            )
         )
         result = await session.execute(statement)
         assigned: dict[UUID, str] = {}

--- a/backend/python/app/services/implementations/route_group_service.py
+++ b/backend/python/app/services/implementations/route_group_service.py
@@ -29,6 +29,7 @@ from app.models.route_stop import RouteStop
 from app.schemas.pagination import PaginatedResponse, PaginationParams
 from app.utilities.boxes import box_count_expr, resolve_children_per_box
 from app.utilities.pagination import paginate_query
+from app.utilities.route_ordering import route_name_sort_key
 
 ROUTE_GROUP_COPY_PREFIX = "Copy of "
 ROUTE_GROUP_NAME_MAX_LENGTH = 255
@@ -119,7 +120,9 @@ class RouteGroupService:
         )
         session.add(duplicated_group)
 
-        for route in sorted(route_group.routes, key=lambda item: item.name):
+        for route in sorted(
+            route_group.routes, key=lambda r: route_name_sort_key(r.name)
+        ):
             duplicated_route = Route(
                 name=route.name,
                 notes=route.notes,
@@ -261,7 +264,8 @@ class RouteGroupService:
 
         routes: list[RouteReadSummary] = []
         if include_routes:
-            for route in rg.routes:
+            # The relationship load has no order of its own.
+            for route in sorted(rg.routes, key=lambda r: route_name_sort_key(r.name)):
                 routes.append(
                     RouteReadSummary(
                         route_id=route.route_id,

--- a/backend/python/app/services/implementations/route_service.py
+++ b/backend/python/app/services/implementations/route_service.py
@@ -43,6 +43,7 @@ from app.utilities.google_maps_link import (
     build_google_maps_directions_url,
 )
 from app.utilities.pagination import paginate_query
+from app.utilities.route_ordering import route_name_order_by
 from app.utilities.routes_utils import fetch_route_polyline
 
 
@@ -250,7 +251,8 @@ class RouteService:
         # share a name, and paginate_query's count and page are separate
         # statements, so any remaining tie can shuffle a row between pages.
         statement = statement.order_by(
-            drive_date_order, col(Route.name), col(Route.route_id)
+            drive_date_order,
+            *route_name_order_by(col(Route.name), col(Route.route_id)),
         )
 
         if pagination is None:

--- a/backend/python/app/utilities/route_ordering.py
+++ b/backend/python/app/utilities/route_ordering.py
@@ -1,4 +1,4 @@
-"""Natural ordering for route names.
+"""Natural, case-insensitive ordering for route names.
 
 Routes are generated as ``Route {n}``, so ordering by the name as text puts
 ``Route 10`` between ``Route 1`` and ``Route 2``. Names are editable, though,
@@ -8,7 +8,12 @@ number alone would drop ``3rd shift`` between ``Route 2`` and ``Route 4``.
 Names in practice are one text prefix followed by one number, so the key is
 (text before the first digit, that number, the whole name): ``Cambridge`` sorts
 among the text names, ``Route 1`` … ``Route 12`` count up inside their shared
-prefix. This is the single source of truth for that ordering — the SQL form for
+prefix. Both text parts are lowered so ``route 1`` sits with ``Route 1``
+rather than after ``Route 9``, and so the result doesn't depend on the
+deployed database's collation. The raw name follows the lowered one, keeping
+the order total when two names differ only in case.
+
+This is the single source of truth for that ordering — the SQL form for
 queries, the Python form for route lists already loaded in memory.
 """
 
@@ -25,26 +30,28 @@ _NUMBER_RUN = r"\d{1,9}"
 
 
 def route_name_order_by(name_col: Any, *tiebreak_cols: Any) -> list[Any]:
-    """ORDER BY clauses sorting route names naturally.
+    """ORDER BY clauses sorting route names naturally, ignoring case.
 
     Splat into ``order_by``, after any leading keys (e.g. drive_date), passing
     a unique column as ``tiebreak_cols`` where the order has to be total.
     """
     return [
-        func.substring(name_col, _TEXT_PREFIX),
+        func.lower(func.substring(name_col, _TEXT_PREFIX)),
         nulls_last(cast(func.substring(name_col, _NUMBER_RUN), Integer)),
+        func.lower(name_col),
         name_col,
         *tiebreak_cols,
     ]
 
 
-def route_name_sort_key(name: str) -> tuple[str, bool, int, str]:
+def route_name_sort_key(name: str) -> tuple[str, bool, int, str, str]:
     """``sorted`` key mirroring :func:`route_name_order_by`."""
     prefix = re.match(_TEXT_PREFIX, name)
     number = re.search(_NUMBER_RUN, name)
     return (
-        prefix.group() if prefix else "",
+        prefix.group().lower() if prefix else "",
         number is None,
         int(number.group()) if number else 0,
+        name.lower(),
         name,
     )

--- a/backend/python/app/utilities/route_ordering.py
+++ b/backend/python/app/utilities/route_ordering.py
@@ -1,12 +1,15 @@
-"""Numeric-aware ordering for route names.
+"""Natural ordering for route names.
 
 Routes are generated as ``Route {n}``, so ordering by the name as text puts
-``Route 10`` between ``Route 1`` and ``Route 2``. Ordering by the first run of
-digits in the name fixes that. Names are editable, so a name with no digits
-sorts last and falls back to the name itself — never an error.
+``Route 10`` between ``Route 1`` and ``Route 2``. Names are editable, though,
+so the ordering also has to place a renamed route sensibly: sorting on the
+number alone would drop ``3rd shift`` between ``Route 2`` and ``Route 4``.
 
-This is the single source of truth for that ordering: the SQL form for queries,
-the Python form for route lists already loaded in memory.
+Names in practice are one text prefix followed by one number, so the key is
+(text before the first digit, that number, the whole name): ``Cambridge`` sorts
+among the text names, ``Route 1`` … ``Route 12`` count up inside their shared
+prefix. This is the single source of truth for that ordering — the SQL form for
+queries, the Python form for route lists already loaded in memory.
 """
 
 import re
@@ -14,25 +17,34 @@ from typing import Any
 
 from sqlalchemy import Integer, cast, func, nulls_last
 
-# First run of digits in the name, capped at 9 digits so a name like
-# "Route 99999999999999" cannot overflow the int cast in Postgres.
+# The name split in two: everything before the first digit, then that first run
+# of digits. The run is capped at 9 digits so a name like "Route 9999999999999"
+# cannot overflow the int cast in Postgres.
+_TEXT_PREFIX = r"^[^0-9]*"
 _NUMBER_RUN = r"\d{1,9}"
 
 
 def route_name_order_by(name_col: Any, *tiebreak_cols: Any) -> list[Any]:
-    """ORDER BY clauses sorting route names by their number, then by name.
+    """ORDER BY clauses sorting route names naturally.
 
     Splat into ``order_by``, after any leading keys (e.g. drive_date), passing
     a unique column as ``tiebreak_cols`` where the order has to be total.
     """
     return [
+        func.substring(name_col, _TEXT_PREFIX),
         nulls_last(cast(func.substring(name_col, _NUMBER_RUN), Integer)),
         name_col,
         *tiebreak_cols,
     ]
 
 
-def route_name_sort_key(name: str) -> tuple[bool, int, str]:
+def route_name_sort_key(name: str) -> tuple[str, bool, int, str]:
     """``sorted`` key mirroring :func:`route_name_order_by`."""
-    match = re.search(_NUMBER_RUN, name)
-    return (match is None, int(match.group()) if match else 0, name)
+    prefix = re.match(_TEXT_PREFIX, name)
+    number = re.search(_NUMBER_RUN, name)
+    return (
+        prefix.group() if prefix else "",
+        number is None,
+        int(number.group()) if number else 0,
+        name,
+    )

--- a/backend/python/app/utilities/route_ordering.py
+++ b/backend/python/app/utilities/route_ordering.py
@@ -1,0 +1,38 @@
+"""Numeric-aware ordering for route names.
+
+Routes are generated as ``Route {n}``, so ordering by the name as text puts
+``Route 10`` between ``Route 1`` and ``Route 2``. Ordering by the first run of
+digits in the name fixes that. Names are editable, so a name with no digits
+sorts last and falls back to the name itself — never an error.
+
+This is the single source of truth for that ordering: the SQL form for queries,
+the Python form for route lists already loaded in memory.
+"""
+
+import re
+from typing import Any
+
+from sqlalchemy import Integer, cast, func, nulls_last
+
+# First run of digits in the name, capped at 9 digits so a name like
+# "Route 99999999999999" cannot overflow the int cast in Postgres.
+_NUMBER_RUN = r"\d{1,9}"
+
+
+def route_name_order_by(name_col: Any, *tiebreak_cols: Any) -> list[Any]:
+    """ORDER BY clauses sorting route names by their number, then by name.
+
+    Splat into ``order_by``, after any leading keys (e.g. drive_date), passing
+    a unique column as ``tiebreak_cols`` where the order has to be total.
+    """
+    return [
+        nulls_last(cast(func.substring(name_col, _NUMBER_RUN), Integer)),
+        name_col,
+        *tiebreak_cols,
+    ]
+
+
+def route_name_sort_key(name: str) -> tuple[bool, int, str]:
+    """``sorted`` key mirroring :func:`route_name_order_by`."""
+    match = re.search(_NUMBER_RUN, name)
+    return (match is None, int(match.group()) if match else 0, name)

--- a/backend/python/tests/test_routes.py
+++ b/backend/python/tests/test_routes.py
@@ -3121,6 +3121,102 @@ class TestRouteRoutes:
         assert empty.json()["items"] == []
 
     @pytest.mark.asyncio
+    async def test_get_routes_orders_by_route_number(
+        self,
+        async_client: AsyncClient,
+        test_session: AsyncSession,
+        test_route_group: Any,
+    ) -> None:
+        """Routes sort by the number in their name, not by the name as text.
+
+        Names are generated as "Route {n}", so a text sort lists route 10
+        before route 2 as soon as a group has ten of them.
+        """
+        numbers = [7, 12, 1, 10, 3, 11, 2, 5, 9, 4, 8, 6]
+        test_session.add_all(
+            [
+                Route(
+                    name=f"Route {n}",
+                    length=1.0,
+                    route_group_id=test_route_group.route_group_id,
+                )
+                for n in numbers
+            ]
+        )
+        await test_session.commit()
+
+        response = await async_client.get("/routes")
+        assert response.status_code == 200
+        assert [item["name"] for item in response.json()["items"]] == [
+            f"Route {n}" for n in range(1, 13)
+        ]
+
+    @pytest.mark.asyncio
+    async def test_get_routes_orders_renamed_routes_after_numbered_ones(
+        self,
+        async_client: AsyncClient,
+        test_session: AsyncSession,
+        test_route_group: Any,
+    ) -> None:
+        """A name with no number sorts last by name, rather than erroring.
+
+        Route.name is editable, so nothing guarantees the "Route {n}" shape.
+        """
+        names = ["Zebra loop", "Route 10", "Airport run", "Route 2", "3rd shift"]
+        test_session.add_all(
+            [
+                Route(
+                    name=name,
+                    length=1.0,
+                    route_group_id=test_route_group.route_group_id,
+                )
+                for name in names
+            ]
+        )
+        await test_session.commit()
+
+        response = await async_client.get("/routes")
+        assert response.status_code == 200
+        assert [item["name"] for item in response.json()["items"]] == [
+            "Route 2",
+            "3rd shift",
+            "Route 10",
+            "Airport run",
+            "Zebra loop",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_get_routes_tolerates_an_oversized_number_in_a_name(
+        self,
+        async_client: AsyncClient,
+        test_session: AsyncSession,
+        test_route_group: Any,
+    ) -> None:
+        """A digit run too long for an int must not blow up the listing."""
+        test_session.add_all(
+            [
+                Route(
+                    name="Route 999999999999999999999",
+                    length=1.0,
+                    route_group_id=test_route_group.route_group_id,
+                ),
+                Route(
+                    name="Route 1",
+                    length=1.0,
+                    route_group_id=test_route_group.route_group_id,
+                ),
+            ]
+        )
+        await test_session.commit()
+
+        response = await async_client.get("/routes")
+        assert response.status_code == 200
+        assert [item["name"] for item in response.json()["items"]] == [
+            "Route 1",
+            "Route 999999999999999999999",
+        ]
+
+    @pytest.mark.asyncio
     async def test_get_routes_returns_derived_row_values(
         self,
         async_client: AsyncClient,
@@ -4882,6 +4978,41 @@ class TestRouteGroupRoutes:
         )
         assert group["num_routes"] == 1
         assert [r["route_id"] for r in group["routes"]] == [str(route.route_id)]
+
+    @pytest.mark.asyncio
+    async def test_get_route_groups_include_routes_ordered_by_number(
+        self, async_client: AsyncClient, test_session: AsyncSession
+    ) -> None:
+        """The embedded routes come back in route-number order."""
+        rg = RouteGroup(name="Numbered", drive_date=date(2026, 6, 2))
+        test_session.add(rg)
+        await test_session.commit()
+        await test_session.refresh(rg)
+
+        names = [f"Route {n}" for n in (11, 2, 1, 10, 3)] + ["Spare van"]
+        test_session.add_all(
+            [
+                Route(name=name, length=1.0, route_group_id=rg.route_group_id)
+                for name in names
+            ]
+        )
+        await test_session.commit()
+
+        response = await async_client.get("/route-groups?include_routes=true")
+        assert response.status_code == 200
+        group = next(
+            g
+            for g in response.json()["items"]
+            if g["route_group_id"] == str(rg.route_group_id)
+        )
+        assert [r["name"] for r in group["routes"]] == [
+            "Route 1",
+            "Route 2",
+            "Route 3",
+            "Route 10",
+            "Route 11",
+            "Spare van",
+        ]
 
     @pytest.mark.asyncio
     async def test_get_route_groups_aggregate_defaults(

--- a/backend/python/tests/test_routes.py
+++ b/backend/python/tests/test_routes.py
@@ -3162,7 +3162,9 @@ class TestRouteRoutes:
 
         Route.name is editable, so nothing guarantees the "Route {n}" shape.
         Sorting on the number alone would put "3rd shift" between "Route 2"
-        and "Route 4"; the text before the number orders these first.
+        and "Route 4"; the text before the number orders these first. Case is
+        ignored, so a lowercase "route 1" still sorts with the numbered
+        routes rather than after every capitalised name.
         """
         names = [
             "Zebra loop",
@@ -3170,7 +3172,7 @@ class TestRouteRoutes:
             "Cambridge",
             "Route 2",
             "3rd shift",
-            "Route 1",
+            "route 1",
             "Airport run",
         ]
         test_session.add_all(
@@ -3191,11 +3193,49 @@ class TestRouteRoutes:
             "3rd shift",
             "Airport run",
             "Cambridge",
-            "Route 1",
+            "route 1",
             "Route 2",
             "Route 10",
             "Zebra loop",
         ]
+
+    @pytest.mark.asyncio
+    async def test_get_routes_orders_case_variants_adjacently_and_stably(
+        self,
+        async_client: AsyncClient,
+        test_session: AsyncSession,
+        test_route_group: Any,
+    ) -> None:
+        """Names differing only in case tie on the lowered key.
+
+        The raw name breaks that tie, so the pair is adjacent and the order
+        repeats. Which of the two comes first is the database collation's
+        call, so it isn't asserted here.
+        """
+        names = ["route 1", "Route 1", "Cambridge", "Route 2"]
+        test_session.add_all(
+            [
+                Route(
+                    name=name,
+                    length=1.0,
+                    route_group_id=test_route_group.route_group_id,
+                )
+                for name in names
+            ]
+        )
+        await test_session.commit()
+
+        first = await async_client.get("/routes")
+        assert first.status_code == 200
+        ordered = [item["name"] for item in first.json()["items"]]
+        assert ordered[0] == "Cambridge"
+        assert set(ordered[1:3]) == {"Route 1", "route 1"}
+        assert ordered[3] == "Route 2"
+
+        # Same order on a second read: the tie is broken by the name, not left
+        # to the database to resolve differently each time.
+        second = await async_client.get("/routes")
+        assert [item["name"] for item in second.json()["items"]] == ordered
 
     @pytest.mark.asyncio
     async def test_get_routes_tolerates_an_oversized_number_in_a_name(

--- a/backend/python/tests/test_routes.py
+++ b/backend/python/tests/test_routes.py
@@ -3152,17 +3152,27 @@ class TestRouteRoutes:
         ]
 
     @pytest.mark.asyncio
-    async def test_get_routes_orders_renamed_routes_after_numbered_ones(
+    async def test_get_routes_orders_renamed_routes_naturally(
         self,
         async_client: AsyncClient,
         test_session: AsyncSession,
         test_route_group: Any,
     ) -> None:
-        """A name with no number sorts last by name, rather than erroring.
+        """A renamed route sorts among the names, not among the numbers.
 
         Route.name is editable, so nothing guarantees the "Route {n}" shape.
+        Sorting on the number alone would put "3rd shift" between "Route 2"
+        and "Route 4"; the text before the number orders these first.
         """
-        names = ["Zebra loop", "Route 10", "Airport run", "Route 2", "3rd shift"]
+        names = [
+            "Zebra loop",
+            "Route 10",
+            "Cambridge",
+            "Route 2",
+            "3rd shift",
+            "Route 1",
+            "Airport run",
+        ]
         test_session.add_all(
             [
                 Route(
@@ -3178,10 +3188,12 @@ class TestRouteRoutes:
         response = await async_client.get("/routes")
         assert response.status_code == 200
         assert [item["name"] for item in response.json()["items"]] == [
-            "Route 2",
             "3rd shift",
-            "Route 10",
             "Airport run",
+            "Cambridge",
+            "Route 1",
+            "Route 2",
+            "Route 10",
             "Zebra loop",
         ]
 


### PR DESCRIPTION
Routes are generated as `Route {n}`, but every listing ordered that name as text, so a group of twelve read `Route 1, Route 10, Route 2, …`.

Ordering now keys on (lowercased text before the first digit, that number, lowercased name, raw name, `route_id`) — a natural, case-insensitive sort. `Cambridge` sorts among the names, `Route 1 … Route 12` count up inside their shared prefix, and a route renamed `route 1` sits beside `Route 1` instead of after `Route 9`. Lowercasing also makes the order independent of the deployed collation. `routes.name` has no index, so nothing regresses.

The expression lives once in `app/utilities/route_ordering.py` (SQL form plus a matching `sorted` key), used by `GET /routes`, the routes embedded in `GET /route-groups?include_routes=true` (previously unordered), group duplication, and the "Assigned Route" lookup.

Route *group* names still sort as text, and "Assigned Route" is still not sortable — say the word on either.
