### PR TITLE
Extract the selected-button stroke; stop guessing locale in Calendar tests

### DIFF
--- a/frontend/src/common/components/Button.variants.test.ts
+++ b/frontend/src/common/components/Button.variants.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import {
   buttonVariantClasses,
   buttonVariants,
+  SELECTED_BUTTON_STROKE,
 } from '@/common/components/Button.variants';
 
 /**
@@ -109,4 +110,57 @@ describe('filled button label colour', () => {
       );
     });
   }
+});
+
+/**
+ * The same stroke, applied by hand outside the Button component. The ledger is
+ * the guard: a new call site fails until it's listed, and a call site that
+ * drops the constant fails too.
+ */
+describe('SELECTED_BUTTON_STROKE', () => {
+  const DEFINITION = '/src/common/components/Button.variants.ts';
+  const THIS_TEST = '/src/common/components/Button.variants.test.ts';
+
+  const CALL_SITES = [
+    '/src/common/components/Sidebar.tsx',
+    '/src/pages/admin/home/components/UnassignedRoutesCard.tsx',
+    '/src/pages/driver/home/DriverHomePage.tsx',
+  ];
+
+  const sources = Object.entries(
+    import.meta.glob<string>('/src/**/*.{ts,tsx}', {
+      query: '?raw',
+      import: 'default',
+      eager: true,
+    })
+  )
+    .filter(([file]) => file !== DEFINITION && file !== THIS_TEST)
+    .sort(([a], [b]) => a.localeCompare(b));
+
+  it('is a 1px stroke in the light-ground blue', () => {
+    expect(SELECTED_BUTTON_STROKE.split(/\s+/)).toEqual([
+      'outline',
+      'outline-1',
+      'outline-offset-[-1px]',
+      'outline-blue-100',
+    ]);
+  });
+
+  it('finds the source tree to scan', () => {
+    expect(sources.length).toBeGreaterThan(50);
+  });
+
+  it('is used by exactly the call sites listed here', () => {
+    const users = sources
+      .filter(([, code]) => code.includes('SELECTED_BUTTON_STROKE'))
+      .map(([file]) => file);
+    expect(users).toEqual([...CALL_SITES].sort());
+  });
+
+  it('is never written out as a literal instead', () => {
+    const inlined = sources
+      .filter(([, code]) => code.includes('outline-blue-100'))
+      .map(([file]) => file);
+    expect(inlined).toEqual([]);
+  });
 });

--- a/frontend/src/common/components/Button.variants.ts
+++ b/frontend/src/common/components/Button.variants.ts
@@ -15,6 +15,13 @@ export const buttonVariantClasses = {
   destructive: 'bg-red text-grey-100 hover:opacity-90',
 } as const;
 
