### PR TITLE
Test the same-day route tiebreak #308 added

### DIFF
--- a/backend/python/tests/test_routes.py
+++ b/backend/python/tests/test_routes.py
@@ -1645,6 +1645,72 @@ class TestLocationRoutes:
         data = response.json()
         assert data["assigned_route"] == "Sooner Route"
 
+    @pytest.mark.asyncio
+    async def test_location_assigned_route_breaks_same_day_tie_numerically(
+        self,
+        async_client: AsyncClient,
+        test_session: AsyncSession,
+        test_location_group: Any,
+    ) -> None:
+        """Two routes the same day: the lower-numbered one wins, not the one a
+        text sort would put first ("Route 10" < "Route 2" as strings)."""
+        loc = Location(
+            location_group_id=test_location_group.location_group_id,
+            name="Same Day Family",
+            contact_name="Same Day Family",
+            address="40 SameDay St",
+            phone_primary="tel:+1-519-576-8888",
+            delivery_type="Family",
+            in_roster=True,
+        )
+        group = RouteGroup(name="Same Day Group", drive_date=date(2098, 6, 1))
+        test_session.add_all([loc, group])
+        await test_session.commit()
+        await test_session.refresh(loc)
+        await test_session.refresh(group)
+
+        # Inserted high-first so an unordered query would surface "Route 10".
+        route_ten = Route(
+            name="Route 10", length=1.0, route_group_id=group.route_group_id
+        )
+        route_two = Route(
+            name="Route 2", length=1.0, route_group_id=group.route_group_id
+        )
+        test_session.add_all([route_ten, route_two])
+        await test_session.commit()
+        await test_session.refresh(route_ten)
+        await test_session.refresh(route_two)
+
+        test_session.add_all(
+            [
+                RouteStop(
+                    route_id=route_ten.route_id,
+                    location_id=loc.location_id,
+                    stop_number=1,
+                ),
+                RouteStop(
+                    route_id=route_two.route_id,
+                    location_id=loc.location_id,
+                    stop_number=1,
+                ),
+            ]
+        )
+        await test_session.commit()
+
+        response = await async_client.get(f"/locations/{loc.location_id}")
+        assert response.status_code == 200
+        assert response.json()["assigned_route"] == "Route 2"
+
+        # The list endpoint reads through the same loader.
+        listed = await async_client.get("/locations/")
+        assert listed.status_code == 200
+        row = next(
+            item
+            for item in listed.json()["items"]
+            if item["location_id"] == str(loc.location_id)
+        )
+        assert row["assigned_route"] == "Route 2"
+
 
 class TestLocationImportRoutes:
     """Test suite for location import validation, review, and ingest."""


### PR DESCRIPTION
#308 made `load_assigned_routes` order same-day routes numerically, and its docstring now promises a location on two routes the same day reports the lower-numbered one. Nothing tested that — the only multi-route test covers different days and predates the change.

This adds the missing case: one location, one route group, routes named "Route 10" and "Route 2". The names are the point — a text sort returns "Route 10", so the test pins the numeric ordering rather than restating it. It asserts on both `GET /locations/{id}` and `GET /locations/`, which read through the same loader.

Verified it fails against the pre-#308 code: under `order_by(drive_date)` alone (what main had) and under an explicit text ordering, all runs return "Route 10".

Test-only. Backend suite green locally.
