### PR TITLE
Wilson/Tiered-Route-Generation

### DIFF
--- a/backend/python/app/config.py
+++ b/backend/python/app/config.py
@@ -69,6 +69,20 @@ class Settings(BaseSettings):
     route_opt_private_key: str = Field(default="")
     route_opt_client_email: str = Field(default="")
 
+    # Route generation quotas — each Google SKU's free monthly allowance, in
+    # that SKU's own billing unit. Google grants these per SKU and they do not
+    # pool, so they are tracked and configured separately.
+    #
+    # Route Optimization bills per *shipment*, and one generation sends one
+    # shipment per delivery plus one per vehicle, so 1000 covers only ~11 runs
+    # of a typical 75-stop group. Set below the true allowance to leave headroom
+    # for our counter drifting from Google's.
+    quota_fleet_routing_shipments: int = Field(default=1000)
+    quota_single_vehicle_shipments: int = Field(default=1000)
+    # Routes API computeRoutes bills per *request* — a much larger allowance,
+    # also drawn on by route polyline lookups.
+    quota_routes_compute_requests: int = Field(default=10000)
+
     # GCP
     gcp_bucket_name: str = Field(default="")
     gcp_service_account_project_id: str = Field(default="")

--- a/backend/python/app/dependencies/services.py
+++ b/backend/python/app/dependencies/services.py
@@ -40,6 +40,9 @@ from app.services.implementations.password_reset_token_service import (
 )
 from app.services.implementations.quota_service import QuotaService
 from app.services.implementations.route_group_service import RouteGroupService
+from app.services.implementations.routes_api_routing_service import (
+    RoutesApiSingleVehicleAlgorithm,
+)
 from app.services.implementations.scheduler_service import SchedulerService
 from app.services.implementations.sweep_algorithm import SweepAlgorithm
 from app.services.implementations.system_settings_service import SystemSettingsService