+/* The same 1px light-ground stroke, for selected/active buttons outside this
+ * component (active sidebar item, driver-home segmented control, unassigned
+ * route row). Button treatment only — a selected calendar day is a flat
+ * ellipse with no stroke. Call sites are listed in Button.variants.test.ts. */
+export const SELECTED_BUTTON_STROKE =
+  'outline outline-1 outline-offset-[-1px] outline-blue-100';
+
 export const buttonVariants = cva(
   /* ---- shared base ---- */
   [

--- a/frontend/src/common/components/Calendar.test.tsx
+++ b/frontend/src/common/components/Calendar.test.tsx
@@ -3,6 +3,7 @@ import { cleanup, fireEvent, render } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { Calendar } from '@/common/components/Calendar';
+import { toNaiveDateString } from '@/common/utils';
 
 afterEach(cleanup);
 
@@ -17,15 +18,6 @@ function weekdayHeader(container: HTMLElement): string[] {
   return [...container.querySelectorAll('thead th')].map(
     (th) => th.textContent ?? ''
   );
-}
-
-/**
- * `data-day` as the component writes it. Going through the same
- * `toLocaleDateString()` call keeps the test's idea of the format from
- * disagreeing with the component's under any runner locale.
- */
-function dataDay(year: number, month: number, day: number): string {
-  return new Date(year, month, day).toLocaleDateString();
 }
 
 /** Every day button in the grid, in DOM order, with the date it stands for. */
@@ -48,6 +40,18 @@ function weekRows(container: HTMLElement) {
   }
   return [...rows.values()];
 }
+
+describe('Calendar day identity', () => {
+  it('labels each cell with its ISO date', () => {
+    const { container } = render(
+      <Calendar mode="single" defaultMonth={JANUARY_2026} />
+    );
+    // The one place the format is pinned: every other expectation below
+    // generates or spells out a date in this shape.
+    expect(toNaiveDateString(new Date(2026, 0, 15))).toBe('2026-01-15');
+    expect(dayCells(container)[0].day).toBe('2025-12-29');
+  });
+});
 
 describe('Calendar weekday order', () => {
   it('renders the header as M T W T F S S', () => {
@@ -77,7 +81,7 @@ describe('Calendar weekday order', () => {
     // Seven-wide rows of consecutive days from a Monday: every row therefore
     // runs Monday through Sunday.
     expect(cells.map((cell) => cell.day)).toEqual(
-      cells.map((_, i) => dataDay(2025, 11, 29 + i))
+      cells.map((_, i) => toNaiveDateString(new Date(2025, 11, 29 + i)))
     );
     for (const row of weekRows(container)) expect(row).toHaveLength(7);
   });
@@ -111,7 +115,7 @@ describe('Calendar weekday order', () => {
       'F',
       'S',
     ]);
-    expect(weekRows(container)[0][0].day).toBe(dataDay(2025, 11, 28));
+    expect(weekRows(container)[0][0].day).toBe('2025-12-28');
   });
 });
 
@@ -121,21 +125,19 @@ describe('Calendar selection', () => {
    * which date a cell stands for by clicking cells at both ends of a row.
    */
   it.each([
-    15, // mid-month, a Thursday
-    5, // first column of its row, a Monday
-    4, // last column of its row, a Sunday
-    31, // last day of the month, a Saturday
-  ])('clicking Jan %i selects that date', (day) => {
+    ['2026-01-15', 15], // mid-month, a Thursday
+    ['2026-01-05', 5], // first column of its row, a Monday
+    ['2026-01-04', 4], // last column of its row, a Sunday
+    ['2026-01-31', 31], // last day of the month, a Saturday
+  ])('clicking %s selects that date', (isoDate, dayOfMonth) => {
     const onSelect = vi.fn();
     const { container } = render(
       <Calendar mode="single" defaultMonth={JANUARY_2026} onSelect={onSelect} />
     );
 
-    const cell = dayCells(container).find(
-      (c) => c.day === dataDay(2026, 0, day)
-    );
+    const cell = dayCells(container).find((c) => c.day === isoDate);
     expect(cell).toBeDefined();
-    expect(cell!.label).toBe(String(day));
+    expect(cell!.label).toBe(String(dayOfMonth));
 
     fireEvent.click(cell!.el);
 
@@ -145,7 +147,7 @@ describe('Calendar selection', () => {
       selected.getFullYear(),
       selected.getMonth(),
       selected.getDate(),
-    ]).toEqual([2026, 0, day]);
+    ]).toEqual([2026, 0, dayOfMonth]);
   });
 
   it('maps every in-month cell to its own date', () => {
@@ -154,7 +156,8 @@ describe('Calendar selection', () => {
     );
     const cells = dayCells(container);
     for (let day = 1; day <= 31; day++) {
-      const matches = cells.filter((c) => c.day === dataDay(2026, 0, day));
+      const isoDate = `2026-01-${String(day).padStart(2, '0')}`;
+      const matches = cells.filter((c) => c.day === isoDate);
       expect(matches).toHaveLength(1);
       expect(matches[0].label).toBe(String(day));
     }

--- a/frontend/src/common/components/Calendar.test.tsx
+++ b/frontend/src/common/components/Calendar.test.tsx
@@ -20,33 +20,21 @@ function weekdayHeader(container: HTMLElement): string[] {
 }
 
 /**
- * `data-day` is `toLocaleDateString()`, so its shape follows the runner's
- * locale: `2026-01-15` under en-CA, `1/15/2026` under en-US. Parse both as a
- * LOCAL date — `new Date('2026-01-15')` would be read as UTC midnight and land
- * on the previous day west of Greenwich.
+ * `data-day` as the component writes it. Going through the same
+ * `toLocaleDateString()` call keeps the test's idea of the format from
+ * disagreeing with the component's under any runner locale.
  */
-function parseDataDay(raw: string): Date {
-  const parts = raw.match(/\d+/g);
-  if (!parts || parts.length !== 3) {
-    throw new Error(`unrecognised data-day: ${raw}`);
-  }
-  const [a, b, c] = parts.map(Number);
-  return parts[0].length === 4
-    ? new Date(a, b - 1, c) // year-first
-    : new Date(c, a - 1, b); // month-first
+function dataDay(year: number, month: number, day: number): string {
+  return new Date(year, month, day).toLocaleDateString();
 }
 
 /** Every day button in the grid, in DOM order, with the date it stands for. */
 function dayCells(container: HTMLElement) {
   return [...container.querySelectorAll<HTMLElement>('button[data-day]')].map(
     (el) => {
-      const raw = el.dataset.day;
-      if (!raw) throw new Error('day button without a data-day');
-      return {
-        el,
-        date: parseDataDay(raw),
-        label: el.textContent?.trim() ?? '',
-      };
+      const day = el.dataset.day;
+      if (!day) throw new Error('day button without a data-day');
+      return { el, day, label: el.textContent?.trim() ?? '' };
     }
   );
 }
@@ -81,16 +69,17 @@ describe('Calendar weekday order', () => {
     const { container } = render(
       <Calendar mode="single" defaultMonth={JANUARY_2026} />
     );
-    const rows = weekRows(container);
-    expect(rows.length).toBeGreaterThan(0);
+    // Fixture check: the grid's first cell, Dec 29 2025, is a Monday.
+    expect(new Date(2025, 11, 29).getDay()).toBe(1);
 
-    for (const row of rows) {
-      expect(row).toHaveLength(7);
-      // 1 = Monday … 0 = Sunday
-      expect(row.map((cell) => cell.date.getDay())).toEqual([
-        1, 2, 3, 4, 5, 6, 0,
-      ]);
-    }
+    const cells = dayCells(container);
+    expect(cells.length % 7).toBe(0);
+    // Seven-wide rows of consecutive days from a Monday: every row therefore
+    // runs Monday through Sunday.
+    expect(cells.map((cell) => cell.day)).toEqual(
+      cells.map((_, i) => dataDay(2025, 11, 29 + i))
+    );
+    for (const row of weekRows(container)) expect(row).toHaveLength(7);
   });
 
   it('opens January 2026 on Dec 29 (Monday), not Dec 28 (Sunday)', () => {
@@ -122,7 +111,7 @@ describe('Calendar weekday order', () => {
       'F',
       'S',
     ]);
-    expect(weekRows(container)[0][0].label).toBe('28');
+    expect(weekRows(container)[0][0].day).toBe(dataDay(2025, 11, 28));
   });
 });
 
@@ -132,22 +121,21 @@ describe('Calendar selection', () => {
    * which date a cell stands for by clicking cells at both ends of a row.
    */
   it.each([
-    ['15', 2026, 0, 15], // mid-month, a Thursday
-    ['5', 2026, 0, 5], // first column of its row, a Monday
-    ['4', 2026, 0, 4], // last column of its row, a Sunday
-    ['31', 2026, 0, 31], // last day of the month, a Saturday
-  ])('clicking %s selects the matching date', (label, year, month, day) => {
+    15, // mid-month, a Thursday
+    5, // first column of its row, a Monday
+    4, // last column of its row, a Sunday
+    31, // last day of the month, a Saturday
+  ])('clicking Jan %i selects that date', (day) => {
     const onSelect = vi.fn();
     const { container } = render(
       <Calendar mode="single" defaultMonth={JANUARY_2026} onSelect={onSelect} />
     );
 
-    // Restrict to in-month cells so outside-day duplicates (Dec 29–31) can't
-    // be picked up by the label match.
     const cell = dayCells(container).find(
-      (c) => c.label === label && c.date.getMonth() === month
+      (c) => c.day === dataDay(2026, 0, day)
     );
     expect(cell).toBeDefined();
+    expect(cell!.label).toBe(String(day));
 
     fireEvent.click(cell!.el);
 
@@ -157,19 +145,18 @@ describe('Calendar selection', () => {
       selected.getFullYear(),
       selected.getMonth(),
       selected.getDate(),
-    ]).toEqual([year, month, day]);
+    ]).toEqual([2026, 0, day]);
   });
 
   it('maps every in-month cell to its own date', () => {
     const { container } = render(
       <Calendar mode="single" defaultMonth={JANUARY_2026} />
     );
-    const inMonth = dayCells(container).filter(
-      (c) => c.date.getMonth() === 0 && c.date.getFullYear() === 2026
-    );
-    expect(inMonth).toHaveLength(31);
-    expect(inMonth.map((c) => c.label)).toEqual(
-      Array.from({ length: 31 }, (_, i) => String(i + 1))
-    );
+    const cells = dayCells(container);
+    for (let day = 1; day <= 31; day++) {
+      const matches = cells.filter((c) => c.day === dataDay(2026, 0, day));
+      expect(matches).toHaveLength(1);
+      expect(matches[0].label).toBe(String(day));
+    }
   });
 });

--- a/frontend/src/common/components/Calendar.tsx
+++ b/frontend/src/common/components/Calendar.tsx
@@ -11,6 +11,7 @@ import {
 } from 'react-day-picker';
 
 import { Button } from '@/common/components/Button';
+import { toNaiveDateString } from '@/common/utils';
 import { cn } from '@/lib/utils';
 
 function Calendar({
@@ -190,7 +191,7 @@ function CalendarDayButton({
       ref={ref}
       variant="primary"
       shape="circular"
-      data-day={day.date.toLocaleDateString()}
+      data-day={toNaiveDateString(day.date)}
       data-selected-single={
         modifiers.selected &&
         !modifiers.range_start &&

--- a/frontend/src/common/components/Sidebar.tsx
+++ b/frontend/src/common/components/Sidebar.tsx
@@ -3,6 +3,8 @@ import { NavLink } from 'react-router-dom';
 
 import { cn } from '@/lib/utils';
 
+import { SELECTED_BUTTON_STROKE } from './Button.variants';
+
 function SidebarProvider({ children }: { children: React.ReactNode }) {
   return <div className="flex h-screen overflow-hidden">{children}</div>;
 }
@@ -106,7 +108,7 @@ function SidebarMenuItem({
           'flex w-20 flex-col items-center justify-center gap-1 rounded-xl px-4 py-3.5',
           'transition-colors',
           isActive
-            ? 'bg-blue-50 text-blue-400 shadow-[0px_4px_24px_0px_rgba(0,0,0,0.08)] outline outline-1 outline-offset-[-1px] outline-blue-100'
+            ? `bg-blue-50 text-blue-400 shadow-[0px_4px_24px_0px_rgba(0,0,0,0.08)] ${SELECTED_BUTTON_STROKE}`
             : 'text-grey-500 hover:bg-grey-150'
         )
       }

--- a/frontend/src/pages/admin/home/components/UnassignedRoutesCard.tsx
+++ b/frontend/src/pages/admin/home/components/UnassignedRoutesCard.tsx
@@ -12,6 +12,7 @@ import {
   Spinner,
   Tag,
 } from '@/common/components';
+import { SELECTED_BUTTON_STROKE } from '@/common/components/Button.variants';
 import { parseDateOnly, toNaiveDateString } from '@/common/utils';
 import { cn } from '@/lib/utils';
 
@@ -49,9 +50,7 @@ function UnassignedRouteRow({
         onClick={onSelect}
         className={cn(
           'flex w-full cursor-pointer items-center justify-between self-stretch rounded-sm px-5 py-2 text-left',
-          // Light ground when selected, so it takes a 1px stroke.
-          isSelected &&
-            'bg-blue-50 outline outline-1 outline-offset-[-1px] outline-blue-100'
+          isSelected && `bg-blue-50 ${SELECTED_BUTTON_STROKE}`
         )}
       >
         <div className="flex min-w-0 flex-col">

--- a/frontend/src/pages/driver/home/DriverHomePage.tsx
+++ b/frontend/src/pages/driver/home/DriverHomePage.tsx
@@ -6,6 +6,7 @@ import { useDriverRoutes, useRoute } from '@/api/routes';
 import noUpcoming from '@/assets/illustrations/boy-edge-case-with-questions.png';
 import noPast from '@/assets/illustrations/girl-confused.png';
 import logo from '@/assets/logos/logo_mobile_one_line.svg';
+import { SELECTED_BUTTON_STROKE } from '@/common/components/Button.variants';
 import { StatisticsCard } from '@/common/components/StatisticsCard';
 import { AnnouncementsBoard } from '@/features/announcements';
 import { cn } from '@/lib/utils';
@@ -120,15 +121,12 @@ export const DriverHomePage = () => {
       <div className="mb-2 w-full">
         <div className="bg-grey-150 w-full rounded-full p-1">
           <div className="flex w-full rounded-full">
-            {/* The selected pill sits on a light ground, so per the stroke
-             * rule it carries a 1px stroke — same treatment as the active
-             * sidebar item. */}
             <button
               onClick={() => setTab('upcoming')}
               className={cn(
                 'text-p2 flex-1 rounded-full px-4 py-3 text-center font-semibold',
                 tab === 'upcoming'
-                  ? 'bg-blue-50 text-blue-300 outline outline-1 outline-offset-[-1px] outline-blue-100'
+                  ? `bg-blue-50 text-blue-300 ${SELECTED_BUTTON_STROKE}`
                   : 'text-grey-500'
               )}
             >
@@ -139,7 +137,7 @@ export const DriverHomePage = () => {
               className={cn(
                 'text-p2 flex-1 rounded-full px-4 py-3 text-center font-semibold',
                 tab === 'past'
-                  ? 'bg-blue-50 text-blue-300 outline outline-1 outline-offset-[-1px] outline-blue-100'
+                  ? `bg-blue-50 text-blue-300 ${SELECTED_BUTTON_STROKE}`
                   : 'text-grey-500'
               )}
             >


### PR DESCRIPTION
Two leftovers from the design sweep (#294).

**Selected-button stroke.** `outline outline-1 outline-offset-[-1px]
outline-blue-100` sat verbatim at four call sites. Extracted as
`SELECTED_BUTTON_STROKE` in `Button.variants.ts`, which already owns the
platform-wide stroke rule. Named for the treatment, not the situation — a
selected *calendar* day is a flat ellipse with no stroke, so this must not
spread there. `Button.variants.test.ts` gains a call-site ledger: it fails if a
file uses the constant unlisted, if a listed file drops it, or if anyone writes
the literal by hand.

**`data-day` is now an ISO date.** It was `toLocaleDateString()`, so
`Calendar.test.tsx` parsed it back and guessed month-first vs year-first —
`15/01/2026` reads as month 15 in a day-first locale. The attribute now uses
`toNaiveDateString` from `common/utils` and the test asserts real dates
(`'2026-01-15'`). It has no other consumer.

Frontend only; lint, format, test and build pass on CI's Node and pnpm.
