### PR TITLE
Stop tests/test_models.py opening a database at import

### DIFF
--- a/backend/python/app/models/__init__.py
+++ b/backend/python/app/models/__init__.py
@@ -90,9 +90,12 @@ def create_db_and_tables() -> None:
     SQLModel.metadata.create_all(engine)
 
 
-def init_app(_app: Any | None = None) -> None:
-    """Initialize database for the application"""
-    # Import models to register them with SQLModel
+def register_models() -> None:
+    """Import every model so SQLAlchemy can resolve relationships by name.
+
+    Pure imports, no connection: anything that only needs the mappers wired up
+    can call this without a database.
+    """
     from .admin import Admin  # noqa: F401
     from .announcement import Announcement  # noqa: F401
     from .announcement_last_read import AnnouncementLastRead  # noqa: F401
@@ -112,6 +115,10 @@ def init_app(_app: Any | None = None) -> None:
     from .user import User  # noqa: F401
     from .user_invite import UserInvite  # noqa: F401
 
+
+def init_app(_app: Any | None = None) -> None:
+    """Initialize database for the application"""
+    register_models()
     init_database()
 
     # Create tables if in testing mode

--- a/backend/python/tests/test_models.py
+++ b/backend/python/tests/test_models.py
@@ -9,8 +9,9 @@ from uuid import uuid4
 import pytest
 from pydantic import ValidationError
 
-# Initialize all models to ensure proper relationship resolution
-from app.models import init_app
+# Register every model so SQLAlchemy resolves the relationship strings. These
+# tests build model objects in memory and never query, so no database is needed.
+from app.models import register_models
 from app.models.admin import Admin
 from app.models.announcement import (
     Announcement,
@@ -52,7 +53,7 @@ from app.models.route_stop import RouteStop
 from app.models.system_settings import EmailReminder, SystemSettings
 from app.models.user import User, UserFinalize
 
-init_app()
+register_models()
 
 
 class TestCoreBusinessValidation:


### PR DESCRIPTION
`tests/test_models.py:55` called `init_app()` at module scope. That runs `init_database()` and, under `APP_ENV=testing`, `create_db_and_tables()` — so importing the module opened a connection and issued DDL before any test or fixture had a say.

Two consequences. `pytest --collect-only` — the command that answers "what would actually run?" — failed without a live database: `Interrupted: 1 error during collection`, exit 2. And since the DDL runs against whatever `DB_HOST` resolves to, a misconfigured host means pytest creates tables somewhere nobody chose.

None of it was needed. All 27 tests build model objects in memory and never query. They only wanted `init_app()`'s imports, so SQLAlchemy resolves the relationship strings; that half is now `register_models()`, and `init_app()` calls it, leaving the app's path unchanged.

Acceptance test, `DB_HOST` unresolvable: `--collect-only` exits 0 with 882 collected, where main exits 2.