@@ -208,6 +211,11 @@ def build_routing_algorithm(
     and a shared instance would race between concurrent jobs.
     """
     fleet_routing = GoogleMapsFleetRoutingAlgorithm()
+    single_vehicle = RoutesApiSingleVehicleAlgorithm(
+        warehouse_lat=warehouse_lat,
+        warehouse_lon=warehouse_lon,
+        children_per_box=children_per_box,
+    )
     cluster_sweep = SweepAlgorithm(
         warehouse_lat=warehouse_lat,
         warehouse_lon=warehouse_lon,
@@ -216,19 +224,17 @@ def build_routing_algorithm(
 
     if method == RouteGenerationMethod.FLEET_ROUTING:
         return fleet_routing
-    if method == RouteGenerationMethod.CLUSTER_SWEEP:
-        return cluster_sweep
     if method == RouteGenerationMethod.SINGLE_VEHICLE:
-        # Not yet implemented — see F4KRP. Falling back to the free engine
-        # rather than the paid one: an unbuilt tier should not quietly start
-        # spending money.
-        get_logger().warning(
-            "Single-vehicle routing is not implemented yet; using cluster+sweep."
-        )
+        return single_vehicle
+    if method == RouteGenerationMethod.CLUSTER_SWEEP:
         return cluster_sweep
 
     return build_default_cascade(
-        get_quota_service(), session_maker, fleet_routing, cluster_sweep
+        get_quota_service(),
+        session_maker,
+        fleet_routing,
+        single_vehicle,
+        cluster_sweep,
     )
 
 

--- a/backend/python/app/dependencies/services.py
+++ b/backend/python/app/dependencies/services.py
@@ -15,12 +15,17 @@ import logging
 from functools import lru_cache
 
 from fastapi import Depends
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from app.config import settings
+from app.models.enum import RouteGenerationMethod
 from app.services.implementations.admin_service import AdminService
 from app.services.implementations.announcement_service import AnnouncementService
 from app.services.implementations.auth_service import AuthService
 from app.services.implementations.billing_service import BillingService
+from app.services.implementations.cascading_routing_algorithm import (
+    build_default_cascade,
+)
 from app.services.implementations.driver_service import DriverService
 from app.services.implementations.email_dispatcher import EmailDispatcher
 from app.services.implementations.email_service import EmailService
@@ -33,8 +38,10 @@ from app.services.implementations.note_chain_service import NoteChainService
 from app.services.implementations.password_reset_token_service import (
     PasswordResetTokenService,
 )
+from app.services.implementations.quota_service import QuotaService
 from app.services.implementations.route_group_service import RouteGroupService
 from app.services.implementations.scheduler_service import SchedulerService
+from app.services.implementations.sweep_algorithm import SweepAlgorithm
 from app.services.implementations.system_settings_service import SystemSettingsService
 from app.services.implementations.user_invite_service import UserInviteService
 from app.services.implementations.user_service import UserService
@@ -167,13 +174,62 @@ def get_route_group_service() -> RouteGroupService:
 
 
 @lru_cache
+def get_quota_service() -> QuotaService:
+    """Get quota service instance"""
+    logger = get_logger()
+    return QuotaService(logger, settings)
+
+
+@lru_cache
 def get_routing_algorithm() -> RoutingAlgorithmProtocol:
-    """Select the routing algorithm to use for route generation.
+    """The routing engine used when no system settings are available.
 
-    Currently always returns the real Google Fleet Routing implementation.
-
+    Prefer ``build_routing_algorithm``, which honours the configured method and
+    can cascade. This remains for callers with no session to read settings on.
     """
     return GoogleMapsFleetRoutingAlgorithm()
+
+
+def build_routing_algorithm(
+    method: RouteGenerationMethod,
+    session_maker: async_sessionmaker[AsyncSession],
+    warehouse_lat: float,
+    warehouse_lon: float,
+    children_per_box: int,
+) -> RoutingAlgorithmProtocol:
+    """Build the routing engine for one generation job.
+
+    ``AUTO`` returns the cascade, which spends each API's free monthly
+    allowance in quality order before falling back. The explicit methods pin
+    generation to a single engine and skip the quota check entirely — forcing a
+    paid engine past its free room is a deliberate decision to start paying.
+
+    Built per job rather than cached: the cascade records which tier it used,
+    and a shared instance would race between concurrent jobs.
+    """
+    fleet_routing = GoogleMapsFleetRoutingAlgorithm()
+    cluster_sweep = SweepAlgorithm(
+        warehouse_lat=warehouse_lat,
+        warehouse_lon=warehouse_lon,
+        children_per_box=children_per_box,
+    )
+
+    if method == RouteGenerationMethod.FLEET_ROUTING:
+        return fleet_routing
+    if method == RouteGenerationMethod.CLUSTER_SWEEP:
+        return cluster_sweep
+    if method == RouteGenerationMethod.SINGLE_VEHICLE:
+        # Not yet implemented — see F4KRP. Falling back to the free engine
+        # rather than the paid one: an unbuilt tier should not quietly start
+        # spending money.
+        get_logger().warning(
+            "Single-vehicle routing is not implemented yet; using cluster+sweep."
+        )
+        return cluster_sweep
+
+    return build_default_cascade(
+        get_quota_service(), session_maker, fleet_routing, cluster_sweep
+    )
 
 
 @lru_cache

--- a/backend/python/app/models/__init__.py
+++ b/backend/python/app/models/__init__.py
@@ -96,6 +96,7 @@ def init_app(_app: Any | None = None) -> None:
     from .admin import Admin  # noqa: F401
     from .announcement import Announcement  # noqa: F401
     from .announcement_last_read import AnnouncementLastRead  # noqa: F401
+    from .api_usage import ApiUsage  # noqa: F401
     from .driver import Driver  # noqa: F401
     from .job import Job  # noqa: F401
     from .location import Location  # noqa: F401

--- a/backend/python/app/models/api_usage.py
+++ b/backend/python/app/models/api_usage.py
@@ -1,0 +1,72 @@
+"""Per-SKU usage counters for the paid Google APIs route generation calls.
+
+Google's free monthly allowances are granted per SKU and do not pool: spending
+Fleet Routing's allowance leaves the Routes API's untouched. Route generation
+walks its tiers in quality order, so it needs to know which individual SKU is
+exhausted, which one combined total could not answer.
+
+The counter is our own live estimate. The BigQuery billing export is
+authoritative but lags hours, far too slow to gate a job that starts now.
+"""
+
+from enum import Enum
+from uuid import UUID, uuid4
+
+from sqlalchemy import UniqueConstraint
+from sqlmodel import Field, SQLModel
+
+from .base import BaseModel
+
+
+class ApiSku(str, Enum):
+    """The billable Google SKUs route generation can draw on.
+
+    Values are stored in the database, so renaming one orphans its counter.
+    """
+
+    # Route Optimization, two or more vehicles. Billed per *shipment*.
+    FLEET_ROUTING = "fleet_routing"
+    # Route Optimization, single vehicle. Also billed per shipment.
+    SINGLE_VEHICLE_ROUTING = "single_vehicle_routing"
+    # Routes API computeRoutes. Billed per *request* — a different unit, and a
+    # far larger allowance. Also spent by route polyline lookups.
+    ROUTES_COMPUTE = "routes_compute"
+
+
+class ApiUsageBase(SQLModel):
+    # Stored as the SKU's string value rather than a native enum so adding a
+    # SKU needs no migration.
+    sku: str = Field(max_length=64)
+    # "YYYYMM", from ``current_billing_month`` — Google's billing month, which
+    # is what the free allowance actually resets on.
+    billing_month: str = Field(max_length=6)
+    units_used: int = Field(default=0, ge=0)
+
+
+class ApiUsage(ApiUsageBase, BaseModel, table=True):
+    """One row per SKU per billing month.
+
+    The unique constraint is load-bearing: it lets the service upsert
+    atomically, so two jobs starting at once cannot each read the same count
+    and both decide they have room.
+    """
+
+    __tablename__ = "api_usage"
+    __table_args__ = (
+        UniqueConstraint("sku", "billing_month", name="uq_api_usage_sku_month"),
+    )
+
+    api_usage_id: UUID = Field(default_factory=uuid4, primary_key=True)
+
+
+class ApiUsageRead(ApiUsageBase):
+    """A SKU's consumption this month, against its configured allowance."""
+
+    api_usage_id: UUID
+    # Carried alongside the count because the allowance lives in settings, not
+    # in the row — a caller comparing them needs both.
+    budget: int
+    remaining: int
+    # Units differ per SKU (shipments vs requests), so a bare number is
+    # ambiguous without this.
+    unit: str

--- a/backend/python/app/models/enum.py
+++ b/backend/python/app/models/enum.py
@@ -16,6 +16,20 @@ class ProgressEnum(str, Enum):
     FAILED = "Failed"
 
 
+class RouteGenerationMethod(str, Enum):
+    """Which engine route generation should use.
+
+    ``AUTO`` walks the tiers in quality order, spending each API's free monthly
+    allowance before moving on. The rest pin generation to one engine
+    regardless of remaining quota — including past it, into paid usage.
+    """
+
+    AUTO = "auto"
+    FLEET_ROUTING = "fleet_routing"
+    SINGLE_VEHICLE = "single_vehicle"
+    CLUSTER_SWEEP = "cluster_sweep"
+
+
 class NotePermission(str, Enum):
     """Controls who can read/write on a note chain"""
 

--- a/backend/python/app/models/system_settings.py
+++ b/backend/python/app/models/system_settings.py
@@ -3,13 +3,14 @@ from typing import Any
 from uuid import UUID, uuid4
 
 from pydantic import EmailStr, field_validator
-from sqlalchemy import JSON
+from sqlalchemy import JSON, String
 from sqlalchemy.types import TypeDecorator
 from sqlmodel import Column, Field, SQLModel
 
 from app.utilities.utils import validate_phone
 
 from .base import BaseModel
+from .enum import RouteGenerationMethod
 
 
 def _validate_delivery_types(v: list[str]) -> list[str]:
@@ -97,6 +98,14 @@ class SystemSettingsBase(SQLModel):
     delivery_types: list[str] = Field(
         default_factory=lambda: ["Family", "School"],
         sa_column=Column(JSON, nullable=False),
+    )
+    # Default Auto spends each routing API's free monthly allowance in quality
+    # order before falling back. The explicit values pin generation to one
+    # engine and ignore quota entirely, so forcing a paid engine past its free
+    # room is a deliberate choice to start paying.
+    route_generation_method: RouteGenerationMethod = Field(
+        default=RouteGenerationMethod.AUTO,
+        sa_column=Column(String(32), nullable=False, server_default="auto"),
     )
 
     @field_validator("contact_phone")

--- a/backend/python/app/services/implementations/cascading_routing_algorithm.py
+++ b/backend/python/app/services/implementations/cascading_routing_algorithm.py
@@ -171,16 +171,15 @@ def build_default_cascade(
     quota_service: QuotaService,
     session_maker: async_sessionmaker[AsyncSession],
     fleet_routing: RoutingAlgorithmProtocol,
+    single_vehicle: RoutingAlgorithmProtocol,
     cluster_sweep: RoutingAlgorithmProtocol,
 ) -> CascadingRoutingAlgorithm:
     """The Auto cascade: best quality first, free in-house engine last.
 
-    The single-vehicle tier is not wired yet — see F4KRP: the ticket's
-    "single-vehicle Routes API" resolves to either Route Optimization's Single
-    Vehicle Routing SKU (per shipment, ~1k/month) or Routes API computeRoutes
-    (per request, 5-10k/month), which differ by roughly three orders of
-    magnitude in usable free room. ``Tier`` takes any number of rungs, so it
-    slots in between these two once that is settled.
+    The rungs degrade by who decides what. Fleet Routing assigns stops to
+    drivers *and* orders them, weighing every stop against every vehicle at
+    once. The middle rung keeps Google's ordering but inherits our clustering's
+    assignment. The floor does both in-house.
     """
     return CascadingRoutingAlgorithm(
         logger,
@@ -192,6 +191,12 @@ def build_default_cascade(
                 algorithm=fleet_routing,
                 sku=ApiSku.FLEET_ROUTING,
                 units_for=fleet_routing_units,
+            ),
+            Tier(
+                name="single_vehicle",
+                algorithm=single_vehicle,
+                sku=ApiSku.ROUTES_COMPUTE,
+                units_for=routes_compute_units,
             ),
             Tier(name="cluster_sweep", algorithm=cluster_sweep),
         ],

--- a/backend/python/app/services/implementations/cascading_routing_algorithm.py
+++ b/backend/python/app/services/implementations/cascading_routing_algorithm.py
@@ -1,0 +1,198 @@
+"""Route generation that drains each API's free quota before falling back.
+
+Each Google routing API has its own free monthly allowance. Walking them in
+quality order — best routes first — and dropping to the next only once the
+current one's free room is gone gives the best routes obtainable without
+paying. The in-house cluster+sweep is the floor: no quota, always available.
+
+Implements ``RoutingAlgorithmProtocol`` so the generation runner is unchanged;
+it sees one algorithm and never learns there were tiers.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from app.models.api_usage import ApiSku
+from app.services.implementations.quota_service import fleet_routing_units
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+    from app.models.location import Location
+    from app.schemas.route_generation import RouteGenerationSettings
+    from app.services.implementations.quota_service import QuotaService
+    from app.services.protocols.routing_algorithm import RoutingAlgorithmProtocol
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class Tier:
+    """One rung of the cascade, in quality order.
+
+    ``sku`` is None for tiers that cost nothing, which are therefore always
+    available and need no reservation.
+    """
+
+    name: str
+    algorithm: RoutingAlgorithmProtocol
+    sku: ApiSku | None = None
+    # Billable units this tier would consume, given (locations, vehicles).
+    # Units differ per SKU: Route Optimization bills per shipment, the Routes
+    # API per request, so each tier brings its own conversion.
+    units_for: Callable[[int, int], int] | None = None
+
+
+def routes_compute_units(_num_locations: int, num_vehicles: int) -> int:
+    """computeRoutes is billed per request, and we issue one per vehicle."""
+    return num_vehicles
+
+
+class CascadingRoutingAlgorithm:
+    """Tries each tier in turn, skipping any whose free quota is spent."""
+
+    def __init__(
+        self,
+        logger_: logging.Logger,
+        quota_service: QuotaService,
+        session_maker: async_sessionmaker[AsyncSession],
+        tiers: list[Tier],
+    ) -> None:
+        self.logger = logger_
+        self.quota_service = quota_service
+        self.session_maker = session_maker
+        self.tiers = tiers
+        # Which tier actually ran. Read by the runner to record on the job, so
+        # a silent drop to a lower-quality tier is visible rather than just
+        # producing quietly worse routes.
+        self.last_tier_used: str | None = None
+
+    async def generate_routes(
+        self,
+        locations: list[Location],
+        warehouse_lat: float,
+        warehouse_lon: float,
+        settings: RouteGenerationSettings,
+        timeout_seconds: float | None = None,
+    ) -> list[list[Location]]:
+        """Generate routes with the best tier that still has free quota."""
+        self.last_tier_used = None
+        attempts: list[str] = []
+
+        for tier in self.tiers:
+            units = self._units_for(tier, len(locations), settings.num_routes)
+
+            if not await self._reserve(tier, units):
+                attempts.append(f"{tier.name} (no free quota)")
+                continue
+
+            try:
+                routes = await tier.algorithm.generate_routes(
+                    locations,
+                    warehouse_lat,
+                    warehouse_lon,
+                    settings,
+                    timeout_seconds=timeout_seconds,
+                )
+            except TimeoutError:
+                # The request may well have reached Google and been billed, so
+                # the reservation stands. Overcounting costs a worse route;
+                # undercounting costs money.
+                attempts.append(f"{tier.name} (timed out)")
+                self.logger.warning(
+                    "Tier %s timed out; keeping its reservation and falling back",
+                    tier.name,
+                )
+                continue
+            except Exception:
+                # Never reached the optimizer — a misconfiguration or a
+                # rejected payload. Hand the units back, or a persistently
+                # broken tier would burn a month of quota failing.
+                await self._release(tier, units)
+                attempts.append(f"{tier.name} (failed)")
+                self.logger.exception(
+                    "Tier %s failed; released its reservation and falling back",
+                    tier.name,
+                )
+                continue
+
+            self.last_tier_used = tier.name
+            if attempts:
+                self.logger.info(
+                    "Generated with %s after skipping: %s",
+                    tier.name,
+                    ", ".join(attempts),
+                )
+            return routes
+
+        # Only reachable if every tier is quota-gated, which would mean the
+        # free cluster+sweep floor was left out of the cascade.
+        raise RuntimeError(
+            "No routing tier could run. Tried: "
+            + (", ".join(attempts) or "none configured")
+        )
+
+    @staticmethod
+    def _units_for(tier: Tier, num_locations: int, num_vehicles: int) -> int:
+        if tier.sku is None or tier.units_for is None:
+            return 0
+        return tier.units_for(num_locations, num_vehicles)
+
+    async def _reserve(self, tier: Tier, units: int) -> bool:
+        """Claim quota for a tier, in its own committed transaction.
+
+        Separate from the job's session on purpose: Google bills for the call
+        whether or not the job later succeeds, so the usage must not roll back
+        with it.
+        """
+        if tier.sku is None:
+            return True
+
+        async with self.session_maker() as session:
+            granted = await self.quota_service.try_reserve(session, tier.sku, units)
+            await session.commit()
+            return granted
+
+    async def _release(self, tier: Tier, units: int) -> None:
+        if tier.sku is None:
+            return
+
+        async with self.session_maker() as session:
+            await self.quota_service.release(session, tier.sku, units)
+            await session.commit()
+
+
+def build_default_cascade(
+    quota_service: QuotaService,
+    session_maker: async_sessionmaker[AsyncSession],
+    fleet_routing: RoutingAlgorithmProtocol,
+    cluster_sweep: RoutingAlgorithmProtocol,
+) -> CascadingRoutingAlgorithm:
+    """The Auto cascade: best quality first, free in-house engine last.
+
+    The single-vehicle tier is not wired yet — see F4KRP: the ticket's
+    "single-vehicle Routes API" resolves to either Route Optimization's Single
+    Vehicle Routing SKU (per shipment, ~1k/month) or Routes API computeRoutes
+    (per request, 5-10k/month), which differ by roughly three orders of
+    magnitude in usable free room. ``Tier`` takes any number of rungs, so it
+    slots in between these two once that is settled.
+    """
+    return CascadingRoutingAlgorithm(
+        logger,
+        quota_service,
+        session_maker,
+        [
+            Tier(
+                name="fleet_routing",
+                algorithm=fleet_routing,
+                sku=ApiSku.FLEET_ROUTING,
+                units_for=fleet_routing_units,
+            ),
+            Tier(name="cluster_sweep", algorithm=cluster_sweep),
+        ],
+    )

--- a/backend/python/app/services/implementations/quota_service.py
+++ b/backend/python/app/services/implementations/quota_service.py
@@ -1,0 +1,220 @@
+"""Tracks consumption of each Google SKU's free monthly allowance.
+
+Route generation walks its tiers in quality order and needs to know, before it
+calls anything, whether a tier's free allowance still has room for this job.
+Google's own figures come from the BigQuery billing export, which lags hours —
+far too slow to gate a job starting now — so this keeps a live local estimate.
+
+Being an estimate, it can drift. The budgets are configurable precisely so they
+can be set below the true allowance, leaving headroom for that drift rather
+than sailing into paid usage on a miscount.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from sqlalchemy import text
+
+from app.models.api_usage import ApiSku
+from app.utilities.datetime_utils import current_billing_month
+
+if TYPE_CHECKING:
+    import logging
+
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+    from app.config import Settings
+
+# Route Optimization bills per shipment; the Routes API bills per request.
+# Surfaced so a caller never has to guess what a bare count means.
+SKU_UNITS: dict[str, str] = {
+    ApiSku.FLEET_ROUTING.value: "shipments",
+    ApiSku.SINGLE_VEHICLE_ROUTING.value: "shipments",
+    ApiSku.ROUTES_COMPUTE.value: "requests",
+}
+
+
+def fleet_routing_units(num_locations: int, num_vehicles: int) -> int:
+    """Shipments one Fleet Routing request will be billed for.
+
+    Route Optimization bills per shipment, and ``_build_payload`` sends one
+    shipment per delivery *plus* one forced pickup per vehicle to stop drivers
+    sitting idle. Counting only the deliveries undercounts every run by the
+    vehicle count — about 14% on a typical group.
+
+    ``test_quota_service`` pins this against the real payload builder, so the
+    two cannot drift apart silently.
+    """
+    return num_locations + num_vehicles
+
+
+class QuotaExhaustedError(Exception):
+    """Raised when a SKU has no free room left for the requested units."""
+
+
+class QuotaService:
+    """Reserves and records usage against each SKU's monthly allowance."""
+
+    def __init__(self, logger: logging.Logger, settings: Settings) -> None:
+        self.logger = logger
+        self.settings = settings
+
+    def budget_for(self, sku: ApiSku) -> int:
+        """The configured free allowance for a SKU, in that SKU's own unit."""
+        budgets = {
+            ApiSku.FLEET_ROUTING: self.settings.quota_fleet_routing_shipments,
+            ApiSku.SINGLE_VEHICLE_ROUTING: (
+                self.settings.quota_single_vehicle_shipments
+            ),
+            ApiSku.ROUTES_COMPUTE: self.settings.quota_routes_compute_requests,
+        }
+        return budgets[sku]
+
+    async def units_used(
+        self, session: AsyncSession, sku: ApiSku, month: str | None = None
+    ) -> int:
+        """Units consumed for a SKU this billing month."""
+        result = await session.execute(
+            text(
+                "SELECT units_used FROM api_usage "
+                "WHERE sku = :sku AND billing_month = :month"
+            ),
+            {"sku": sku.value, "month": month or current_billing_month()},
+        )
+        row = result.first()
+        return int(row[0]) if row else 0
+
+    async def try_reserve(
+        self,
+        session: AsyncSession,
+        sku: ApiSku,
+        units: int,
+        month: str | None = None,
+    ) -> bool:
+        """Claim ``units`` against a SKU's allowance, if they fit.
+
+        Returns True when the claim succeeded. The check and the increment are
+        one statement so two jobs starting together cannot both read the same
+        count and each conclude there is room — the loser's UPDATE simply
+        matches no row.
+
+        Reserving up front rather than recording afterwards means a crash
+        mid-call overcounts rather than undercounts. That direction is
+        deliberate: overcounting costs us a slightly worse route, undercounting
+        costs money.
+        """
+        if units <= 0:
+            return True
+
+        billing_month = month or current_billing_month()
+        budget = self.budget_for(sku)
+
+        # Ensure the row exists before the guarded UPDATE. Doing the whole
+        # thing as one upsert would let the INSERT branch through unguarded,
+        # since ON CONFLICT's WHERE only applies to the update path.
+        await session.execute(
+            text(
+                "INSERT INTO api_usage "
+                "  (api_usage_id, sku, billing_month, units_used, "
+                "   created_at, updated_at) "
+                "VALUES (gen_random_uuid(), :sku, :month, 0, now(), now()) "
+                "ON CONFLICT (sku, billing_month) DO NOTHING"
+            ),
+            {"sku": sku.value, "month": billing_month},
+        )
+
+        result = await session.execute(
+            text(
+                "UPDATE api_usage "
+                "SET units_used = units_used + :units, updated_at = now() "
+                "WHERE sku = :sku AND billing_month = :month "
+                "  AND units_used + :units <= :budget "
+                "RETURNING units_used"
+            ),
+            {
+                "sku": sku.value,
+                "month": billing_month,
+                "units": units,
+                "budget": budget,
+            },
+        )
+        row = result.first()
+
+        if row is None:
+            self.logger.info(
+                "%s has no free room for %d %s this month (budget %d)",
+                sku.value,
+                units,
+                SKU_UNITS[sku.value],
+                budget,
+            )
+            return False
+
+        self.logger.info(
+            "Reserved %d %s against %s (%d/%d used this month)",
+            units,
+            SKU_UNITS[sku.value],
+            sku.value,
+            int(row[0]),
+            budget,
+        )
+        return True
+
+    async def record(
+        self,
+        session: AsyncSession,
+        sku: ApiSku,
+        units: int,
+        month: str | None = None,
+    ) -> None:
+        """Add usage unconditionally, past the budget if need be.
+
+        For calls we do not gate — route polylines are issued as part of saving
+        a generation and are not worth failing over — where the counter still
+        has to reflect that the allowance was spent.
+        """
+        if units <= 0:
+            return
+
+        billing_month = month or current_billing_month()
+        await session.execute(
+            text(
+                "INSERT INTO api_usage "
+                "  (api_usage_id, sku, billing_month, units_used, "
+                "   created_at, updated_at) "
+                "VALUES (gen_random_uuid(), :sku, :month, :units, now(), now()) "
+                "ON CONFLICT (sku, billing_month) DO UPDATE "
+                "SET units_used = api_usage.units_used + :units, "
+                "    updated_at = now()"
+            ),
+            {"sku": sku.value, "month": billing_month, "units": units},
+        )
+
+    async def release(
+        self,
+        session: AsyncSession,
+        sku: ApiSku,
+        units: int,
+        month: str | None = None,
+    ) -> None:
+        """Hand back units reserved for a call that never reached Google.
+
+        Only for failures we know were never billed — a timeout waiting on a
+        response may well have been charged, so those keep their reservation.
+        Clamped at zero so a stray release cannot drive the counter negative
+        and manufacture free quota.
+        """
+        if units <= 0:
+            return
+
+        billing_month = month or current_billing_month()
+        await session.execute(
+            text(
+                "UPDATE api_usage "
+                "SET units_used = GREATEST(units_used - :units, 0), "
+                "    updated_at = now() "
+                "WHERE sku = :sku AND billing_month = :month"
+            ),
+            {"sku": sku.value, "month": billing_month, "units": units},
+        )

--- a/backend/python/app/services/implementations/quota_service.py
+++ b/backend/python/app/services/implementations/quota_service.py
@@ -12,16 +12,16 @@ than sailing into paid usage on a miscount.
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING
 
 from sqlalchemy import text
 
+from app.config import settings
 from app.models.api_usage import ApiSku
 from app.utilities.datetime_utils import current_billing_month
 
 if TYPE_CHECKING:
-    import logging
-
     from sqlalchemy.ext.asyncio import AsyncSession
 
     from app.config import Settings
@@ -51,6 +51,42 @@ def fleet_routing_units(num_locations: int, num_vehicles: int) -> int:
 
 class QuotaExhaustedError(Exception):
     """Raised when a SKU has no free room left for the requested units."""
+
+
+async def record_usage_out_of_band(sku: ApiSku, units: int) -> None:
+    """Record usage from a call that had no session to hand.
+
+    For ungated Google calls made deep in a request — route polylines, say —
+    which spend a SKU's allowance without going through the cascade. Left
+    unrecorded, the counter under-reports, and the cascade would offer a tier
+    room it no longer has. Undercounting is the direction that costs money.
+
+    Opens its own session and commits: Google billed the call regardless of
+    what the surrounding transaction eventually does. Never raises, because
+    losing count is a smaller problem than failing the work that prompted it.
+    """
+    if units <= 0:
+        return
+
+    from app import models as app_models
+
+    session_maker = app_models.async_session_maker_instance
+    if session_maker is None:
+        return
+
+    try:
+        service = QuotaService(logging.getLogger(__name__), settings)
+        async with session_maker() as session:
+            await service.record(session, sku, units)
+            await session.commit()
+    except Exception:
+        logging.getLogger(__name__).warning(
+            "Could not record %d %s against %s; the counter will under-report",
+            units,
+            SKU_UNITS[sku.value],
+            sku.value,
+            exc_info=True,
+        )
 
 
 class QuotaService:

--- a/backend/python/app/services/implementations/route_generation_runner.py
+++ b/backend/python/app/services/implementations/route_generation_runner.py
@@ -22,6 +22,7 @@ from pydantic import ValidationError
 from sqlalchemy import update
 from sqlmodel import col, select
 
+from app.models.api_usage import ApiSku
 from app.models.enum import ProgressEnum
 from app.models.job import Job
 from app.models.location import Location
@@ -31,6 +32,9 @@ from app.models.route_group import RouteGroup
 from app.models.route_stop import RouteStop
 from app.models.system_settings import SystemSettings
 from app.schemas.route_generation import RouteGenerationGroupInput
+from app.services.implementations.quota_service import (
+    record_usage_out_of_band,
+)
 from app.services.implementations.route_group_service import (
     ROUTE_GROUP_NAME_MAX_LENGTH,
 )
@@ -350,6 +354,10 @@ async def _build_route_group(
             for cluster in filled
         )
     )
