### PR TITLE
Land the deployment config main was missing from #210

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,8 +175,10 @@ the browser sees one origin and the refresh cookie stays `SameSite=strict`.
 
 **Backend** (Cloud Run, `backend-service`, `us-east1`). Its config is the Secret Manager
 secret `food4kids-config-dev`, a JSON object of `UPPER_CASE` keys mounted at
-`/secrets/config.json`; `Settings` reads it directly. Keep the service's own environment
-variables empty so nothing shadows the secret:
+`/secrets/config.json`; `Settings` reads it directly and refuses to start in production
+unless every key in `REQUIRED_IN_PRODUCTION` (`app/config.py`) is present, so a typo in
+the secret fails the deploy rather than the first request. Keep the service's own
+environment variables empty so nothing shadows the secret:
 
 ```bash
 gcloud run deploy backend-service --source backend/python --region us-east1 \

--- a/README.md
+++ b/README.md
@@ -167,6 +167,29 @@ After changing a template, regenerate both copies with one command from the repo
 
 Commit both directories together; CI fails if they drift. To preview while editing, run `pnpm run email:dev` from `frontend/`.
 
+## Deployment
+
+Both halves live in the `food4kids-473501` GCP project. Firebase Hosting serves the
+frontend and rewrites `/api/**` to the Cloud Run backend (`frontend/firebase.json`), so
+the browser sees one origin and the refresh cookie stays `SameSite=strict`.
+
+**Backend** (Cloud Run, `backend-service`, `us-east1`). Its config is the Secret Manager
+secret `food4kids-config-dev`, a JSON object of `UPPER_CASE` keys mounted at
+`/secrets/config.json`; `Settings` reads it directly. Keep the service's own environment
+variables empty so nothing shadows the secret:
+
+```bash
+gcloud run deploy backend-service --source backend/python --region us-east1 \
+  --project food4kids-473501 --clear-env-vars
+```
+
+**Frontend** (Firebase Hosting, site `food4kids-473501`). Production builds talk to their
+own origin, so no `VITE_API_BASE_URL` is needed:
+
+```bash
+cd frontend && pnpm build && npx firebase-tools deploy --only hosting
+```
+
 ## Docker Commands
 
 ```bash

--- a/backend/python/app/config.py
+++ b/backend/python/app/config.py
@@ -1,7 +1,16 @@
 from enum import StrEnum
 
 from pydantic import Field
-from pydantic_settings import BaseSettings, SettingsConfigDict
+from pydantic_settings import (
+    BaseSettings,
+    JsonConfigSettingsSource,
+    PydanticBaseSettingsSource,
+    SettingsConfigDict,
+)
+
+# Cloud Run mounts the Secret Manager secret (a JSON object of UPPER_CASE keys)
+# here; see README "Deployment". Absent locally, where .env plays that role.
+CLOUD_RUN_SECRETS_FILE = "/secrets/config.json"
 
 
 class Environment(StrEnum):
@@ -25,9 +34,32 @@ class Settings(BaseSettings):
     model_config = SettingsConfigDict(
         env_file=".env",
         env_file_encoding="utf-8",
+        json_file=CLOUD_RUN_SECRETS_FILE,
         case_sensitive=False,
         populate_by_name=True,
+        # The secret is shared with scripts, so it carries keys that are not
+        # settings; skip them the way unknown environment variables are skipped.
+        extra="ignore",
     )
+
+    @classmethod
+    def settings_customise_sources(
+        cls,
+        settings_cls: type[BaseSettings],
+        init_settings: PydanticBaseSettingsSource,
+        env_settings: PydanticBaseSettingsSource,
+        dotenv_settings: PydanticBaseSettingsSource,
+        file_secret_settings: PydanticBaseSettingsSource,
+    ) -> tuple[PydanticBaseSettingsSource, ...]:
+        # Environment variables still win, so a value can be overridden per
+        # revision without editing the secret.
+        return (
+            init_settings,
+            env_settings,
+            JsonConfigSettingsSource(settings_cls),
+            dotenv_settings,
+            file_secret_settings,
+        )
 
     # Environment
     environment: Environment = Field(default=Environment.DEVELOPMENT, alias="APP_ENV")

--- a/backend/python/app/config.py
+++ b/backend/python/app/config.py
@@ -1,6 +1,8 @@
+import os
 from enum import StrEnum
+from pathlib import Path
 
-from pydantic import Field
+from pydantic import Field, model_validator
 from pydantic_settings import (
     BaseSettings,
     JsonConfigSettingsSource,
@@ -11,6 +13,30 @@ from pydantic_settings import (
 # Cloud Run mounts the Secret Manager secret (a JSON object of UPPER_CASE keys)
 # here; see README "Deployment". Absent locally, where .env plays that role.
 CLOUD_RUN_SECRETS_FILE = "/secrets/config.json"
+
+# Everything a deployed backend reads unconditionally. Listed by hand so a
+# typo'd key in the secret fails at startup, not at first use.
+REQUIRED_IN_PRODUCTION = (
+    "database_url",
+    "firebase_project_id",
+    "firebase_web_api_key",
+    "firebase_svc_account_private_key_id",
+    "firebase_svc_account_private_key",
+    "firebase_svc_account_client_email",
+    "firebase_svc_account_client_id",
+    "firebase_svc_account_auth_uri",
+    "firebase_svc_account_token_uri",
+    "firebase_svc_account_auth_provider_x509_cert_url",
+    "firebase_svc_account_client_x509_cert_url",
+    "mailer_refresh_token",
+    "mailer_client_id",
+    "mailer_client_secret",
+    "mailer_user",
+    "google_maps_api_key",
+    "gcp_bucket_name",
+    "route_opt_project_id",
+    "frontend_base_url",
+)
 
 
 class Environment(StrEnum):
@@ -164,6 +190,28 @@ class Settings(BaseSettings):
     def FRONTEND_BASE_URL(self) -> str:
         return self.frontend_base_url
 
+    @model_validator(mode="after")
+    def _production_is_fully_configured(self) -> "Settings":
+        if self.environment is not Environment.PRODUCTION:
+            return self
+        # "Set" rather than "truthy": frontend_base_url defaults to localhost,
+        # and production emails must not link there.
+        missing = [
+            name.upper()
+            for name in REQUIRED_IN_PRODUCTION
+            if name not in self.model_fields_set or not getattr(self, name)
+        ]
+        if missing:
+            raise ValueError(f"production config is missing {', '.join(missing)}")
+        return self
 
-# Global settings instance
+
+def require_the_secret_mount(path: Path = Path(CLOUD_RUN_SECRETS_FILE)) -> None:
+    """Cloud Run sets K_SERVICE on every instance. Without this check a failed
+    mount would start the service in development mode with empty credentials."""
+    if "K_SERVICE" in os.environ and not path.is_file():
+        raise RuntimeError(f"Running on Cloud Run but {path} is not mounted")
+
+
+require_the_secret_mount()
 settings = Settings()

--- a/backend/python/app/database_url.py
+++ b/backend/python/app/database_url.py
@@ -24,12 +24,7 @@ def get_database_url(driver: Driver = ASYNC_DRIVER) -> str:
     URL with "None" where the host should be and failing at connect time.
     """
     if settings.environment is Environment.PRODUCTION:
-        if not settings.database_url:
-            raise RuntimeError(
-                "DATABASE_URL must be set in production. It is the only source "
-                "for the deployed database; the POSTGRES_* fields describe the "
-                "local container."
-            )
+        # Settings refuses to start in production without DATABASE_URL.
         return (
             make_url(settings.database_url)
             .set(drivername=driver)

--- a/backend/python/app/routers/__init__.py
+++ b/backend/python/app/routers/__init__.py
@@ -23,8 +23,8 @@ from . import (
 # /api/** to this service and the browser sees a single origin — which is what
 # lets the refresh cookie stay SameSite=strict. Hosting forwards the matched
 # path verbatim rather than stripping the prefix, so the routes carry it.
-# The rewrite (source "/api/**") is deployed Hosting config not yet checked in;
-# tests/test_api_prefix.py pins the literal until frontend/firebase.json lands.
+# The rewrite lives in frontend/firebase.json; tests/test_api_prefix.py keeps
+# the two in step.
 API_PREFIX = "/api"
 
 

--- a/backend/python/app/utilities/cookies.py
+++ b/backend/python/app/utilities/cookies.py
@@ -16,7 +16,10 @@ def get_cookie_options() -> dict[str, bool | Literal["none", "strict", "lax"]]:
     return {
         "httponly": True,
         "samesite": samesite,
-        "secure": settings.environment is Environment.PRODUCTION,
+        # Browsers drop a SameSite=None cookie that is not also Secure, so a
+        # preview deploy needs it as much as production does.
+        "secure": settings.preview_deploy
+        or settings.environment is Environment.PRODUCTION,
     }
 
 

--- a/backend/python/tests/test_api_prefix.py
+++ b/backend/python/tests/test_api_prefix.py
@@ -10,6 +10,9 @@ prefix before comparing, which means it would stay green if the prefix
 vanished. This is the test that would not.
 """
 
+import json
+from pathlib import Path
+
 import pytest
 from fastapi.routing import APIRoute
 from fastapi.testclient import TestClient
@@ -29,11 +32,20 @@ def schema_paths() -> list[str]:
     ]
 
 
+FIREBASE_JSON = Path(__file__).resolve().parents[3] / "frontend" / "firebase.json"
+
+
 def test_the_prefix_is_what_hosting_rewrites() -> None:
-    """Hosting's rewrite is configured for this exact string. It is deployed
-    config not yet checked in; once frontend/firebase.json lands on main, parse
-    it here instead of pinning the literal."""
-    assert API_PREFIX == "/api"
+    """The Hosting rewrite and the router prefix have to agree, or every request
+    404s through the rewrite. Skipped (visibly) when only backend/python is
+    mounted, as in the compose container; CI checks out the whole repo."""
+    if not FIREBASE_JSON.exists():
+        pytest.skip(f"{FIREBASE_JSON} is not mounted here")
+    rewrites = json.loads(FIREBASE_JSON.read_text())["hosting"]["rewrites"]
+    to_backend = [r for r in rewrites if "run" in r]
+    assert len(to_backend) == 1, rewrites
+    assert to_backend[0]["source"] == f"{API_PREFIX}/**"
+    assert to_backend[0]["run"]["serviceId"] == "backend-service"
 
 
 def test_every_route_carries_the_prefix(schema_paths: list[str]) -> None:

--- a/backend/python/tests/test_config_sources.py
+++ b/backend/python/tests/test_config_sources.py
@@ -10,11 +10,27 @@ from pathlib import Path
 
 import pytest
 
-from app.config import CLOUD_RUN_SECRETS_FILE, Environment, Settings
+from app.config import (
+    CLOUD_RUN_SECRETS_FILE,
+    REQUIRED_IN_PRODUCTION,
+    Environment,
+    Settings,
+    require_the_secret_mount,
+)
 
 # Keys the tests set themselves; cleared from the process environment first so
-# conftest's APP_ENV=testing and CI's POSTGRES_* cannot mask a source.
-KEYS = ("APP_ENV", "DB_HOST", "POSTGRES_USER", "PREVIEW_DEPLOY", "FRONTEND_BASE_URL")
+# conftest's APP_ENV=testing and the container's real .env cannot mask a source.
+KEYS = (
+    "APP_ENV",
+    "DB_HOST",
+    "POSTGRES_USER",
+    "PREVIEW_DEPLOY",
+    *(name.upper() for name in REQUIRED_IN_PRODUCTION),
+)
+
+COMPLETE_PRODUCTION = {name.upper(): f"{name}-value" for name in REQUIRED_IN_PRODUCTION}
+COMPLETE_PRODUCTION["APP_ENV"] = "production"
+COMPLETE_PRODUCTION["DATABASE_URL"] = "postgresql://u:p@db.neon.tech:5432/prod"
 
 
 @pytest.fixture
@@ -44,7 +60,7 @@ class TestJsonFile:
         assert settings.db_host == "db.example"
 
     def test_app_env_reaches_the_aliased_field(self, isolated: Path) -> None:
-        write_json(isolated, APP_ENV="production")
+        write_json(isolated, **COMPLETE_PRODUCTION)
         assert Settings().environment is Environment.PRODUCTION
 
     def test_a_bad_app_env_still_fails_at_startup(self, isolated: Path) -> None:
@@ -65,6 +81,68 @@ class TestJsonFile:
         settings = Settings()
         assert settings.environment is Environment.DEVELOPMENT
         assert settings.db_host == ""
+
+
+class TestProductionRefusesToStartHalfConfigured:
+    def test_a_complete_secret_starts(self, isolated: Path) -> None:
+        write_json(isolated, **COMPLETE_PRODUCTION)
+        assert Settings().environment is Environment.PRODUCTION
+
+    @pytest.mark.parametrize("name", REQUIRED_IN_PRODUCTION)
+    def test_each_required_key_is_named_when_absent(
+        self, isolated: Path, name: str
+    ) -> None:
+        """A typo'd key (POSTGRES_USR) reads as absent, so this is the typo
+        case too."""
+        values = dict(COMPLETE_PRODUCTION)
+        del values[name.upper()]
+        write_json(isolated, **values)
+        with pytest.raises(ValueError, match=name.upper()):
+            Settings()
+
+    def test_an_empty_value_counts_as_missing(self, isolated: Path) -> None:
+        write_json(isolated, **{**COMPLETE_PRODUCTION, "GOOGLE_MAPS_API_KEY": ""})
+        with pytest.raises(ValueError, match="GOOGLE_MAPS_API_KEY"):
+            Settings()
+
+    def test_every_gap_is_reported_at_once(self, isolated: Path) -> None:
+        values = dict(COMPLETE_PRODUCTION)
+        del values["MAILER_USER"]
+        del values["GCP_BUCKET_NAME"]
+        write_json(isolated, **values)
+        with pytest.raises(ValueError, match="MAILER_USER, GCP_BUCKET_NAME"):
+            Settings()
+
+    @pytest.mark.parametrize(
+        "environment", [Environment.DEVELOPMENT, Environment.TESTING]
+    )
+    def test_other_environments_do_not_require_them(
+        self, isolated: Path, environment: Environment
+    ) -> None:
+        write_json(isolated, APP_ENV=environment.value)
+        assert Settings().environment is environment
+
+
+class TestTheCloudRunMount:
+    @pytest.fixture
+    def on_cloud_run(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("K_SERVICE", "backend-service")
+
+    @pytest.mark.usefixtures("on_cloud_run")
+    def test_a_missing_mount_refuses_to_start(self, tmp_path: Path) -> None:
+        with pytest.raises(RuntimeError, match="not mounted"):
+            require_the_secret_mount(tmp_path / "config.json")
+
+    @pytest.mark.usefixtures("on_cloud_run")
+    def test_a_present_mount_is_fine(self, tmp_path: Path) -> None:
+        (tmp_path / "config.json").write_text("{}")
+        require_the_secret_mount(tmp_path / "config.json")
+
+    def test_off_cloud_run_nothing_is_required(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        monkeypatch.delenv("K_SERVICE", raising=False)
+        require_the_secret_mount(tmp_path / "config.json")
 
 
 class TestPrecedence:

--- a/backend/python/tests/test_config_sources.py
+++ b/backend/python/tests/test_config_sources.py
@@ -1,0 +1,88 @@
+"""Where Settings gets its values, and in what order.
+
+Cloud Run mounts the Secret Manager secret as a JSON file; locally the same
+keys arrive as environment variables or .env. A revision-level environment
+variable outranks the file, the file outranks .env.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from app.config import CLOUD_RUN_SECRETS_FILE, Environment, Settings
+
+# Keys the tests set themselves; cleared from the process environment first so
+# conftest's APP_ENV=testing and CI's POSTGRES_* cannot mask a source.
+KEYS = ("APP_ENV", "DB_HOST", "POSTGRES_USER", "PREVIEW_DEPLOY", "FRONTEND_BASE_URL")
+
+
+@pytest.fixture
+def isolated(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    for key in KEYS:
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setitem(Settings.model_config, "env_file", str(tmp_path / ".env"))
+    monkeypatch.setitem(
+        Settings.model_config, "json_file", str(tmp_path / "config.json")
+    )
+    return tmp_path
+
+
+def write_json(directory: Path, **values: object) -> None:
+    (directory / "config.json").write_text(json.dumps(values))
+
+
+def test_the_mount_path_is_where_cloud_run_puts_the_secret() -> None:
+    assert CLOUD_RUN_SECRETS_FILE == "/secrets/config.json"
+
+
+class TestJsonFile:
+    def test_upper_case_keys_populate_the_fields(self, isolated: Path) -> None:
+        write_json(isolated, POSTGRES_USER="neondb_owner", DB_HOST="db.example")
+        settings = Settings()
+        assert settings.postgres_user == "neondb_owner"
+        assert settings.db_host == "db.example"
+
+    def test_app_env_reaches_the_aliased_field(self, isolated: Path) -> None:
+        write_json(isolated, APP_ENV="production")
+        assert Settings().environment is Environment.PRODUCTION
+
+    def test_a_bad_app_env_still_fails_at_startup(self, isolated: Path) -> None:
+        write_json(isolated, APP_ENV="prod")
+        with pytest.raises(ValueError, match="APP_ENV"):
+            Settings()
+
+    def test_booleans_are_coerced(self, isolated: Path) -> None:
+        write_json(isolated, PREVIEW_DEPLOY="true")
+        assert Settings().preview_deploy is True
+
+    def test_keys_that_are_not_settings_are_skipped(self, isolated: Path) -> None:
+        write_json(isolated, DB_HOST="db.example", ADMIN_AUTH_ID="shared-with-scripts")
+        assert Settings().db_host == "db.example"
+
+    @pytest.mark.usefixtures("isolated")
+    def test_a_missing_file_means_defaults(self) -> None:
+        settings = Settings()
+        assert settings.environment is Environment.DEVELOPMENT
+        assert settings.db_host == ""
+
+
+class TestPrecedence:
+    def test_an_environment_variable_beats_the_file(
+        self, isolated: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        write_json(isolated, DB_HOST="from-json")
+        monkeypatch.setenv("DB_HOST", "from-env")
+        assert Settings().db_host == "from-env"
+
+    def test_the_file_beats_dotenv(self, isolated: Path) -> None:
+        write_json(isolated, DB_HOST="from-json")
+        (isolated / ".env").write_text("DB_HOST=from-dotenv\n")
+        assert Settings().db_host == "from-json"
+
+    def test_dotenv_fills_what_the_file_leaves_out(self, isolated: Path) -> None:
+        write_json(isolated, DB_HOST="from-json")
+        (isolated / ".env").write_text("FRONTEND_BASE_URL=https://dotenv.example\n")
+        settings = Settings()
+        assert settings.db_host == "from-json"
+        assert settings.frontend_base_url == "https://dotenv.example"

--- a/backend/python/tests/test_cookies.py
+++ b/backend/python/tests/test_cookies.py
@@ -1,0 +1,116 @@
+"""Refresh-cookie attributes per deployment.
+
+The one combination browsers reject outright is SameSite=None without Secure:
+the cookie is silently dropped and every session restore fails. Nothing here
+may produce it.
+"""
+
+import itertools
+
+import pytest
+from fastapi import Response
+
+from app.config import Environment, settings
+from app.utilities.cookies import (
+    clear_auth_cookies,
+    get_cookie_options,
+    set_refresh_token_cookie,
+)
+
+COMBINATIONS = list(itertools.product(Environment, (False, True)))
+
+
+def configure(
+    monkeypatch: pytest.MonkeyPatch, environment: Environment, preview: bool
+) -> None:
+    monkeypatch.setattr(settings, "environment", environment)
+    monkeypatch.setattr(settings, "preview_deploy", preview)
+
+
+def set_cookie_headers(response: Response) -> list[str]:
+    return [v.decode() for k, v in response.raw_headers if k == b"set-cookie"]
+
+
+@pytest.mark.parametrize(("environment", "preview"), COMBINATIONS)
+def test_samesite_none_is_always_secure(
+    monkeypatch: pytest.MonkeyPatch, environment: Environment, preview: bool
+) -> None:
+    configure(monkeypatch, environment, preview)
+    options = get_cookie_options()
+    assert options["httponly"] is True
+    if options["samesite"] == "none":
+        assert options["secure"] is True
+
+
+class TestWhereEachDeploymentLands:
+    def test_local_development_is_plain_http(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        configure(monkeypatch, Environment.DEVELOPMENT, preview=False)
+        assert get_cookie_options() == {
+            "httponly": True,
+            "samesite": "strict",
+            "secure": False,
+        }
+
+    def test_production_is_same_origin_and_secure(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        configure(monkeypatch, Environment.PRODUCTION, preview=False)
+        assert get_cookie_options() == {
+            "httponly": True,
+            "samesite": "strict",
+            "secure": True,
+        }
+
+    @pytest.mark.parametrize("environment", list(Environment))
+    def test_a_preview_deploy_is_cross_site_and_secure(
+        self, monkeypatch: pytest.MonkeyPatch, environment: Environment
+    ) -> None:
+        configure(monkeypatch, environment, preview=True)
+        assert get_cookie_options() == {
+            "httponly": True,
+            "samesite": "none",
+            "secure": True,
+        }
+
+
+class TestTheHeadersCarryTheOptions:
+    @pytest.mark.parametrize(("environment", "preview"), COMBINATIONS)
+    @pytest.mark.parametrize("remember_me", (False, True))
+    def test_set(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        environment: Environment,
+        preview: bool,
+        remember_me: bool,
+    ) -> None:
+        configure(monkeypatch, environment, preview)
+        response = Response()
+        set_refresh_token_cookie(response, "tok", remember_me)
+        headers = set_cookie_headers(response)
+        assert sorted(h.split("=", 1)[0] for h in headers) == [
+            "refreshToken",
+            "rememberMe",
+        ]
+        for header in headers:
+            assert "HttpOnly" in header
+            assert f"SameSite={get_cookie_options()['samesite']}" in header
+            assert ("Secure" in header) is bool(get_cookie_options()["secure"])
+            assert ("Max-Age=" in header) is remember_me
+
+    @pytest.mark.parametrize(("environment", "preview"), COMBINATIONS)
+    def test_clear(
+        self, monkeypatch: pytest.MonkeyPatch, environment: Environment, preview: bool
+    ) -> None:
+        configure(monkeypatch, environment, preview)
+        response = Response()
+        clear_auth_cookies(response)
+        headers = set_cookie_headers(response)
+        assert sorted(h.split("=", 1)[0] for h in headers) == [
+            "refreshToken",
+            "rememberMe",
+        ]
+        for header in headers:
+            assert "Max-Age=0" in header
+            assert ("Secure" in header) is bool(get_cookie_options()["secure"])

--- a/backend/python/tests/test_database_url.py
+++ b/backend/python/tests/test_database_url.py
@@ -163,13 +163,6 @@ class TestMissingCredentials:
         ):
             assert expected in str(caught.value)
 
-    def test_production_without_database_url_fails_loudly(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        use(monkeypatch, Environment.PRODUCTION)
-        with pytest.raises(RuntimeError, match="DATABASE_URL"):
-            get_database_url()
-
 
 class TestPasswordEscaping:
     @pytest.mark.parametrize("password", ["p@ss:word", "p/w?x", "p#w", "p%w", "p w"])

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,5 +1,6 @@
-# Base URL of the backend API. Defaults to http://localhost:8080 in code
-# (src/lib/axiosClient.ts) if unset; set it here to override.
+# Base URL of the backend API. Unset, dev builds use http://localhost:8080 and
+# production builds use the page's own origin (Hosting rewrites /api/** to the
+# backend, see firebase.json). Set it only to point a build somewhere else.
 VITE_API_BASE_URL=http://localhost:8080
 
 # Sentry Error Logging DSN

--- a/frontend/.firebaserc
+++ b/frontend/.firebaserc
@@ -1,0 +1,5 @@
+{
+  "projects": {
+    "default": "food4kids-473501"
+  }
+}

--- a/frontend/firebase.json
+++ b/frontend/firebase.json
@@ -1,0 +1,20 @@
+{
+  "hosting": {
+    "site": "food4kids-473501",
+    "public": "dist",
+    "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
+    "rewrites": [
+      {
+        "source": "/api/**",
+        "run": {
+          "serviceId": "backend-service",
+          "region": "us-east1"
+        }
+      },
+      {
+        "source": "**",
+        "destination": "/index.html"
+      }
+    ]
+  }
+}

--- a/frontend/src/lib/axiosClient.baseUrl.test.ts
+++ b/frontend/src/lib/axiosClient.baseUrl.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Where requests go. The module reads import.meta.env at import time, so each
+ * case stubs the environment and re-imports a fresh copy.
+ */
+async function load() {
+  vi.resetModules();
+  return import('@/lib/axiosClient');
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe('API base URL', () => {
+  it('points a dev build at the backend container', async () => {
+    vi.stubEnv('DEV', true);
+    vi.stubEnv('VITE_API_BASE_URL', undefined);
+    const { API_BASE_URL, default: client } = await load();
+    expect(API_BASE_URL).toBe('http://localhost:8080');
+    expect(client.defaults.baseURL).toBe('http://localhost:8080');
+  });
+
+  it('keeps a production build same-origin, where Hosting rewrites /api', async () => {
+    vi.stubEnv('DEV', false);
+    vi.stubEnv('VITE_API_BASE_URL', undefined);
+    const { API_BASE_URL, default: client } = await load();
+    expect(API_BASE_URL).toBe('');
+    expect(client.defaults.baseURL).toBe('');
+  });
+
+  it.each([true, false])(
+    'lets VITE_API_BASE_URL override either default (DEV=%s)',
+    async (dev) => {
+      vi.stubEnv('DEV', dev);
+      vi.stubEnv('VITE_API_BASE_URL', 'https://preview.example');
+      const { API_BASE_URL } = await load();
+      expect(API_BASE_URL).toBe('https://preview.example');
+    }
+  );
+
+  it('sends the refresh to a same-origin /api path in production', async () => {
+    vi.stubEnv('DEV', false);
+    vi.stubEnv('VITE_API_BASE_URL', undefined);
+    const { default: client } = await load();
+    const url = client.getUri({ url: '/api/auth/refresh' });
+    expect(url).toBe('/api/auth/refresh');
+  });
+});

--- a/frontend/src/lib/axiosClient.ts
+++ b/frontend/src/lib/axiosClient.ts
@@ -15,8 +15,15 @@ import type { AuthResponse } from '@/api/generated';
 // the instance default silently wins. Axios then sees FormData labelled as JSON
 // and re-serializes it (any File becomes `{}`), which the API rejects as a 422.
 // See src/lib/axiosClient.test.ts.
+// Production builds default to same-origin: Firebase Hosting rewrites /api/**
+// to the backend, and the generated client's paths already carry /api. Set
+// VITE_API_BASE_URL only to point a build somewhere else (dev, previews).
+export const API_BASE_URL: string =
+  import.meta.env.VITE_API_BASE_URL ??
+  (import.meta.env.DEV ? 'http://localhost:8080' : '');
+
 const axiosClient = axios.create({
-  baseURL: import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:8080',
+  baseURL: API_BASE_URL,
   withCredentials: true,
 });
 


### PR DESCRIPTION
## JIRA Ticket

N/A — closes the last gap between `main` and #210 so #210 can be closed.

## Implementation Description

Deploying `main` today would fail at `alembic upgrade head`: the DB password and `DATABASE_URL` exist only in the Secret Manager JSON that Cloud Run mounts at `/secrets/config.json`, and only #210's branch reads it.

- `Settings` reads that file through pydantic-settings' `JsonConfigSettingsSource`. Precedence is env var → secret file → `.env`. `extra="ignore"` because the secret is shared with scripts (same as unknown env vars today).
- Startup validation, so a typo'd key or a failed mount cannot degrade silently: on Cloud Run (`K_SERVICE` set) the secret file must exist, and in production every name in `REQUIRED_IN_PRODUCTION` must be set and non-empty, reported together. The production `DATABASE_URL` check moves here from `database_url.py`.
- `frontend/firebase.json` + `.firebaserc` checked in; `test_the_prefix_is_what_hosting_rewrites` now parses the rewrite instead of pinning a literal.
- Production frontend builds default to same-origin (`baseURL: ''`); `VITE_API_BASE_URL` remains an override. Previously a prod build silently pointed at `localhost:8080`.
- Preview-deploy cookies are `Secure` (browsers drop `SameSite=None` without it).
- README “Deployment” section with the two deploy commands.

**Secret is ready:** `FRONTEND_BASE_URL=https://food4kids-473501.web.app` was added as version 16 of `food4kids-config-dev` (2026-09-15); all 19 required keys are present. Swap it to `https://app.food4kidswr.ca` when that domain stops redirecting to the placeholder site.

**Behaviour change at next deploy:** the secret carries `APP_ENV=production`, so the service flips to production mode (docs off, Secure cookies) once its stale plain env vars are cleared (`--clear-env-vars`, in the README).

## Steps to Test

1. `docker exec -e APP_ENV=testing f4k_backend python -m pytest -q tests/test_config_sources.py tests/test_cookies.py tests/test_api_prefix.py`
2. `cd frontend && pnpm test && pnpm build` (no `.env`) — bundle base URL is empty.

## Checklist

- [x] PR name and commits are descriptive, imperative, and atomic
- [x] Requested a review from Claude
- [ ] Requested a review from the PL and relevant devs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

