### PR TITLE
Stop CI making live Google Maps calls (pytest.ini was inert)

### DIFF
--- a/.github/workflows/boot-smoke.yml
+++ b/.github/workflows/boot-smoke.yml
@@ -79,7 +79,9 @@ jobs:
           FIREBASE_SVC_ACCOUNT_CLIENT_ID: ${{ secrets.FIREBASE_SVC_ACCOUNT_CLIENT_ID }}
           FIREBASE_SVC_ACCOUNT_CLIENT_X509_CERT_URL: ${{ secrets.FIREBASE_SVC_ACCOUNT_CLIENT_X509_CERT_URL }}
           FIREBASE_WEB_API_KEY: ${{ secrets.FIREBASE_WEB_API_KEY }}
-          GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}
+          # Fake on purpose — CI must never hold a working Maps key; see
+          # .github/workflows/pytest.yml.
+          GOOGLE_MAPS_API_KEY: AIzaSyDUMMY-not-a-real-key-for-tests
         run: |
           if [ -n "$FIREBASE_PROJECT_ID" ]; then
             echo "Real Firebase credentials available — authed API smoke enabled."

--- a/.github/workflows/openapi-sync.yml
+++ b/.github/workflows/openapi-sync.yml
@@ -111,7 +111,9 @@ jobs:
       - name: Regenerate the OpenAPI client (schema + TS)
         if: steps.changes.outputs.contract == 'true'
         env:
-          GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}
+          # Fake on purpose — CI must never hold a working Maps key; see
+          # .github/workflows/pytest.yml.
+          GOOGLE_MAPS_API_KEY: AIzaSyDUMMY-not-a-real-key-for-tests
         run: ./scripts/regen-openapi.sh
 
       # If the regen changed anything, auto-commit it back to the PR branch. We
@@ -217,7 +219,9 @@ jobs:
       # Same byte-deterministic regen the PR job and the pre-commit hook run.
       - name: Regenerate the OpenAPI client (schema + TS)
         env:
-          GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}
+          # Fake on purpose — CI must never hold a working Maps key; see
+          # .github/workflows/pytest.yml.
+          GOOGLE_MAPS_API_KEY: AIzaSyDUMMY-not-a-real-key-for-tests
         run: ./scripts/regen-openapi.sh
 
       # Fail loudly if the committed client doesn't match a fresh regen. No

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -77,6 +77,9 @@ jobs:
           POSTGRES_DB_TEST: f4k_test
           DB_HOST: localhost
           TEST_DATABASE_URL: "postgresql+asyncpg://postgres:password@127.0.0.1:5432/f4k_test"
-          GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}
+          # Deliberately fake. The suite mocks every Maps call, so CI has no
+          # business holding a working key — a real one here means a green run
+          # can quietly spend the app's daily quota.
+          GOOGLE_MAPS_API_KEY: AIzaSyDUMMY-not-a-real-key-for-tests
         run: |
           pytest -q --disable-warnings -ra

--- a/backend/python/pytest.ini
+++ b/backend/python/pytest.ini
@@ -1,4 +1,7 @@
-[tool:pytest]
+# The section MUST be [pytest] here; [tool:pytest] is the setup.cfg spelling,
+# and pytest silently ignores this whole file when it sees it.
+[pytest]
+
 # Test discovery
 testpaths = tests
 python_files = test_*.py
@@ -9,15 +12,11 @@ python_functions = test_*
 asyncio_mode = auto
 
 # Output options
-addopts = 
+addopts =
     --strict-markers
     --strict-config
     --verbose
     --tb=short
-    --cov=app
-    --cov-report=term-missing
-    --cov-report=html:htmlcov
-    --cov-fail-under=80
 
 # Markers
 markers =


### PR DESCRIPTION
`scripts/fetch_route_polyline_test.py` is a developer script — its own docstring says so — that calls the live Google Routes API. It ran once per CI run against this project's 50/day cap: 1 call/day on Aug 27–28, then 54 on Aug 29, which exhausted the cap and turned the backend job red on every open PR.

It was collected because `pytest.ini` declared `[tool:pytest]`, the setup.cfg spelling. In a pytest.ini the section must be `[pytest]`, so pytest applied none of the file — `testpaths`, `python_files`, markers, `addopts`, all dead. Collection goes from 882 items, one of them under `scripts/`, to 881 with nothing outside `tests/`. The documented `pytest scripts/…` invocation still works.

The coverage flags leave `addopts`: never enforced, and the suite sits at 76.8% against their 80% gate.

Three workflows also get a dummy Maps key, so a live call fails loudly.