+    # Polylines draw on the same Routes API allowance the single-vehicle tier
+    # gates on, so they have to show up in the counter or that tier will be
+    # offered room it no longer has.
+    await record_usage_out_of_band(ApiSku.ROUTES_COMPUTE, len(filled))
 
     for number, (cluster, (encoded_polyline, distance_km)) in enumerate(
         zip(filled, polyline_results, strict=True),

--- a/backend/python/app/services/implementations/route_generation_worker.py
+++ b/backend/python/app/services/implementations/route_generation_worker.py
@@ -25,9 +25,10 @@ from sqlalchemy import update
 from sqlmodel import col, select
 
 from app import models as app_models
-from app.dependencies.services import get_routing_algorithm
-from app.models.enum import ProgressEnum
+from app.dependencies.services import build_routing_algorithm
+from app.models.enum import ProgressEnum, RouteGenerationMethod
 from app.models.job import Job
+from app.models.system_settings import SystemSettings
 from app.services.implementations.route_generation_runner import run_generation_job
 from app.utilities.datetime_utils import now_utc
 
@@ -209,6 +210,34 @@ async def route_generation_worker_loop() -> None:
         raise
 
 
+async def _build_algorithm_for_job(
+    session: AsyncSession,
+    session_maker: Any,
+) -> Any:
+    """Build this job's routing engine from the configured method.
+
+    The warehouse and box size come from the same settings row, since the
+    in-house engine clusters around the depot and needs both up front.
+    """
+    row = (await session.execute(select(SystemSettings).limit(1))).scalars().first()
+    if row is None:
+        raise RuntimeError(
+            "SystemSettings row is missing; it must be created at startup "
+            "via ensure_settings()."
+        )
+
+    method = RouteGenerationMethod(row.route_generation_method)
+    logger.info("Route generation method: %s", method.value)
+
+    return build_routing_algorithm(
+        method,
+        session_maker,
+        warehouse_lat=row.warehouse_latitude or 0.0,
+        warehouse_lon=row.warehouse_longitude or 0.0,
+        children_per_box=row.children_per_box,
+    )
+
+
 async def _claim_and_run_one() -> bool:
     """Claim one job and run it. Returns False when claim finds no PENDING job.
 
@@ -222,12 +251,14 @@ async def _claim_and_run_one() -> bool:
         )
         return False
 
-    algorithm = get_routing_algorithm()
     async with session_maker() as session:
         job_id = await claim_next_pending_job(session)
         if job_id is None:
             return False
         logger.info("Claimed route generation job %s", job_id)
+        # Built per job, after claiming, so an admin changing the method in
+        # settings takes effect on the next job rather than at process start.
+        algorithm = await _build_algorithm_for_job(session, session_maker)
         started = time.perf_counter()
         await run_generation_job(job_id, session, algorithm)
         logger.info(

--- a/backend/python/app/services/implementations/route_service.py
+++ b/backend/python/app/services/implementations/route_service.py
@@ -11,6 +11,7 @@ from sqlalchemy.orm import selectinload
 from sqlmodel import col, select
 
 from app.config import settings
+from app.models.api_usage import ApiSku
 from app.models.driver import Driver
 from app.models.enum import (
     DriveDaysOfWeekEnum,
@@ -33,6 +34,9 @@ from app.models.route_stop_snapshot import RouteStopSnapshot
 from app.models.system_settings import SystemSettings
 from app.models.user import User
 from app.schemas.pagination import PaginatedResponse, PaginationParams
+from app.services.implementations.quota_service import (
+    record_usage_out_of_band,
+)
 from app.utilities.boxes import (
     box_count_expr,
     compute_boxes,
@@ -517,6 +521,10 @@ class RouteService:
                     warehouse_lon=warehouse_lon,
                     ends_at_warehouse=route.ends_at_warehouse,
                 )
+                # Route edits spend the same Routes API allowance as the
+                # single-vehicle generation tier; unrecorded, they would leave
+                # the counter reporting room that is already gone.
+                await record_usage_out_of_band(ApiSku.ROUTES_COMPUTE, 1)
 
                 # Delete existing route stops
                 existing_stops_result = await session.execute(

--- a/backend/python/app/services/implementations/routes_api_routing_service.py
+++ b/backend/python/app/services/implementations/routes_api_routing_service.py
@@ -1,0 +1,207 @@
+"""Single-vehicle route ordering via the Routes API.
+
+The middle rung of the generation cascade. Our clustering decides which stops
+go to which driver; Google then puts each driver's stops in the best order.
+
+That split is what makes this a cheaper tier than Fleet Routing rather than a
+worse one at the same price. Fleet Routing bills per *shipment* and does both
+jobs — assignment and ordering — in one pass over every stop. computeRoutes
+bills per *request*, and we send one request per driver, so a 75-stop run costs
+12 units here against roughly 75 there. The quality we give up is assignment:
+Fleet Routing weighs every stop against every vehicle at once, while this
+inherits whatever clusters the sweep produced.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import TYPE_CHECKING
+
+from google.api_core import exceptions as google_exceptions
+from google.api_core.client_options import ClientOptions
+from google.maps import routing_v2
+
+from app.config import settings as app_settings
+from app.services.implementations.sweep_clustering import (
+    DEFAULT_MAX_BOXES_PER_CLUSTER,
+    SweepClusteringAlgorithm,
+)
+
+if TYPE_CHECKING:
+    from app.models.location import Location
+    from app.schemas.route_generation import RouteGenerationSettings
+    from app.services.protocols.clustering_algorithm import ClusteringAlgorithmProtocol
+
+logger = logging.getLogger(__name__)
+
+# Only the optimised ordering is needed here; polylines and distances are
+# fetched separately when the generation is saved. Asking for less keeps the
+# response small and the field mask honest about what we use.
+FIELD_MASK = "routes.optimizedIntermediateWaypointIndex"
+
+# A single computeRoutes request accepts at most this many intermediates.
+# Clusters are far smaller in practice (~6 stops), but a mis-set route count
+# could produce one oversized cluster, and a silent truncation would drop
+# deliveries.
+MAX_INTERMEDIATES = 25
+
+
+class RoutesApiRoutingError(Exception):
+    """Raised when the Routes API cannot order a cluster."""
+
+
+class RoutesApiSingleVehicleAlgorithm:
+    """Clusters in-house, then orders each cluster with the Routes API."""
+
+    clustering_algorithm: ClusteringAlgorithmProtocol
+
+    def __init__(
+        self, warehouse_lat: float, warehouse_lon: float, children_per_box: int
+    ) -> None:
+        self.warehouse_lat = warehouse_lat
+        self.warehouse_lon = warehouse_lon
+        self.clustering_algorithm = SweepClusteringAlgorithm(
+            warehouse_lat=warehouse_lat,
+            warehouse_lon=warehouse_lon,
+            children_per_box=children_per_box,
+        )
+
+    async def generate_routes(
+        self,
+        locations: list[Location],
+        warehouse_lat: float,
+        warehouse_lon: float,
+        settings: RouteGenerationSettings,
+        timeout_seconds: float | None = None,
+    ) -> list[list[Location]]:
+        """Cluster the stops, then order each cluster via the Routes API."""
+        if not locations:
+            return []
+
+        clusters = await self.clustering_algorithm.cluster_locations(
+            locations=locations,
+            num_clusters=settings.num_routes,
+            max_boxes_per_cluster=DEFAULT_MAX_BOXES_PER_CLUSTER,
+            timeout_seconds=timeout_seconds,
+        )
+
+        # One request per non-empty cluster, issued together: they are
+        # independent, and serialising them would multiply the wall-clock cost
+        # of a tier that is meant to be the cheap one.
+        ordered = await asyncio.gather(
+            *(
+                self._order_cluster(
+                    cluster, warehouse_lat, warehouse_lon, settings.return_to_warehouse
+                )
+                for cluster in clusters
+            )
+        )
+        return list(ordered)
+
+    async def _order_cluster(
+        self,
+        cluster: list[Location],
+        warehouse_lat: float,
+        warehouse_lon: float,
+        return_to_warehouse: bool,
+    ) -> list[Location]:
+        """Return one cluster's stops in the order Google recommends.
+
+        Ordering fewer than two stops is a no-op, so those clusters skip the
+        call entirely rather than spending a request to learn nothing.
+        """
+        if len(cluster) < 2:
+            return list(cluster)
+
+        if len(cluster) > MAX_INTERMEDIATES:
+            raise RoutesApiRoutingError(
+                f"Cluster of {len(cluster)} stops exceeds the Routes API's "
+                f"{MAX_INTERMEDIATES}-waypoint limit."
+            )
+
+        order = await self._request_order(
+            cluster, warehouse_lat, warehouse_lon, return_to_warehouse
+        )
+        return [cluster[i] for i in order]
+
+    async def _request_order(
+        self,
+        cluster: list[Location],
+        warehouse_lat: float,
+        warehouse_lon: float,
+        return_to_warehouse: bool,
+    ) -> list[int]:
+        """Ask the Routes API for the best visit order, as cluster indices."""
+        if not app_settings.google_maps_api_key:
+            raise RoutesApiRoutingError(
+                "Routes API ordering is not configured. Set GOOGLE_MAPS_API_KEY."
+            )
+
+        warehouse = routing_v2.Waypoint(
+            location=routing_v2.Location(
+                lat_lng={"latitude": warehouse_lat, "longitude": warehouse_lon}
+            )
+        )
+        stops = [
+            routing_v2.Waypoint(
+                location=routing_v2.Location(
+                    lat_lng={"latitude": loc.latitude, "longitude": loc.longitude}
+                )
+            )
+            for loc in cluster
+        ]
+
+        # When drivers do not return to the depot the last stop is the
+        # destination, so it is fixed and only the rest get reordered. Its
+        # index is appended back on below.
+        if return_to_warehouse:
+            destination, intermediates = warehouse, stops
+            trailing: list[int] = []
+        else:
+            destination, intermediates = stops[-1], stops[:-1]
+            trailing = [len(cluster) - 1]
+
+        request = routing_v2.ComputeRoutesRequest(
+            origin=warehouse,
+            destination=destination,
+            intermediates=intermediates,
+            travel_mode=routing_v2.RouteTravelMode.DRIVE,
+            routing_preference=routing_v2.RoutingPreference.TRAFFIC_AWARE,
+            optimize_waypoint_order=True,
+        )
+
+        try:
+            client = routing_v2.RoutesAsyncClient(
+                client_options=ClientOptions(api_key=app_settings.google_maps_api_key)
+            )
+            response = await client.compute_routes(
+                request=request, metadata=[("x-goog-fieldmask", FIELD_MASK)]
+            )
+        except google_exceptions.PermissionDenied as e:
+            raise RoutesApiRoutingError(
+                "Routes API ordering failed: permission denied."
+            ) from e
+        except google_exceptions.GoogleAPICallError as e:
+            raise RoutesApiRoutingError(
+                "Routes API ordering failed: upstream error."
+            ) from e
+
+        if not response.routes:
+            raise RoutesApiRoutingError("Routes API returned no route for a cluster.")
+
+        order = list(response.routes[0].optimized_intermediate_waypoint_index)
+
+        # A response that does not reorder (or omits the field) must not be
+        # allowed to drop or duplicate stops — silently losing a delivery is
+        # far worse than a slightly longer drive.
+        if sorted(order) != list(range(len(intermediates))):
+            logger.warning(
+                "Routes API returned an unusable waypoint order (%d of %d "
+                "indices); keeping the cluster's original order",
+                len(order),
+                len(intermediates),
+            )
+            return list(range(len(cluster)))
+
+        return order + trailing

--- a/backend/python/app/utilities/datetime_utils.py
+++ b/backend/python/app/utilities/datetime_utils.py
@@ -20,6 +20,17 @@ def now_utc() -> datetime:
     return datetime.now(timezone.utc)
 
 
+def current_billing_month(now: datetime | None = None) -> str:
+    """The Google billing month as ``YYYYMM``.
+
+    Shared by the billing export query and the API quota counters so the two
+    always agree on which month usage belongs to. Drifting definitions here
+    would make a counter irreconcilable with the spend it is meant to predict.
+    """
+    moment = now or datetime.now(ZoneInfo(settings.scheduler_timezone))
+    return moment.strftime("%Y%m")
+
+
 def from_local_wall_clock(wall_clock: datetime) -> datetime:
     """Read a naive local wall-clock time as a real instant, in UTC.
 

--- a/backend/python/migrations/env.py
+++ b/backend/python/migrations/env.py
@@ -18,6 +18,7 @@ from alembic import context
 # Import all models to ensure they're registered with SQLModel
 from app.models.admin import Admin
 from app.models.announcement import Announcement
+from app.models.api_usage import ApiUsage
 from app.models.driver import Driver
 from app.models.job import Job
 from app.models.location import Location

--- a/backend/python/migrations/versions/05a30c326771_add_route_generation_method.py
+++ b/backend/python/migrations/versions/05a30c326771_add_route_generation_method.py
@@ -1,0 +1,32 @@
+"""Add route_generation_method to system settings
+
+Revision ID: 05a30c326771
+Revises: 5d64c664475d
+Create Date: 2026-08-21 11:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "05a30c326771"
+down_revision = "5d64c664475d"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "system_settings",
+        sa.Column(
+            "route_generation_method",
+            sa.String(length=32),
+            nullable=False,
+            server_default="auto",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("system_settings", "route_generation_method")

--- a/backend/python/migrations/versions/5d64c664475d_add_api_usage_table.py
+++ b/backend/python/migrations/versions/5d64c664475d_add_api_usage_table.py
@@ -1,0 +1,40 @@
+"""Add api_usage table for per-SKU quota tracking
+
+Revision ID: 5d64c664475d
+Revises: b8e3f1a70c92
+Create Date: 2026-08-21 10:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "5d64c664475d"
+down_revision = "b8e3f1a70c92"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "api_usage",
+        sa.Column("api_usage_id", sa.Uuid(), nullable=False),
+        sa.Column("sku", sa.String(length=64), nullable=False),
+        sa.Column("billing_month", sa.String(length=6), nullable=False),
+        sa.Column(
+            "units_used", sa.Integer(), nullable=False, server_default=sa.text("0")
+        ),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
+        sa.PrimaryKeyConstraint("api_usage_id"),
+        # Load-bearing, not just hygiene: the service upserts against this
+        # constraint so concurrent jobs can't both read the same count and
+        # each conclude there is room.
+        sa.UniqueConstraint("sku", "billing_month", name="uq_api_usage_sku_month"),
+        sa.CheckConstraint("units_used >= 0", name="ck_api_usage_units_nonnegative"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("api_usage")

--- a/backend/python/tests/test_cascading_routing_algorithm.py
+++ b/backend/python/tests/test_cascading_routing_algorithm.py
@@ -106,21 +106,28 @@ def _cascade(
     maker: Any,
     paid: FakeAlgorithm,
     free: FakeAlgorithm,
+    middle: FakeAlgorithm | None = None,
 ) -> CascadingRoutingAlgorithm:
-    return CascadingRoutingAlgorithm(
-        logging.getLogger(__name__),
-        quota,
-        maker,
-        [
+    """Two rungs by default; pass ``middle`` to exercise all three."""
+    tiers = [
+        Tier(
+            name="fleet_routing",
+            algorithm=paid,
+            sku=ApiSku.FLEET_ROUTING,
+            units_for=fleet_routing_units,
+        )
+    ]
+    if middle is not None:
+        tiers.append(
             Tier(
-                name="fleet_routing",
-                algorithm=paid,
-                sku=ApiSku.FLEET_ROUTING,
-                units_for=fleet_routing_units,
-            ),
-            Tier(name="cluster_sweep", algorithm=free),
-        ],
-    )
+                name="single_vehicle",
+                algorithm=middle,
+                sku=ApiSku.ROUTES_COMPUTE,
+                units_for=routes_compute_units,
+            )
+        )
+    tiers.append(Tier(name="cluster_sweep", algorithm=free))
+    return CascadingRoutingAlgorithm(logging.getLogger(__name__), quota, maker, tiers)
 
 
 class TestQualityOrder:
@@ -276,3 +283,43 @@ class TestBillingUnitsPerTier:
         """One computeRoutes call per vehicle, regardless of stop count."""
         assert routes_compute_units(75, 12) == 12
         assert fleet_routing_units(75, 12) == 87
+
+
+class TestThreeRungCascade:
+    """The shipped ladder: Fleet Routing, then Routes API, then in-house."""
+
+    async def test_middle_rung_catches_the_job_when_the_top_is_spent(
+        self, maker: Any, locations: list[Any], gen_settings: Any
+    ) -> None:
+        paid, middle, free = FakeAlgorithm(), FakeAlgorithm(), FakeAlgorithm()
+        cascade = _cascade(_quota(fleet=12), maker, paid, free, middle)
+
+        await cascade.generate_routes(locations, 43.0, -79.0, gen_settings)
+
+        assert (paid.calls, middle.calls, free.calls) == (0, 1, 0)
+        assert cascade.last_tier_used == "single_vehicle"
+
+    async def test_middle_rung_bills_per_driver_not_per_stop(
+        self, maker: Any, locations: list[Any], gen_settings: Any
+    ) -> None:
+        """9 stops over 4 drivers costs 4 requests, against 13 shipments."""
+        quota = _quota(fleet=12)
+        cascade = _cascade(
+            quota, maker, FakeAlgorithm(), FakeAlgorithm(), FakeAlgorithm()
+        )
+
+        await cascade.generate_routes(locations, 43.0, -79.0, gen_settings)
+
+        async with maker() as session:
+            assert await quota.units_used(session, ApiSku.ROUTES_COMPUTE) == 4
+
+    async def test_drops_to_the_floor_only_when_both_apis_are_spent(
+        self, maker: Any, locations: list[Any], gen_settings: Any
+    ) -> None:
+        paid, middle, free = FakeAlgorithm(), FakeAlgorithm(), FakeAlgorithm()
+        cascade = _cascade(_quota(fleet=0, routes=0), maker, paid, free, middle)
+
+        await cascade.generate_routes(locations, 43.0, -79.0, gen_settings)
+
+        assert (paid.calls, middle.calls, free.calls) == (0, 0, 1)
+        assert cascade.last_tier_used == "cluster_sweep"

--- a/backend/python/tests/test_cascading_routing_algorithm.py
+++ b/backend/python/tests/test_cascading_routing_algorithm.py
@@ -1,0 +1,278 @@
+"""Tests for the tiered route generation cascade.
+
+The cascade decides how much we pay for routes and how good they are, so the
+cases that matter are the transitions: when a tier is skipped, when its quota
+is handed back, and when it is deliberately kept.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any
+from uuid import UUID, uuid4
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from app.config import Settings
+from app.models.api_usage import ApiSku
+from app.schemas.route_generation import RouteGenerationSettings
+from app.services.implementations.cascading_routing_algorithm import (
+    CascadingRoutingAlgorithm,
+    Tier,
+    routes_compute_units,
+)
+from app.services.implementations.quota_service import (
+    QuotaService,
+    fleet_routing_units,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+@dataclass
+class FakeLocation:
+    """Lightweight stand-in for Location that avoids SQLAlchemy mapper init."""
+
+    latitude: float = 43.0
+    longitude: float = -79.0
+    address: str = "123 Test St"
+    location_id: UUID = field(default_factory=uuid4)
+    num_children: int = 2
+
+
+class FakeAlgorithm:
+    """Routing algorithm that records its calls, or fails on demand."""
+
+    def __init__(self, error: Exception | None = None) -> None:
+        self.error = error
+        self.calls = 0
+
+    async def generate_routes(
+        self,
+        locations: list[Any],
+        _warehouse_lat: float,
+        _warehouse_lon: float,
+        _settings: Any,
+        timeout_seconds: float | None = None,  # noqa: ARG002
+    ) -> list[list[Any]]:
+        self.calls += 1
+        if self.error is not None:
+            raise self.error
+        return [list(locations)]
+
+
+@pytest.fixture
+def gen_settings() -> RouteGenerationSettings:
+    return RouteGenerationSettings(
+        route_start_time=datetime(2026, 8, 21, 8, 0), num_routes=4
+    )
+
+
+@pytest.fixture
+def locations() -> list[Any]:
+    return [FakeLocation() for _ in range(9)]
+
+
+@pytest_asyncio.fixture
+async def maker(test_db_engine: Any) -> Any:
+    """Session factory plus cleanup — the cascade commits outside the test's
+    rolled-back session, deliberately, so rows have to be removed by hand."""
+    factory = async_sessionmaker(
+        test_db_engine, class_=AsyncSession, expire_on_commit=False
+    )
+    yield factory
+    async with factory() as session:
+        await session.execute(text("DELETE FROM api_usage"))
+        await session.commit()
+
+
+def _quota(**budgets: int) -> QuotaService:
+    return QuotaService(
+        logging.getLogger(__name__),
+        Settings(
+            quota_fleet_routing_shipments=budgets.get("fleet", 1000),
+            quota_routes_compute_requests=budgets.get("routes", 10000),
+        ),
+    )
+
+
+def _cascade(
+    quota: QuotaService,
+    maker: Any,
+    paid: FakeAlgorithm,
+    free: FakeAlgorithm,
+) -> CascadingRoutingAlgorithm:
+    return CascadingRoutingAlgorithm(
+        logging.getLogger(__name__),
+        quota,
+        maker,
+        [
+            Tier(
+                name="fleet_routing",
+                algorithm=paid,
+                sku=ApiSku.FLEET_ROUTING,
+                units_for=fleet_routing_units,
+            ),
+            Tier(name="cluster_sweep", algorithm=free),
+        ],
+    )
+
+
+class TestQualityOrder:
+    """The best tier runs whenever its free allowance can cover the job."""
+
+    async def test_uses_the_top_tier_when_quota_allows(
+        self, maker: Any, locations: list[Any], gen_settings: Any
+    ) -> None:
+        paid, free = FakeAlgorithm(), FakeAlgorithm()
+        cascade = _cascade(_quota(fleet=1000), maker, paid, free)
+
+        await cascade.generate_routes(locations, 43.0, -79.0, gen_settings)
+
+        assert paid.calls == 1
+        assert free.calls == 0
+        assert cascade.last_tier_used == "fleet_routing"
+
+    async def test_consumes_shipments_including_the_per_vehicle_pickups(
+        self, maker: Any, locations: list[Any], gen_settings: Any
+    ) -> None:
+        quota = _quota(fleet=1000)
+        cascade = _cascade(quota, maker, FakeAlgorithm(), FakeAlgorithm())
+
+        await cascade.generate_routes(locations, 43.0, -79.0, gen_settings)
+
+        async with maker() as session:
+            used = await quota.units_used(session, ApiSku.FLEET_ROUTING)
+        assert used == 9 + 4
+
+
+class TestFallback:
+    """Exhausting a tier's free room drops to the next, never to an error."""
+
+    async def test_falls_back_when_the_top_tier_has_no_free_room(
+        self, maker: Any, locations: list[Any], gen_settings: Any
+    ) -> None:
+        paid, free = FakeAlgorithm(), FakeAlgorithm()
+        # Room for 12 shipments; this job needs 13.
+        cascade = _cascade(_quota(fleet=12), maker, paid, free)
+
+        await cascade.generate_routes(locations, 43.0, -79.0, gen_settings)
+
+        assert paid.calls == 0
+        assert free.calls == 1
+        assert cascade.last_tier_used == "cluster_sweep"
+
+    async def test_the_free_floor_needs_no_quota(
+        self, maker: Any, locations: list[Any], gen_settings: Any
+    ) -> None:
+        """cluster+sweep is in-house, so it runs with every budget at zero."""
+        free = FakeAlgorithm()
+        cascade = _cascade(_quota(fleet=0), maker, FakeAlgorithm(), free)
+
+        routes = await cascade.generate_routes(locations, 43.0, -79.0, gen_settings)
+
+        assert free.calls == 1
+        assert routes == [locations]
+
+    async def test_raises_when_no_tier_can_run(
+        self, maker: Any, locations: list[Any], gen_settings: Any
+    ) -> None:
+        """Only reachable if the free floor was left out of the cascade."""
+        cascade = CascadingRoutingAlgorithm(
+            logging.getLogger(__name__),
+            _quota(fleet=0),
+            maker,
+            [
+                Tier(
+                    name="fleet_routing",
+                    algorithm=FakeAlgorithm(),
+                    sku=ApiSku.FLEET_ROUTING,
+                    units_for=fleet_routing_units,
+                )
+            ],
+        )
+
+        with pytest.raises(RuntimeError, match="No routing tier"):
+            await cascade.generate_routes(locations, 43.0, -79.0, gen_settings)
+
+
+class TestFailureHandling:
+    """A tier that breaks must not quietly eat a month of quota."""
+
+    async def test_a_failing_tier_hands_its_quota_back(
+        self, maker: Any, locations: list[Any], gen_settings: Any
+    ) -> None:
+        """Otherwise a misconfigured tier burns the allowance failing."""
+        quota = _quota(fleet=1000)
+        paid = FakeAlgorithm(error=ValueError("bad credentials"))
+        free = FakeAlgorithm()
+        cascade = _cascade(quota, maker, paid, free)
+
+        await cascade.generate_routes(locations, 43.0, -79.0, gen_settings)
+
+        async with maker() as session:
+            assert await quota.units_used(session, ApiSku.FLEET_ROUTING) == 0
+        assert free.calls == 1
+
+    async def test_a_timeout_keeps_its_reservation(
+        self, maker: Any, locations: list[Any], gen_settings: Any
+    ) -> None:
+        """A timed-out request may still have reached Google and been billed.
+
+        Overcounting costs a slightly worse route; undercounting costs money.
+        """
+        quota = _quota(fleet=1000)
+        paid = FakeAlgorithm(error=TimeoutError())
+        free = FakeAlgorithm()
+        cascade = _cascade(quota, maker, paid, free)
+
+        await cascade.generate_routes(locations, 43.0, -79.0, gen_settings)
+
+        async with maker() as session:
+            assert await quota.units_used(session, ApiSku.FLEET_ROUTING) == 13
+        assert free.calls == 1
+
+    async def test_generation_still_succeeds_when_the_paid_tier_breaks(
+        self, maker: Any, locations: list[Any], gen_settings: Any
+    ) -> None:
+        cascade = _cascade(
+            _quota(fleet=1000),
+            maker,
+            FakeAlgorithm(error=RuntimeError("upstream 500")),
+            FakeAlgorithm(),
+        )
+
+        routes = await cascade.generate_routes(locations, 43.0, -79.0, gen_settings)
+
+        assert routes == [locations]
+        assert cascade.last_tier_used == "cluster_sweep"
+
+
+class TestUsageIsIndependentOfTheJob:
+    """Google bills for the call however the job ends."""
+
+    async def test_reservation_survives_a_rolled_back_job(
+        self, maker: Any, locations: list[Any], gen_settings: Any
+    ) -> None:
+        """The cascade commits quota on its own session, not the job's."""
+        quota = _quota(fleet=1000)
+        cascade = _cascade(quota, maker, FakeAlgorithm(), FakeAlgorithm())
+
+        await cascade.generate_routes(locations, 43.0, -79.0, gen_settings)
+
+        async with maker() as fresh:
+            assert await quota.units_used(fresh, ApiSku.FLEET_ROUTING) == 13
+
+
+class TestBillingUnitsPerTier:
+    """Units are not comparable across SKUs."""
+
+    async def test_routes_compute_counts_requests_not_shipments(self) -> None:
+        """One computeRoutes call per vehicle, regardless of stop count."""
+        assert routes_compute_units(75, 12) == 12
+        assert fleet_routing_units(75, 12) == 87

--- a/backend/python/tests/test_quota_service.py
+++ b/backend/python/tests/test_quota_service.py
@@ -1,0 +1,263 @@
+"""Tests for per-SKU quota tracking.
+
+The counter decides whether route generation calls a paid API, so the two
+failures that matter are opposite: undercounting sails past the free allowance
+and costs money, overcounting downgrades route quality for no reason.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any
+from uuid import UUID, uuid4
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from app.config import Settings
+from app.models.api_usage import ApiSku
+from app.schemas.route_generation import RouteGenerationSettings
+from app.services.implementations.google_maps_routing_service import (
+    GoogleMapsFleetRoutingAlgorithm,
+)
+from app.services.implementations.quota_service import (
+    SKU_UNITS,
+    QuotaService,
+    fleet_routing_units,
+)
+
+pytestmark = pytest.mark.asyncio
+
+MONTH = "202608"
+
+
+@dataclass
+class FakeLocation:
+    """Lightweight stand-in for Location that avoids SQLAlchemy mapper init."""
+
+    latitude: float = 43.0
+    longitude: float = -79.0
+    address: str = "123 Test St"
+    location_id: UUID = field(default_factory=uuid4)
+    num_children: int = 2
+
+
+def _service(**budgets: int) -> QuotaService:
+    settings = Settings(
+        quota_fleet_routing_shipments=budgets.get("fleet", 1000),
+        quota_single_vehicle_shipments=budgets.get("single", 1000),
+        quota_routes_compute_requests=budgets.get("routes", 10000),
+    )
+    return QuotaService(logging.getLogger(__name__), settings)
+
+
+class TestBillingUnits:
+    """Shipments billed per run must match what the payload actually sends."""
+
+    async def test_counts_one_shipment_per_delivery_and_per_vehicle(self) -> None:
+        assert fleet_routing_units(num_locations=75, num_vehicles=12) == 87
+
+    async def test_matches_the_real_payload_builder(self) -> None:
+        """Pins the estimate to ``_build_payload``.
+
+        The payload adds a forced pickup per vehicle on top of the deliveries.
+        If that changes, the quota estimate silently undercounts every run —
+        so this fails loudly instead.
+        """
+        algorithm = GoogleMapsFleetRoutingAlgorithm()
+        locations = [FakeLocation() for _ in range(9)]
+        settings = RouteGenerationSettings(
+            route_start_time=datetime(2026, 8, 21, 8, 0), num_routes=4
+        )
+
+        payload = algorithm._build_payload(
+            locations,  # type: ignore[arg-type]
+            warehouse_lat=43.0,
+            warehouse_lon=-79.0,
+            settings=settings,
+        )
+        actual_shipments = len(payload["model"]["shipments"])
+
+        assert actual_shipments == fleet_routing_units(num_locations=9, num_vehicles=4)
+
+    async def test_every_sku_declares_its_unit(self) -> None:
+        """A bare count is ambiguous — shipments and requests are not alike."""
+        assert {sku.value for sku in ApiSku} == set(SKU_UNITS)
+
+
+class TestTryReserve:
+    """Reservation is the gate that keeps generation inside the free tier."""
+
+    async def test_reserves_when_there_is_room(
+        self, test_session: AsyncSession
+    ) -> None:
+        service = _service(fleet=100)
+
+        assert await service.try_reserve(test_session, ApiSku.FLEET_ROUTING, 87, MONTH)
+        assert await service.units_used(test_session, ApiSku.FLEET_ROUTING, MONTH) == 87
+
+    async def test_refuses_when_the_request_would_exceed_the_budget(
+        self, test_session: AsyncSession
+    ) -> None:
+        service = _service(fleet=100)
+        await service.try_reserve(test_session, ApiSku.FLEET_ROUTING, 87, MONTH)
+
+        assert not await service.try_reserve(
+            test_session, ApiSku.FLEET_ROUTING, 87, MONTH
+        )
+
+    async def test_a_refused_reservation_consumes_nothing(
+        self, test_session: AsyncSession
+    ) -> None:
+        """A partial claim would strand quota nobody can use."""
+        service = _service(fleet=100)
+        await service.try_reserve(test_session, ApiSku.FLEET_ROUTING, 87, MONTH)
+
+        await service.try_reserve(test_session, ApiSku.FLEET_ROUTING, 87, MONTH)
+
+        assert await service.units_used(test_session, ApiSku.FLEET_ROUTING, MONTH) == 87
+
+    async def test_a_request_landing_exactly_on_the_budget_fits(
+        self, test_session: AsyncSession
+    ) -> None:
+        service = _service(fleet=100)
+
+        assert await service.try_reserve(test_session, ApiSku.FLEET_ROUTING, 100, MONTH)
+
+    async def test_one_unit_over_does_not(self, test_session: AsyncSession) -> None:
+        service = _service(fleet=100)
+
+        assert not await service.try_reserve(
+            test_session, ApiSku.FLEET_ROUTING, 101, MONTH
+        )
+
+    async def test_skus_draw_on_separate_allowances(
+        self, test_session: AsyncSession
+    ) -> None:
+        """Google grants these per SKU; spending one must not touch another."""
+        service = _service(fleet=100, routes=100)
+        await service.try_reserve(test_session, ApiSku.FLEET_ROUTING, 100, MONTH)
+
+        assert await service.try_reserve(
+            test_session, ApiSku.ROUTES_COMPUTE, 100, MONTH
+        )
+
+    async def test_a_new_month_starts_from_zero(
+        self, test_session: AsyncSession
+    ) -> None:
+        service = _service(fleet=100)
+        await service.try_reserve(test_session, ApiSku.FLEET_ROUTING, 100, "202608")
+
+        assert await service.try_reserve(
+            test_session, ApiSku.FLEET_ROUTING, 100, "202609"
+        )
+
+    async def test_zero_units_is_a_no_op(self, test_session: AsyncSession) -> None:
+        service = _service(fleet=0)
+
+        assert await service.try_reserve(test_session, ApiSku.FLEET_ROUTING, 0, MONTH)
+
+    async def test_a_zero_budget_refuses_everything(
+        self, test_session: AsyncSession
+    ) -> None:
+        """How an admin forces a tier off without code changes."""
+        service = _service(fleet=0)
+
+        assert not await service.try_reserve(
+            test_session, ApiSku.FLEET_ROUTING, 1, MONTH
+        )
+
+
+class TestConcurrentReservation:
+    """Two jobs starting together must not both claim the last of the quota."""
+
+    async def test_concurrent_reservations_never_exceed_the_budget(
+        self, test_db_engine: Any
+    ) -> None:
+        """The classic check-then-act race, on real Postgres.
+
+        Ten jobs race for a budget that fits four. Separate sessions because a
+        single one would serialize them and prove nothing.
+        """
+        budget, units, racers = 40, 10, 10
+        service = _service(fleet=budget)
+        maker = async_sessionmaker(
+            test_db_engine, class_=AsyncSession, expire_on_commit=False
+        )
+
+        async def claim() -> bool:
+            async with maker() as session:
+                granted = await service.try_reserve(
+                    session, ApiSku.FLEET_ROUTING, units, MONTH
+                )
+                await session.commit()
+                return granted
+
+        results = await asyncio.gather(*(claim() for _ in range(racers)))
+
+        async with maker() as session:
+            used = await service.units_used(session, ApiSku.FLEET_ROUTING, MONTH)
+            # Committed rows escape the per-test rollback, so clean up by hand.
+            await session.execute(
+                text("DELETE FROM api_usage WHERE billing_month = :m"),
+                {"m": MONTH},
+            )
+            await session.commit()
+
+        assert sum(results) == budget // units
+        assert used == budget
+
+
+class TestRecord:
+    """Ungated calls still have to show up in the counter."""
+
+    async def test_records_past_the_budget(self, test_session: AsyncSession) -> None:
+        """Polylines are issued while saving a generation, too late to refuse.
+
+        The allowance is spent either way, so the counter must say so rather
+        than quietly under-reporting.
+        """
+        service = _service(routes=10)
+
+        await service.record(test_session, ApiSku.ROUTES_COMPUTE, 25, MONTH)
+
+        assert (
+            await service.units_used(test_session, ApiSku.ROUTES_COMPUTE, MONTH) == 25
+        )
+
+    async def test_accumulates(self, test_session: AsyncSession) -> None:
+        service = _service()
+
+        await service.record(test_session, ApiSku.ROUTES_COMPUTE, 12, MONTH)
+        await service.record(test_session, ApiSku.ROUTES_COMPUTE, 12, MONTH)
+
+        assert (
+            await service.units_used(test_session, ApiSku.ROUTES_COMPUTE, MONTH) == 24
+        )
+
+
+class TestRelease:
+    """Units handed back when a reserved call provably never happened."""
+
+    async def test_returns_unused_units(self, test_session: AsyncSession) -> None:
+        service = _service(fleet=100)
+        await service.try_reserve(test_session, ApiSku.FLEET_ROUTING, 87, MONTH)
+
+        await service.release(test_session, ApiSku.FLEET_ROUTING, 87, MONTH)
+
+        assert await service.units_used(test_session, ApiSku.FLEET_ROUTING, MONTH) == 0
+
+    async def test_cannot_drive_the_counter_negative(
+        self, test_session: AsyncSession
+    ) -> None:
+        """A negative count would manufacture free quota out of nothing."""
+        service = _service(fleet=100)
+        await service.try_reserve(test_session, ApiSku.FLEET_ROUTING, 10, MONTH)
+
+        await service.release(test_session, ApiSku.FLEET_ROUTING, 999, MONTH)
+
+        assert await service.units_used(test_session, ApiSku.FLEET_ROUTING, MONTH) == 0

--- a/backend/python/tests/test_route_generation_worker.py
+++ b/backend/python/tests/test_route_generation_worker.py
@@ -323,6 +323,19 @@ class TestEnqueueDoorbell:
             await service.enqueue(job.job_id)
 
 
+def _fixed_algorithm(algorithm: Any) -> Any:
+    """Stand in for the worker's per-job algorithm builder.
+
+    The worker picks its engine from system settings on every job; these tests
+    care about the loop, not the choice, so they pin it to one fake.
+    """
+
+    async def _build(_session: Any, _session_maker: Any) -> Any:
+        return algorithm
+
+    return _build
+
+
 class TestWorkerLoop:
     @pytest.mark.asyncio
     async def test_worker_claims_and_completes_a_pending_job(
@@ -335,7 +348,11 @@ class TestWorkerLoop:
         job = await _queue_pending_job(maker, group)
 
         algorithm = FakeRoutingAlgorithm(lambda locations: [locations])
-        monkeypatch.setattr(worker, "get_routing_algorithm", lambda: algorithm)
+        monkeypatch.setattr(
+            worker,
+            "_build_algorithm_for_job",
+            _fixed_algorithm(algorithm),
+        )
 
         start_route_generation_worker()
         wake_route_generation_worker()
@@ -381,7 +398,11 @@ class TestWorkerLoop:
         second = await _queue_pending_job(maker, group)
 
         algorithm = FakeRoutingAlgorithm(lambda locations: [locations])
-        monkeypatch.setattr(worker, "get_routing_algorithm", lambda: algorithm)
+        monkeypatch.setattr(
+            worker,
+            "_build_algorithm_for_job",
+            _fixed_algorithm(algorithm),
+        )
 
         start_route_generation_worker()
         wake_route_generation_worker()

--- a/backend/python/tests/test_routes_api_routing_service.py
+++ b/backend/python/tests/test_routes_api_routing_service.py
@@ -1,0 +1,229 @@
+"""Tests for the Routes API single-vehicle ordering tier.
+
+Ordering is the cheap half of route generation: our clustering already decided
+who goes where, so the failure that matters here is losing or duplicating a
+stop while reordering, which would silently drop a delivery.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any
+from uuid import UUID, uuid4
+
+import pytest
+
+from app.config import settings
+from app.schemas.route_generation import RouteGenerationSettings
+from app.services.implementations.routes_api_routing_service import (
+    MAX_INTERMEDIATES,
+    RoutesApiRoutingError,
+    RoutesApiSingleVehicleAlgorithm,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+@dataclass
+class FakeLocation:
+    """Lightweight stand-in for Location that avoids SQLAlchemy mapper init."""
+
+    latitude: float = 43.0
+    longitude: float = -79.0
+    address: str = "123 Test St"
+    location_id: UUID = field(default_factory=uuid4)
+    num_children: int = 2
+
+
+def _algorithm() -> RoutesApiSingleVehicleAlgorithm:
+    return RoutesApiSingleVehicleAlgorithm(
+        warehouse_lat=43.4, warehouse_lon=-80.5, children_per_box=2
+    )
+
+
+def _settings(num_routes: int = 2, return_to_warehouse: bool = True) -> Any:
+    return RouteGenerationSettings(
+        route_start_time=datetime(2026, 9, 2, 8, 0),
+        num_routes=num_routes,
+        return_to_warehouse=return_to_warehouse,
+    )
+
+
+class TestOrderCluster:
+    """A cluster comes back reordered, whole, and in Google's order."""
+
+    async def test_applies_the_returned_order(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        algorithm = _algorithm()
+        cluster = [FakeLocation(address=str(i)) for i in range(4)]
+
+        async def fake_order(*_args: Any, **_kwargs: Any) -> list[int]:
+            return [2, 0, 3, 1]
+
+        monkeypatch.setattr(algorithm, "_request_order", fake_order)
+
+        ordered = await algorithm._order_cluster(cluster, 43.4, -80.5, True)  # type: ignore[arg-type]
+
+        assert [loc.address for loc in ordered] == ["2", "0", "3", "1"]
+
+    async def test_a_single_stop_needs_no_call(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Nothing to optimise, so the request would spend quota for nothing."""
+        algorithm = _algorithm()
+        called = False
+
+        async def fake_order(*_args: Any, **_kwargs: Any) -> list[int]:
+            nonlocal called
+            called = True
+            return [0]
+
+        monkeypatch.setattr(algorithm, "_request_order", fake_order)
+
+        ordered = await algorithm._order_cluster([FakeLocation()], 43.4, -80.5, True)  # type: ignore[list-item]
+
+        assert len(ordered) == 1
+        assert not called
+
+    async def test_an_empty_cluster_needs_no_call(self) -> None:
+        assert await _algorithm()._order_cluster([], 43.4, -80.5, True) == []
+
+    async def test_rejects_a_cluster_over_the_waypoint_limit(self) -> None:
+        """Silently truncating would drop deliveries."""
+        oversized = [FakeLocation() for _ in range(MAX_INTERMEDIATES + 1)]
+
+        with pytest.raises(RoutesApiRoutingError, match="waypoint limit"):
+            await _algorithm()._order_cluster(oversized, 43.4, -80.5, True)  # type: ignore[arg-type]
+
+
+class TestGenerateRoutes:
+    """Every stop that goes in must come out, exactly once."""
+
+    async def test_preserves_every_stop_across_clusters(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        algorithm = _algorithm()
+        locations = [FakeLocation(address=str(i)) for i in range(8)]
+
+        async def fake_cluster(**kwargs: Any) -> list[list[Any]]:
+            locs = kwargs["locations"]
+            return [locs[:4], locs[4:]]
+
+        async def fake_order(cluster: list[Any], *_args: Any) -> list[int]:
+            return list(reversed(range(len(cluster))))
+
+        monkeypatch.setattr(
+            algorithm.clustering_algorithm, "cluster_locations", fake_cluster
+        )
+        monkeypatch.setattr(algorithm, "_request_order", fake_order)
+
+        routes = await algorithm.generate_routes(
+            locations,  # type: ignore[arg-type]
+            43.4,
+            -80.5,
+            _settings(),
+        )
+
+        returned = [loc.address for route in routes for loc in route]
+        assert sorted(returned) == sorted(loc.address for loc in locations)
+
+    async def test_no_locations_makes_no_calls(self) -> None:
+        assert await _algorithm().generate_routes([], 43.4, -80.5, _settings()) == []
+
+
+class TestUnusableResponse:
+    """A bad ordering must never cost a delivery."""
+
+    async def test_a_short_order_falls_back_to_the_original(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Google returning fewer indices than stops would drop the rest."""
+        algorithm = _algorithm()
+        cluster = [FakeLocation(address=str(i)) for i in range(4)]
+
+        @dataclass
+        class _Route:
+            optimized_intermediate_waypoint_index: list[int] = field(
+                default_factory=lambda: [0, 1]
+            )
+
+        @dataclass
+        class _Response:
+            routes: list[Any] = field(default_factory=lambda: [_Route()])
+
+        async def fake_compute(*_args: Any, **_kwargs: Any) -> Any:
+            return _Response()
+
+        monkeypatch.setattr(settings, "google_maps_api_key", "test-key")
+        monkeypatch.setattr(
+            "app.services.implementations.routes_api_routing_service."
+            "routing_v2.RoutesAsyncClient",
+            lambda **_kw: type(
+                "C", (), {"compute_routes": staticmethod(fake_compute)}
+            )(),
+        )
+
+        order = await algorithm._request_order(cluster, 43.4, -80.5, True)  # type: ignore[arg-type]
+
+        assert order == [0, 1, 2, 3]
+
+    async def test_missing_api_key_fails_clearly(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(settings, "google_maps_api_key", "")
+
+        with pytest.raises(RoutesApiRoutingError, match="GOOGLE_MAPS_API_KEY"):
+            await _algorithm()._request_order(
+                [FakeLocation(), FakeLocation()],  # type: ignore[list-item]
+                43.4,
+                -80.5,
+                True,
+            )
+
+
+class TestBillingShape:
+    """Why this tier is cheaper than Fleet Routing, encoded as a test."""
+
+    async def test_costs_one_request_per_driver_not_per_stop(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """computeRoutes bills per request, so 75 stops over 12 drivers is 12."""
+        algorithm = _algorithm()
+        locations = [FakeLocation(address=str(i)) for i in range(75)]
+        requests = 0
+
+        async def fake_cluster(**kwargs: Any) -> list[list[Any]]:
+            locs = kwargs["locations"]
+            size = len(locs) // 12
+            return [locs[i * size : (i + 1) * size] for i in range(12)]
+
+        async def fake_order(cluster: list[Any], *_args: Any) -> list[int]:
+            nonlocal requests
+            requests += 1
+            return list(range(len(cluster)))
+
+        monkeypatch.setattr(
+            algorithm.clustering_algorithm, "cluster_locations", fake_cluster
+        )
+        monkeypatch.setattr(algorithm, "_request_order", fake_order)
+
+        await algorithm.generate_routes(
+            locations,  # type: ignore[arg-type]
+            43.4,
+            -80.5,
+            _settings(num_routes=12),
+        )
+
+        assert requests == 12
+
+
+class TestLogger:
+    """The module logger is used for the unusable-response warning."""
+
+    async def test_module_exposes_a_logger(self) -> None:
+        from app.services.implementations import routes_api_routing_service
+
+        assert isinstance(routes_api_routing_service.logger, logging.Logger)

--- a/frontend/openapi.json
+++ b/frontend/openapi.json
@@ -3022,6 +3022,17 @@
         "title": "RouteGenerationGroupInput",
         "type": "object"
       },
+      "RouteGenerationMethod": {
+        "description": "Which engine route generation should use.\n\n``AUTO`` walks the tiers in quality order, spending each API's free monthly\nallowance before moving on. The rest pin generation to one engine\nregardless of remaining quota — including past it, into paid usage.",
+        "enum": [
+          "auto",
+          "fleet_routing",
+          "single_vehicle",
+          "cluster_sweep"
+        ],
+        "title": "RouteGenerationMethod",
+        "type": "string"
+      },
       "RouteGenerationSettings": {
         "description": "Settings for route generation.\n\nThese are not persisted to the database; used as inputs to services.",
         "properties": {
@@ -3878,6 +3889,10 @@
               }
             ],
             "title": "Import Column Map"
+          },
+          "route_generation_method": {
+            "$ref": "#/components/schemas/RouteGenerationMethod",
+            "default": "auto"
           },
           "route_start_time": {
             "anyOf": [

--- a/frontend/src/api/generated/index.ts
+++ b/frontend/src/api/generated/index.ts
@@ -411,6 +411,7 @@ export type {
   RenameDeliveryTypeResponses,
   RouteDetailRead,
   RouteGenerationGroupInput,
+  RouteGenerationMethod,
   RouteGenerationSettings,
   RouteGroupCreate,
   RouteGroupDuplicate,

--- a/frontend/src/api/generated/types.gen.ts
+++ b/frontend/src/api/generated/types.gen.ts
@@ -1736,6 +1736,21 @@ export type RouteGenerationGroupInput = {
 };
 
 /**
+ * RouteGenerationMethod
+ *
+ * Which engine route generation should use.
+ *
+ * ``AUTO`` walks the tiers in quality order, spending each API's free monthly
+ * allowance before moving on. The rest pin generation to one engine
+ * regardless of remaining quota — including past it, into paid usage.
+ */
+export type RouteGenerationMethod =
+  | 'auto'
+  | 'fleet_routing'
+  | 'single_vehicle'
+  | 'cluster_sweep';
+
+/**
  * RouteGenerationSettings
  *
  * Settings for route generation.
@@ -2225,6 +2240,7 @@ export type SystemSettingsRead = {
   import_column_map?: {
     [key: string]: string;
   } | null;
+  route_generation_method?: RouteGenerationMethod;
   /**
    * Route Start Time
    */


### PR DESCRIPTION
## JIRA Ticket
[Ticket Name](https://f4kblueprint.atlassian.net/browse/F4KRP)

## Implementation Description
<!-- Quick summary of what you built and why. Include design justifications if needed -->
*

our current route generation always calls fleet routing which is handled by google and bills per shipment so our payload sends one per delivery plus one forced pickup per vehicle. so basically if we had 10 stops and 2 drivers, the run costs is 12 out of our 1000/month allowance

so the first tier of route generations will drain the free 1k credits and google will handle both the assigning and ordering

second tier will be we do the clustering and google will do the ordering per driver

last tier will be our in house algo when we drain both previous tiers, it is hard to get to this tier as the second tier does not cost a lot per request and we have a good amount

## Steps to Test
<!-- What should the reviewer do to verify your changes? Include expected results -->
1. we have 2 new migrations so start up docker like this:
 `docker compose up -d backend && docker exec f4k_backend sh -c "cd /app && alembic upgrade head"`
2. set the budgets low in `.env` (`QUOTA_FLEET_ROUTING_SHIPMENTS=100`, `QUOTA_ROUTES_COMPUTE_REQUESTS=25`) so the ladder cascades without spending real quota, then generate routes repeatedly. verified against the real db:
   run 1: tier=fleet_routing   fleet= 87/100  routes= 0/25
   run 2: tier=single_vehicle  fleet= 87/100  routes=12/25   ← fleet spent
   run 3: tier=single_vehicle  fleet= 87/100  routes=24/25
   run 4: tier=cluster_sweep   fleet= 87/100  routes=24/25   ← both spent
3. set `route_generation_method` to `fleet_routing` in system settings → next job uses it regardless of remaining quota.

## Screenshots *(frontend only — delete if not applicable)*
<!-- Attach implemented screens alongside Zeplin designs for comparison -->
| Implemented | Zeplin Design |
|-------------|---------------|
|             |               |

## What Should Reviewers Focus On?
<!-- Call out substantial changes or anything you want a second opinion on -->
*

## Checklist
- [ ] PR name and commits are descriptive, imperative, and atomic (trivial commits squashed)
- [ ] I have requested a review from Claude, understood its suggestions, and implemented fixes where needed (or documented disagreements)
- [ ] I have requested a review from the PL and relevant devs with background on this PR

**Frontend only — delete if not applicable:**
- [ ] Follows Tailwind/shadcn best practices per README; no hardcoded color or spacing values
- [ ] Implementation matches Zeplin designs and screenshots are attached above
- [ ] Screens render correctly on mobile and desktop; no console warnings or errors